### PR TITLE
Fix KeyError on Value's metadata

### DIFF
--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -117,9 +117,9 @@ class Value:
         return get_value_id(self.node, self.data)
 
     @property
-    def metadata(self) -> ValueMetadata:
+    def metadata(self) -> Optional[ValueMetadata]:
         """Return value metadata."""
-        return ValueMetadata(self.data["metadata"])
+        return ValueMetadata(self.data["metadata"]) if "metadata" in self.data else None
 
     @property
     def value(self) -> Optional[Any]:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -119,7 +119,9 @@ class Value:
     @property
     def metadata(self) -> Optional[ValueMetadata]:
         """Return value metadata."""
-        return ValueMetadata(self.data["metadata"]) if "metadata" in self.data else None
+        if "metadata" in self.data:
+            return ValueMetadata(self.data["metadata"])
+        return None
 
     @property
     def value(self) -> Optional[Any]:

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -56,7 +56,9 @@ def _get_code_slots(
         # that is an int, so we can ignore mypy
         slot = {
             ATTR_CODE_SLOT: int(value.property_key),  # type: ignore
-            ATTR_NAME: value.metadata.label,
+            ATTR_NAME: value.metadata.label
+            if value.metadata
+            else value.property_key_name,
             ATTR_IN_USE: status_value.value == CodeSlotStatus.ENABLED,
         }
         if include_usercode:


### PR DESCRIPTION
metadata is optional and thus can be missing in events.
Only initialize it if it's actually present in the data.

This also fixes the issue of nodes being interviewed when HA already started. The node ready event fails because metadata key is missing on one or more values.