### PR TITLE
cc_specific should be a property too

### DIFF
--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -92,6 +92,7 @@ class ValueMetadata:
         """Return (optional) states."""
         return self.data.get("states")
 
+    @property
     def cc_specific(self) -> Optional[Dict[str, Any]]:
         """Return ccSpecific."""
         return self.data.get("ccSpecific")


### PR DESCRIPTION
fix typo (missing property)