### PR TITLE
Clean up the client

### DIFF
--- a/zwave_js_server/__main__.py
+++ b/zwave_js_server/__main__.py
@@ -54,6 +54,7 @@ async def print_version(
     args: argparse.Namespace, session: aiohttp.ClientSession
 ) -> None:
     """Print the version of the server."""
+    logger.setLevel(logging.WARNING)
     version = await get_server_version(args.url, session)
     print("Driver:", version.driver_version)
     print("Server:", version.server_version)

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -9,12 +9,15 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, cast
 from aiohttp import ClientSession, ClientWebSocketResponse, WSMsgType, client_exceptions
 
 from .event import Event
+from .model.version import VersionInfo
 from .model.driver import Driver
-from .version import VersionInfo
 
 STATE_CONNECTING = "connecting"
 STATE_CONNECTED = "connected"
 STATE_DISCONNECTED = "disconnected"
+
+
+SIZE_PARSE_JSON_EXECUTOR = 8192
 
 
 async def gather_callbacks(
@@ -49,7 +52,13 @@ class FailedCommand(Exception):
 class Client:
     """Class to manage the IoT connection."""
 
-    def __init__(self, ws_server_url: str, aiohttp_session: ClientSession):
+    def __init__(
+        self,
+        ws_server_url: str,
+        aiohttp_session: ClientSession,
+        *,
+        start_listening_on_connect=True,
+    ):
         """Initialize the Client class."""
         self.ws_server_url = ws_server_url
         self.aiohttp_session = aiohttp_session
@@ -73,6 +82,9 @@ class Client:
         self._disconnect_event: Optional[asyncio.Event] = None
         self._result_futures: Dict[str, asyncio.Future] = {}
         self._loop = asyncio.get_running_loop()
+
+        if start_listening_on_connect:
+            self.register_on_connect(self._start_listening)
 
     def __repr__(self) -> str:
         """Return the representation."""
@@ -206,8 +218,10 @@ class Client:
                 )
                 # notify callbacks about disconnection
                 if self._on_disconnect:
-                    await gather_callbacks(
-                        self._logger, "on_disconnect", self._on_disconnect
+                    asyncio.create_task(
+                        gather_callbacks(
+                            self._logger, "on_disconnect", self._on_disconnect
+                        )
                     )
 
             if self.close_requested:
@@ -260,9 +274,11 @@ class Client:
             self.state = STATE_CONNECTED
 
             if self._on_connect:
-                await gather_callbacks(self._logger, "on_connect", self._on_connect)
+                asyncio.create_task(
+                    gather_callbacks(self._logger, "on_connect", self._on_connect)
+                )
 
-            asyncio.create_task(self._start_listening())
+            loop = asyncio.get_running_loop()
 
             while not client.closed:
                 msg = await client.receive()
@@ -279,7 +295,10 @@ class Client:
                     break
 
                 try:
-                    msg = msg.json()
+                    if len(msg.data) > SIZE_PARSE_JSON_EXECUTOR:
+                        msg = await loop.run_in_executor(None, msg.json)
+                    else:
+                        msg = msg.json()
                 except ValueError:
                     disconnect_warn = "Received invalid JSON."
                     break
@@ -330,9 +349,12 @@ class Client:
     async def _start_listening(self) -> None:
         """When connected, start listening."""
         result = await self.async_send_command({"command": "start_listening"})
+        loop = asyncio.get_running_loop()
 
         if self.driver is None:
-            self.driver = Driver(self, result["state"])
+            self.driver = await loop.run_in_executor(
+                None, Driver, self, result["state"]
+            )
             self._logger.info(
                 "Z-Wave JS initialized. %s nodes", len(self.driver.controller.nodes)
             )
@@ -340,5 +362,6 @@ class Client:
                 gather_callbacks(self._logger, "on_initialized", self._on_initialized)
             )
         else:
-            # TODO how do we handle reconnect?
-            pass
+            self._logger.warning(
+                "Re-connected and don't know how to handle new state yet"
+            )

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -57,7 +57,7 @@ class Client:
         ws_server_url: str,
         aiohttp_session: ClientSession,
         *,
-        start_listening_on_connect=True,
+        start_listening_on_connect: bool = True,
     ):
         """Initialize the Client class."""
         self.ws_server_url = ws_server_url
@@ -352,8 +352,8 @@ class Client:
         loop = asyncio.get_running_loop()
 
         if self.driver is None:
-            self.driver = await loop.run_in_executor(
-                None, Driver, self, result["state"]
+            self.driver = cast(
+                Driver, await loop.run_in_executor(None, Driver, self, result["state"])
             )
             self._logger.info(
                 "Z-Wave JS initialized. %s nodes", len(self.driver.controller.nodes)

--- a/zwave_js_server/model/version.py
+++ b/zwave_js_server/model/version.py
@@ -1,0 +1,21 @@
+"""Represents the version from the server."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class VersionInfo:
+    """Version info of the server."""
+
+    driver_version: str
+    server_version: str
+    home_id: int
+
+    @classmethod
+    def from_message(cls, msg: dict) -> "VersionInfo":
+        """Create a version info from a version message."""
+        return cls(
+            driver_version=msg["driverVersion"],
+            server_version=msg["serverVersion"],
+            home_id=msg["homeId"],
+        )

--- a/zwave_js_server/version.py
+++ b/zwave_js_server/version.py
@@ -1,4 +1,6 @@
 """Version helper."""
+from typing import cast
+
 import aiohttp
 
 from .client import Client, VersionInfo
@@ -8,10 +10,10 @@ async def get_server_version(url: str, session: aiohttp.ClientSession) -> Versio
     """Return a server version."""
     client = Client(url, session, start_listening_on_connect=False)
 
-    async def handle_connected():
+    async def handle_connected() -> None:
         await client.disconnect()
 
     client.register_on_connect(handle_connected)
 
     await client.connect()
-    return client.version
+    return cast(VersionInfo, client.version)

--- a/zwave_js_server/version.py
+++ b/zwave_js_server/version.py
@@ -1,33 +1,17 @@
 """Version helper."""
-from dataclasses import dataclass
-
 import aiohttp
 
-
-@dataclass
-class VersionInfo:
-    """Version info of the server."""
-
-    driver_version: str
-    server_version: str
-    home_id: int
-
-    @classmethod
-    def from_message(cls, msg: dict) -> "VersionInfo":
-        """Create a version info from a version message."""
-        return cls(
-            driver_version=msg["driverVersion"],
-            server_version=msg["serverVersion"],
-            home_id=msg["homeId"],
-        )
+from .client import Client, VersionInfo
 
 
 async def get_server_version(url: str, session: aiohttp.ClientSession) -> VersionInfo:
     """Return a server version."""
-    client = await session.ws_connect(
-        url,
-    )
-    try:
-        return VersionInfo.from_message(await client.receive_json())
-    finally:
-        await client.close()
+    client = Client(url, session, start_listening_on_connect=False)
+
+    async def handle_connected():
+        await client.disconnect()
+
+    client.register_on_connect(handle_connected)
+
+    await client.connect()
+    return client.version


### PR DESCRIPTION
- Make `start_listening` command optional
- Rewrite `get_server_version` command to use our client
- Big JSON results will now we parsed in a thread to avoid blocking event loop. Those server states are BIG.
- Add a warning when we reconnect as we don't handle that case yet. Created issue #66 to track it.
- Version info class moved to model folder