### PR TITLE
Implement very basic server version check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp==3.7.3
+packaging==20.8

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -7,10 +7,12 @@ import uuid
 from typing import Any, Awaitable, Callable, Dict, List, Optional, cast
 
 from aiohttp import ClientSession, ClientWebSocketResponse, WSMsgType, client_exceptions
+from packaging.version import parse as parse_version
 
+from .const import MIN_SERVER_VERSION
 from .event import Event
-from .model.version import VersionInfo
 from .model.driver import Driver
+from .model.version import VersionInfo
 
 STATE_CONNECTING = "connecting"
 STATE_CONNECTED = "connected"
@@ -37,6 +39,10 @@ class NotConnected(Exception):
 
 class InvalidState(Exception):
     """Exception raised when data gets in invalid state."""
+
+
+class InvalidServerVersion(Exception):
+    """Exception raised when connected to server with incompatible major version."""
 
 
 class FailedCommand(Exception):
@@ -265,6 +271,9 @@ class Client:
                 await client.receive_json()
             )
 
+            # basic check for server version compatability
+            self._check_server_version(self.version.server_version)
+
             self._logger.info(
                 "Connected to Home %s (Server %s, Driver %s)",
                 version.home_id,
@@ -364,4 +373,16 @@ class Client:
         else:
             self._logger.warning(
                 "Re-connected and don't know how to handle new state yet"
+            )
+
+    def _check_server_version(self, server_version: str) -> None:
+        """Perform a basic check on the server version compatability."""
+        min_version = parse_version(MIN_SERVER_VERSION)
+        if (server_version.major != min_version.major) or (
+            server_version.minor < min_version.minor
+        ):
+            raise InvalidServerVersion
+        if server_version.minor > min_version:
+            self._logger.warning(
+                "Connected to a Zwave JS Server with an untested version, you may run into compatibility issues!"
             )

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -42,7 +42,7 @@ class InvalidState(Exception):
 
 
 class InvalidServerVersion(Exception):
-    """Exception raised when connected to server with incompatible major version."""
+    """Exception raised when connected to server with incompatible version."""
 
 
 class FailedCommand(Exception):

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -377,12 +377,13 @@ class Client:
 
     def _check_server_version(self, server_version: str) -> None:
         """Perform a basic check on the server version compatability."""
+        cur_version = parse_version(server_version)
         min_version = parse_version(MIN_SERVER_VERSION)
-        if (server_version.major != min_version.major) or (
-            server_version.minor < min_version.minor
+        if (cur_version.major != min_version.major) or (
+            cur_version.minor < min_version.minor
         ):
             raise InvalidServerVersion
-        if server_version.minor > min_version:
+        if cur_version.minor > min_version:
             self._logger.warning(
                 "Connected to a Zwave JS Server with an untested version, you may run into compatibility issues!"
             )

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -385,5 +385,6 @@ class Client:
             raise InvalidServerVersion
         if cur_version.minor > min_version:
             self._logger.warning(
-                "Connected to a Zwave JS Server with an untested version, you may run into compatibility issues!"
+                "Connected to a Zwave JS Server with an untested version, \
+                    you may run into compatibility issues!"
             )

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -2,6 +2,8 @@
 from enum import Enum, IntEnum
 from typing import Dict, List
 
+MIN_SERVER_VERSION = "1.0.4"
+
 
 class CommandClass(IntEnum):
     """Enum with all known CommandClasses."""

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -2,7 +2,7 @@
 from enum import Enum, IntEnum
 from typing import Dict, List
 
-MIN_SERVER_VERSION = "1.0.4"
+MIN_SERVER_VERSION = "1.0.0-beta.1"
 
 
 class CommandClass(IntEnum):


### PR DESCRIPTION
Feel free to give feedback. Implemented this as a very basic server version check as I can see some debugging issues coming because of mismatched server versions.

This will basically enforce a compatible server version and prevent us from doing all kind of backwards compatible checks.

Possible fix for #5 