### PR TITLE
Add lock constants

### DIFF
--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -144,7 +144,6 @@ class DoorLockMode(IntEnum):
     UNKNOWN = 254
     SECURED = 255
 
-
 # Depending on the Commmand Class being used by the lock, the lock state is
 # different so we need a map to track it
 LOCK_CMD_CLASS_TO_LOCKED_STATE_MAP = {

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -128,3 +128,30 @@ class CommandClass(IntEnum):
     ZIP_ND = 88
     ZIP_PORTAL = 97
     ZWAVEPLUS_INFO = 94
+
+class DoorLockMode(IntEnum):
+    """Enum with all (known/used) Z-Wave lock states for CommandClass.DOOR_LOCK."""
+
+    # https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/DoorLockCC.ts#L56-L65
+    UNSECURED = 0
+    UNSECURED_WITH_TIMEOUT = 1
+    INSIDE_UNSECURED = 2
+    INSIDE_UNSECURED_WITH_TIMEOUT = 3
+    OUTSIDE_UNSECURED = 4
+    OUTSIDE_UNSECURED_WITH_TIMEOUT = 5
+    UNKNOWN = 254
+    SECURED = 255
+
+# Depending on the Commmand Class being used by the lock, the lock state is
+# different so we need a map to track it
+CMD_CLASS_TO_LOCKED_STATE_MAP = {
+    CommandClass.DOOR_LOCK: DoorLockMode.SECURED,
+    CommandClass.LOCK: 1,
+}
+
+# Depending on the Command Class being used by the lock, the locked state property
+# is different so we need a map to track it
+CMD_CLASS_TO_PROPERTY_MAP = {
+    CommandClass.DOOR_LOCK: "targetMode",
+    CommandClass.LOCK: "locked",
+}

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -131,11 +131,6 @@ class CommandClass(IntEnum):
     ZWAVEPLUS_INFO = 94
 
 
-# Lock constants
-STATE_LOCKED = "locked"
-STATE_UNLOCKED = "unlocked"
-
-
 class DoorLockMode(IntEnum):
     """Enum with all (known/used) Z-Wave lock states for CommandClass.DOOR_LOCK."""
 
@@ -152,25 +147,14 @@ class DoorLockMode(IntEnum):
 
 # Depending on the Commmand Class being used by the lock, the lock state is
 # different so we need a map to track it
-CMD_CLASS_TO_LOCKED_STATE_MAP = {
+LOCK_CMD_CLASS_TO_LOCKED_STATE_MAP = {
     CommandClass.DOOR_LOCK: DoorLockMode.SECURED,
     CommandClass.LOCK: 1,
 }
 
 # Depending on the Command Class being used by the lock, the locked state property
 # is different so we need a map to track it
-CMD_CLASS_TO_PROPERTY_MAP = {
+LOCK_CMD_CLASS_TO_PROPERTY_MAP = {
     CommandClass.DOOR_LOCK: "targetMode",
     CommandClass.LOCK: "locked",
-}
-
-STATE_TO_ZWAVE_MAP: Dict[int, Dict[str, Union[int, bool]]] = {
-    CommandClass.DOOR_LOCK: {
-        STATE_UNLOCKED: DoorLockMode.UNSECURED,
-        STATE_LOCKED: DoorLockMode.SECURED,
-    },
-    CommandClass.LOCK: {
-        STATE_UNLOCKED: False,
-        STATE_LOCKED: True,
-    },
 }

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -1,5 +1,6 @@
 """Constants for the Z-Wave JS python library."""
 from enum import IntEnum
+from typing import Dict, Union
 
 
 class CommandClass(IntEnum):
@@ -129,6 +130,12 @@ class CommandClass(IntEnum):
     ZIP_PORTAL = 97
     ZWAVEPLUS_INFO = 94
 
+
+# Lock constants
+STATE_LOCKED = "locked"
+STATE_UNLOCKED = "unlocked"
+
+
 class DoorLockMode(IntEnum):
     """Enum with all (known/used) Z-Wave lock states for CommandClass.DOOR_LOCK."""
 
@@ -142,6 +149,7 @@ class DoorLockMode(IntEnum):
     UNKNOWN = 254
     SECURED = 255
 
+
 # Depending on the Commmand Class being used by the lock, the lock state is
 # different so we need a map to track it
 CMD_CLASS_TO_LOCKED_STATE_MAP = {
@@ -154,4 +162,15 @@ CMD_CLASS_TO_LOCKED_STATE_MAP = {
 CMD_CLASS_TO_PROPERTY_MAP = {
     CommandClass.DOOR_LOCK: "targetMode",
     CommandClass.LOCK: "locked",
+}
+
+STATE_TO_ZWAVE_MAP: Dict[int, Dict[str, Union[int, bool]]] = {
+    CommandClass.DOOR_LOCK: {
+        STATE_UNLOCKED: DoorLockMode.UNSECURED,
+        STATE_LOCKED: DoorLockMode.SECURED,
+    },
+    CommandClass.LOCK: {
+        STATE_UNLOCKED: False,
+        STATE_LOCKED: True,
+    },
 }

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -143,6 +143,7 @@ class DoorLockMode(IntEnum):
     UNKNOWN = 254
     SECURED = 255
 
+
 # Depending on the Commmand Class being used by the lock, the lock state is
 # different so we need a map to track it
 LOCK_CMD_CLASS_TO_LOCKED_STATE_MAP = {

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -1,6 +1,5 @@
 """Constants for the Z-Wave JS python library."""
 from enum import IntEnum
-from typing import Dict, Union
 
 
 class CommandClass(IntEnum):


### PR DESCRIPTION
Moving lock constants from https://github.com/home-assistant/core/pull/45175 into the library. I originally did not add https://github.com/home-assistant/core/pull/45175/files#diff-1bed63c2518298f6b68c0d6c8325514a97971b914be9a7d6809a1c1b68a631f5R47-R56 but I think it makes sense here as long as we don't tie it to HA constants.