### PR TITLE
Allow getting results

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ Python library for communicating with zwave-js-server. Goal for this library is 
 ```shell
 python3 -m zwave_js_server ws://localhost:3000/zjs
 ```
+
+## Sending commands
+
+```python
+try:
+    result = await client.async_send_command({ "command": "start_listening" })
+except zwave_js_server.client.FailedCommand as err:
+    print("Command failed with", err.error_code)
+```

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -149,7 +149,7 @@ class Client:
 
     async def async_send_command(self, message: Dict[str, Any]) -> dict:
         """Send a command and get a response."""
-        future = self._loop.create_future()
+        future: asyncio.Future[dict] = self._loop.create_future()
         message_id = message["messageId"] = uuid.uuid4().hex
         self._result_futures[message_id] = future
         await self.async_send_json_message(message)

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -149,7 +149,7 @@ class Client:
 
     async def async_send_command(self, message: Dict[str, Any]) -> dict:
         """Send a command and get a response."""
-        future: asyncio.Future[dict] = self._loop.create_future()
+        future: "asyncio.Future[dict]" = self._loop.create_future()
         message_id = message["messageId"] = uuid.uuid4().hex
         self._result_futures[message_id] = future
         await self.async_send_json_message(message)

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -319,7 +319,7 @@ class Client:
         if self._disconnect_event is not None:
             await self._disconnect_event.wait()
 
-    async def _start_listening(self):
+    async def _start_listening(self) -> None:
         """When connected, start listening."""
         result = await self.async_send_command({"command": "start_listening"})
 


### PR DESCRIPTION
Add feature to client to send commands and get the results.

```python
try:
    result = await client.async_send_command({ "command": "start_listening" })
except zwave_js_server.client.FailedCommand as err:
    print("Command failed with", err.error_code)
```
