### PR TITLE
Fix node state and values

### DIFF
--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -62,10 +62,6 @@ class Node(EventBase):
         """Initialize the node."""
         super().__init__()
         self.client = client
-        self.update_data(data)
-
-    def update_data(self, data: NodeDataType) -> None:
-        """Update data when received."""
         self.data = data
         self.values = {
             get_value_id(self, val): Value(self, val) for val in data["values"]
@@ -319,7 +315,14 @@ class Node(EventBase):
     def handle_ready(self, event: Event) -> None:
         """Process a node ready event."""
         # the event contains a full dump of the node
-        self.update_data(event.data["nodeState"])
+        self.data.update(event.data["nodeState"])
+        # update/add values
+        for value_state in event.data["nodeState"]["values"]:
+            value = self.values.get(get_value_id(self, value_state))
+            if value is None:
+                self.values[value.value_id] = Value(self, value_state)
+            else:
+                value.update(value_state)
 
     def handle_value_added(self, event: Event) -> None:
         """Process a node value added event."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -318,11 +318,9 @@ class Node(EventBase):
         self.data.update(event.data["nodeState"])
         # update/add values
         for value_state in event.data["nodeState"]["values"]:
-            value = self.values.get(get_value_id(self, value_state))
-            if value is None:
-                self.values[value.value_id] = Value(self, value_state)
-            else:
-                value.update(value_state)
+            value_id = get_value_id(self, value_state)
+            value = self.values.get(value_id, Value(self, value_state))
+            value.update(value_state)
 
     def handle_value_added(self, event: Event) -> None:
         """Process a node value added event."""

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -174,12 +174,13 @@ class Value:
 
     def receive_event(self, event: Event) -> None:
         """Receive an event."""
-        self.update(event.data["args"])
+        self.data.update(event.data["args"])
+        self._value = event.data["args"].get("newValue")
 
     def update(self, data: ValueDataType) -> None:
         """Update data."""
         self.data.update(data)
-        self._value = data.get("newValue")
+        self._value = data.get("value")
 
 
 class ValueNotification(Value):

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -174,8 +174,12 @@ class Value:
 
     def receive_event(self, event: Event) -> None:
         """Receive an event."""
-        self.data.update(event.data["args"])
-        self._value = event.data["args"].get("newValue")
+        self.update(event.data["args"])
+
+    def update(self, data: ValueDataType) -> None:
+        """Update data."""
+        self.data.update(data)
+        self._value = data.get("newValue")
 
 
 class ValueNotification(Value):

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -1,5 +1,4 @@
 """Provide a model for the Z-Wave JS value."""
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union
 
 from ..event import Event
@@ -179,35 +178,11 @@ class Value:
         self._value = event.data["args"].get("newValue")
 
 
-@dataclass
-class ValueNotification:
+class ValueNotification(Value):
     """
     Model for a Value Nofification message.
 
     https://zwave-js.github.io/node-zwave-js/#/api/node?id=quotvalue-notificationquot
     """
 
-    command_class_name: str
-    command_class: int
-    endpoint: int
-    property: str
-    value: Any
-    property_name: str
-    metadata: Optional[ValueMetadata] = None
-
-    @classmethod
-    def from_event(cls, event: Event) -> "ValueNotification":
-        """Parse event message into ValueNotification."""
-        return cls(
-            command_class_name=event.data["args"]["commandClassName"],
-            command_class=event.data["args"]["commandClass"],
-            endpoint=event.data["args"]["endpoint"],
-            property=event.data["args"]["property"],
-            value=event.data["args"].get("value"),
-            property_name=event.data["args"]["propertyName"],
-            metadata=ValueMetadata(
-                event.data["args"]["metadata"]
-                if "metadata" in event.data["args"]
-                else None
-            ),
-        )
+    # format is the same as a Value message, subclassed for easier identifying and future use


### PR DESCRIPTION
This fixes the unpredicted behaviour of processing values before the node is ready.
Belongs to this change in the server: https://github.com/zwave-js/zwave-js-server/pull/68

- Value events will not be forwarded before the node is ready
- Node ready event includes a full dump of the state
- The dump that is received at initialization (start_listening) will only include node values for nodes that are ready