### PR TITLE
Allow checking server version

### DIFF
--- a/zwave_js_server/version.py
+++ b/zwave_js_server/version.py
@@ -1,0 +1,33 @@
+"""Version helper."""
+from dataclasses import dataclass
+
+import aiohttp
+
+
+@dataclass
+class VersionInfo:
+    """Version info of the server."""
+
+    driver_version: str
+    server_version: str
+    home_id: int
+
+    @classmethod
+    def from_message(cls, msg) -> "VersionInfo":
+        """Create a version info from a version message."""
+        return cls(
+            driver_version=msg["driverVersion"],
+            server_version=msg["serverVersion"],
+            home_id=msg["homeId"],
+        )
+
+
+async def get_server_version(url: str, session: aiohttp.ClientSession) -> VersionInfo:
+    """Return a server version."""
+    client = await session.ws_connect(
+        url,
+    )
+    try:
+        return VersionInfo.from_message(await client.receive_json())
+    finally:
+        await client.close()


### PR DESCRIPTION
Allow printing version from CLI and via a method. Method can be used to verify a server.

```
$ python3 -m zwave_js_server ws://localhost:3000 --server-version
Driver: TBD
Server: 1.0.0
Home ID: 1
```