### PR TITLE
Make CLI shutdown cleaner

### DIFF
--- a/zwave_js_server/__main__.py
+++ b/zwave_js_server/__main__.py
@@ -90,12 +90,14 @@ async def connect(args: argparse.Namespace, session: aiohttp.ClientSession) -> N
                 # Set up listeners on existing nodes
                 for node in client.driver.controller.nodes.values():
                     node.on("value updated", log_value_updated)
-        except KeyboardInterrupt:
+        except asyncio.CancelledError:
             logger.info("Close requested")
-            break
-
-    await client.disconnect()
+            await client.disconnect()
+            raise
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -175,7 +175,7 @@ class Client:
         self.tries = 0
         self._disconnect_event = asyncio.Event()
 
-        while True:
+        while not self.close_requested:
             try:
                 self._logger.debug("Trying to connect")
                 await self._handle_connection()


### PR DESCRIPTION
- When `asyncio.run` is closing down due to Keyboard signal, it will ask all tasks to cancel. So the `client.connect` task will receive a cancel exception before we ask the client to disconnect. This causes us to re-enter the retry connection loop unless we check the `close_requested` attribute.
- The flow is still not optimal after this change. The client connect task is still asked to cancel before we disconnect. Optimally we should handle the cancel error outside the client and ask the client to disconnect. 