### PR TITLE
Add command to dump the state of a server

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,19 @@ Python library for communicating with zwave-js-server. Goal for this library is 
 ## Trying it out
 
 ```shell
-python3 -m zwave_js_server ws://localhost:3000/zjs
+python3 -m zwave_js_server ws://localhost:3000
+```
+
+Or get the version of the server
+
+```shell
+python3 -m zwave_js_server ws://localhost:3000 --server-version
+```
+
+Or dump the state. Optionally add `--event-timeout 5` if you want to listen 5 seconds extra for events.
+
+```shell
+python3 -m zwave_js_server ws://localhost:3000 --dump-state
 ```
 
 ## Sending commands

--- a/zwave_js_server/__main__.py
+++ b/zwave_js_server/__main__.py
@@ -64,7 +64,7 @@ async def handle_dump_state(
     args: argparse.Namespace, session: aiohttp.ClientSession
 ) -> None:
     """Dump the state of the server."""
-    timeout = None if args.event_timeout is None else int(args.event_timeout)
+    timeout = None if args.event_timeout is None else float(args.event_timeout)
     msgs = await dump_msgs(args.url, session, timeout=timeout)
     for msg in msgs:
         print(msg)

--- a/zwave_js_server/__main__.py
+++ b/zwave_js_server/__main__.py
@@ -21,7 +21,7 @@ def get_arguments() -> argparse.Namespace:
         "--server-version", action="store_true", help="Print the version of the server"
     )
     parser.add_argument(
-        "--dump-state", action="store_true", help="Print the version of the server"
+        "--dump-state", action="store_true", help="Dump the driver state"
     )
     parser.add_argument(
         "--event-timeout",

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -25,6 +25,7 @@ async def dump_msgs(url: str, session: aiohttp.ClientSession, timeout=None, node
         event = await client.receive_str()
         msgs.append(event)
     except asyncio.CancelledError:
-        await client.close()
+        pass
 
+    await client.close()
     return msgs

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -3,7 +3,7 @@ import asyncio
 import aiohttp
 
 
-async def dump_msgs(url: str, session: aiohttp.ClientSession, timeout=None, node=None):
+async def dump_msgs(url: str, session: aiohttp.ClientSession, timeout=None):
     """Dump server state."""
     client = await session.ws_connect(url)
     msgs = []

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -1,0 +1,30 @@
+"""Dump helper."""
+import asyncio
+import aiohttp
+
+
+async def dump_msgs(url: str, session: aiohttp.ClientSession, timeout=None, node=None):
+    """Dump server state."""
+    client = await session.ws_connect(url)
+    msgs = []
+
+    version = await client.receive_json()
+    msgs.append(version)
+
+    await client.send_json({"command": "start_listening"})
+    state = await client.receive_str()
+    msgs.append(state)
+
+    if timeout is None:
+        await client.close()
+        return msgs
+
+    asyncio.get_running_loop().call_later(timeout, asyncio.current_task().cancel)
+
+    try:
+        event = await client.receive_str()
+        msgs.append(event)
+    except asyncio.CancelledError:
+        await client.close()
+
+    return msgs

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -1,9 +1,12 @@
 """Dump helper."""
 import asyncio
+from typing import List
 import aiohttp
 
 
-async def dump_msgs(url: str, session: aiohttp.ClientSession, timeout=None):
+async def dump_msgs(
+    url: str, session: aiohttp.ClientSession, timeout: float = None
+) -> List[dict]:
     """Dump server state."""
     client = await session.ws_connect(url)
     msgs = []
@@ -12,17 +15,19 @@ async def dump_msgs(url: str, session: aiohttp.ClientSession, timeout=None):
     msgs.append(version)
 
     await client.send_json({"command": "start_listening"})
-    state = await client.receive_str()
+    state = await client.receive_json()
     msgs.append(state)
 
     if timeout is None:
         await client.close()
         return msgs
 
-    asyncio.get_running_loop().call_later(timeout, asyncio.current_task().cancel)
+    current_task = asyncio.current_task()
+    assert current_task is not None
+    asyncio.get_running_loop().call_later(timeout, current_task.cancel)
 
     try:
-        event = await client.receive_str()
+        event = await client.receive_json()
         msgs.append(event)
     except asyncio.CancelledError:
         pass

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -1,11 +1,12 @@
 """Dump helper."""
 import asyncio
 from typing import List
+
 import aiohttp
 
 
 async def dump_msgs(
-    url: str, session: aiohttp.ClientSession, timeout: float = None
+    url: str, session: aiohttp.ClientSession, timeout: Optional[float] = None
 ) -> List[dict]:
     """Dump server state."""
     client = await session.ws_connect(url)

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -1,6 +1,6 @@
 """Dump helper."""
 import asyncio
-from typing import List
+from typing import List, Optional
 
 import aiohttp
 


### PR DESCRIPTION
Adds a function to dump the commands from the server. Gets state and optionally keeps connection open to get events.

```
$ python3 -m zwave_js_server --dump-state ws://localhost:3000 --event-timeout 5
{'type': 'version', 'driverVersion': '6.0.0', 'serverVersion': '1.0.0-alpha.2', 'homeId': 1}
{"type":"result","success":true,"result":{"state":{"controller":{"homeId":1},"nodes":[]}}}
```