### PR TITLE
Add value notification model

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -23,6 +23,7 @@ disable=
   too-few-public-methods,
   too-many-public-methods,
   too-many-instance-attributes,
+  no-self-use
 
 [REPORTS]
 score=no

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -344,7 +344,7 @@ class Node(EventBase):
 
     def handle_value_notification(self, event: Event) -> None:
         """Process a node value notification event."""
-        event.data["value"] = ValueNotification.from_event(event)
+        event.data["notification"] = ValueNotification.from_event(event)
 
     def handle_metadata_updated(self, event: Event) -> None:
         """Process a node metadata updated event."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -4,7 +4,14 @@ from typing import TYPE_CHECKING, Any, List, Optional, TypedDict, Union, cast
 from ..event import Event, EventBase
 from .device_class import DeviceClass, DeviceClassDataType
 from .device_config import DeviceConfig, DeviceConfigDataType
-from .value import Value, ValueDataType, ValueMetadata, MetaDataType, get_value_id
+from .value import (
+    MetaDataType,
+    Value,
+    ValueDataType,
+    ValueMetadata,
+    ValueNotification,
+    get_value_id,
+)
 
 if TYPE_CHECKING:
     from ..client import Client
@@ -337,6 +344,7 @@ class Node(EventBase):
 
     def handle_value_notification(self, event: Event) -> None:
         """Process a node value notification event."""
+        event.data["value"] = ValueNotification.from_event(event)
 
     def handle_metadata_updated(self, event: Event) -> None:
         """Process a node metadata updated event."""

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -190,7 +190,7 @@ class ValueNotification:
     metadata: Optional[ValueMetadata] = None
 
     @classmethod
-    def from_event(cls, event: Event): # type: ignore
+    def from_event(cls, event: Event):  # type: ignore
         """Parse event message into ValueNotification."""
         return cls(
             command_class_name=event.data["args"]["commandClassName"],

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -190,7 +190,7 @@ class ValueNotification:
     metadata: Optional[ValueMetadata] = None
 
     @classmethod
-    def from_event(cls, event: Event):  # type: ignore
+    def from_event(cls, event: Event) -> "ValueNotification":
         """Parse event message into ValueNotification."""
         return cls(
             command_class_name=event.data["args"]["commandClassName"],
@@ -199,4 +199,9 @@ class ValueNotification:
             property=event.data["args"]["property"],
             value=event.data["args"].get("value"),
             property_name=event.data["args"]["propertyName"],
+            metadata=ValueMetadata(
+                event.data["args"]["metadata"]
+                if "metadata" in event.data["args"]
+                else None
+            ),
         )

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -190,7 +190,7 @@ class ValueNotification:
     metadata: Optional[ValueMetadata] = None
 
     @classmethod
-    def from_event(cls, event: Event):
+    def from_event(cls, event: Event) -> "ValueNotification":
         """Parse event message into ValueNotification."""
         return cls(
             command_class_name=event.data["args"]["commandClassName"],

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -1,4 +1,5 @@
 """Provide a model for the Z-Wave JS value."""
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union
 
 from ..event import Event
@@ -170,3 +171,32 @@ class Value:
         """Receive an event."""
         self.data.update(event.data["args"])
         self._value = event.data["args"].get("newValue")
+
+
+@dataclass
+class ValueNotification:
+    """
+    Model for a Value Nofification message.
+
+    https://zwave-js.github.io/node-zwave-js/#/api/node?id=quotvalue-notificationquot
+    """
+
+    command_class_name: str
+    command_class: int
+    endpoint: int
+    property: str
+    value: Any
+    property_name: str
+    metadata: Optional[ValueMetadata] = None
+
+    @classmethod
+    def from_event(cls, event: Event):
+        """Parse event message into ValueNotification."""
+        return cls(
+            command_class_name=event.data["args"]["commandClassName"],
+            command_class=event.data["args"]["commandClass"],
+            endpoint=event.data["args"]["endpoint"],
+            property=event.data["args"]["property"],
+            value=event.data["args"].get("value"),
+            property_name=event.data["args"]["propertyName"],
+        )

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -190,7 +190,7 @@ class ValueNotification:
     metadata: Optional[ValueMetadata] = None
 
     @classmethod
-    def from_event(cls, event: Event) -> "ValueNotification":
+    def from_event(cls, event: Event): # type: ignore
         """Parse event message into ValueNotification."""
         return cls(
             command_class_name=event.data["args"]["commandClassName"],


### PR DESCRIPTION
adds a model for value notification events

https://zwave-js.github.io/node-zwave-js/#/api/node?id=quotvalue-notificationquot

will be used by the integration to fire HA events for these (stateless) value notifications (e.g. scene support for remotes)