### PR TITLE
Dump to wait nodes ready

### DIFF
--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -1,6 +1,7 @@
 """Dump helper."""
 import asyncio
 from typing import List, Optional
+
 import aiohttp
 
 

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -23,7 +23,7 @@ async def dump_msgs(
     state = msg["result"]["state"]
 
     # If it's None, old version of the server, ignore it.
-    if wait_nodes_ready and state["driver"].get("allNodesReady") is False:
+    if wait_nodes_ready and state.get("driver", {}).get("allNodesReady") is False:
         # Wait for nodes ready event and refetch state
         while True:
             msg = await client.receive_json()

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -8,7 +8,7 @@ async def dump_msgs(
     url: str,
     session: aiohttp.ClientSession,
     timeout: Optional[float] = None,
-    wait_nodes_ready=True,
+    wait_nodes_ready: bool = True,
 ) -> List[dict]:
     """Dump server state."""
     client = await session.ws_connect(url)


### PR DESCRIPTION
If not all nodes are ready, wait until they are and then restart the command.

Also fixes so that we don't listen for 1 event during timeout but all events. (thanks @MartinHjelmare)