### PR TITLE
Disable mypy on CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,9 @@ skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.8: py38, lint, mypy
+# Disabled while typing is failing
+#  3.8: py38, lint, mypy
+  3.8: py38, lint
   3.9: py39
 
 [testenv]


### PR DESCRIPTION
MyPy has a lot of issues. Let's disable it so we can actually use CI status to check if new things start failing. 