### PR TITLE
Fix handling node state

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -2,6 +2,7 @@
 import json
 
 from zwave_js_server.model import node as node_pkg
+from zwave_js_server.event import Event
 
 from .. import load_fixture
 
@@ -187,3 +188,17 @@ async def test_abort_firmware_update(node, uuid4, mock_command):
         "nodeId": node.node_id,
         "messageId": uuid4,
     }
+
+def test_node_inclusion():
+    """Emulate a node being added."""
+    # when a node node is added, it has minimal info first
+    node = node_pkg.Node(None, {"nodeId": 52, "status": 1, "ready": False, "values": []})
+    assert node.node_id == 52
+    assert node.status == 1
+    assert not node.ready
+    assert len(node.values) == 0
+    # the ready event contains a full (and complete) dump of the node, including values
+    state = json.loads(load_fixture("multisensor_6_state.json"))
+    event = Event("ready", { "nodeState": state })
+    node.receive_event(event)
+    assert len(node.values) > 0

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -189,16 +189,19 @@ async def test_abort_firmware_update(node, uuid4, mock_command):
         "messageId": uuid4,
     }
 
+
 def test_node_inclusion():
     """Emulate a node being added."""
     # when a node node is added, it has minimal info first
-    node = node_pkg.Node(None, {"nodeId": 52, "status": 1, "ready": False, "values": []})
+    node = node_pkg.Node(
+        None, {"nodeId": 52, "status": 1, "ready": False, "values": []}
+    )
     assert node.node_id == 52
     assert node.status == 1
     assert not node.ready
     assert len(node.values) == 0
     # the ready event contains a full (and complete) dump of the node, including values
     state = json.loads(load_fixture("multisensor_6_state.json"))
-    event = Event("ready", { "nodeState": state })
+    event = Event("ready", {"nodeState": state})
     node.receive_event(event)
     assert len(node.values) > 0

--- a/zwave_js_server/model/device_class.py
+++ b/zwave_js_server/model/device_class.py
@@ -7,7 +7,7 @@ https://zwave-js.github.io/node-zwave-js/#/api/node?id=deviceclass
 from typing import List, Optional, TypedDict
 
 
-class DeviceClassDataType(TypedDict):
+class DeviceClassDataType(TypedDict, total=False):
     """Represent a device class data dict type."""
 
     basic: str

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -24,25 +24,25 @@ class NodeDataType(TypedDict, total=False):
     name: str
     location: str
     status: int  # 0-4  # required
-    deviceClass: DeviceClassDataType  # required
+    deviceClass: DeviceClassDataType
     zwavePlusVersion: int
     nodeType: int
     roleType: int
-    isListening: bool  # required
-    isFrequentListening: bool  # required
-    isRouting: bool  # required
-    maxBaudRate: int  # required
-    isSecure: bool  # required
-    isBeaming: bool  # required
-    version: int  # required
+    isListening: bool
+    isFrequentListening: bool
+    isRouting: bool
+    maxBaudRate: int
+    isSecure: bool
+    isBeaming: bool
+    version: int
     firmwareVersion: str
-    manufacturerId: int  # required
-    productId: int  # required
-    productType: int  # required
+    manufacturerId: int
+    productId: int
+    productType: int
     deviceConfig: DeviceConfigDataType
-    neighbors: List[int]  # required
-    keepAwake: bool  # required
-    index: int  # TODO: I can't the below items in the docs.
+    neighbors: List[int]
+    keepAwake: bool
+    index: int
     installerIcon: int
     userIcon: int
     ready: bool
@@ -104,57 +104,57 @@ class Node(EventBase):
     @property
     def device_class(self) -> DeviceClass:
         """Return the device_class."""
-        return DeviceClass(self.data["deviceClass"])
+        return DeviceClass(self.data.get("deviceClass", {}))
 
     @property
-    def is_listening(self) -> bool:
+    def is_listening(self) -> Optional[bool]:
         """Return the is_listening."""
         return self.data["isListening"]
 
     @property
-    def is_frequent_listening(self) -> bool:
+    def is_frequent_listening(self) -> Optional[bool]:
         """Return the is_frequent_listening."""
         return self.data["isFrequentListening"]
 
     @property
-    def is_routing(self) -> bool:
+    def is_routing(self) -> Optional[bool]:
         """Return the is_routing."""
-        return self.data["isRouting"]
+        return self.data.get("isRouting")
 
     @property
-    def max_baud_rate(self) -> int:
+    def max_baud_rate(self) -> Optional[int]:
         """Return the max_baud_rate."""
-        return self.data["maxBaudRate"]
+        return self.data.get("maxBaudRate")
 
     @property
-    def is_secure(self) -> bool:
+    def is_secure(self) -> Optional[bool]:
         """Return the is_secure."""
-        return self.data["isSecure"]
+        return self.data.get("isSecure")
 
     @property
-    def version(self) -> int:
+    def version(self) -> Optional[int]:
         """Return the version."""
-        return self.data["version"]
+        return self.data.get("version")
 
     @property
-    def is_beaming(self) -> bool:
+    def is_beaming(self) -> Optional[bool]:
         """Return the is_beaming."""
-        return self.data["isBeaming"]
+        return self.data.get("isBeaming")
 
     @property
-    def manufacturer_id(self) -> int:
+    def manufacturer_id(self) -> Optional[int]:
         """Return the manufacturer_id."""
-        return self.data["manufacturerId"]
+        return self.data.get("manufacturerId")
 
     @property
-    def product_id(self) -> int:
+    def product_id(self) -> Optional[int]:
         """Return the product_id."""
-        return self.data["productId"]
+        return self.data.get("productId")
 
     @property
-    def product_type(self) -> int:
+    def product_type(self) -> Optional[int]:
         """Return the product_type."""
-        return self.data["productType"]
+        return self.data.get("productType")
 
     @property
     def firmware_version(self) -> Optional[str]:
@@ -199,7 +199,7 @@ class Node(EventBase):
     @property
     def neighbors(self) -> List[int]:
         """Return the neighbors."""
-        return self.data["neighbors"]
+        return self.data.get("neighbors", [])
 
     @property
     def endpoint_count_is_dynamic(self) -> Optional[bool]:
@@ -319,8 +319,11 @@ class Node(EventBase):
         # update/add values
         for value_state in event.data["nodeState"]["values"]:
             value_id = get_value_id(self, value_state)
-            value = self.values.get(value_id, Value(self, value_state))
-            value.update(value_state)
+            value = self.values.get(value_id)
+            if value is None:
+                self.values[value_id] = Value(self, value_state)
+            else:
+                value.update(value_state)
 
     def handle_value_added(self, event: Event) -> None:
         """Process a node value added event."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -109,7 +109,7 @@ class Node(EventBase):
     @property
     def is_listening(self) -> Optional[bool]:
         """Return the is_listening."""
-        return self.data["isListening"]
+        return self.data.get("isListening")
 
     @property
     def is_frequent_listening(self) -> Optional[bool]:


### PR DESCRIPTION
This fixes 2 issues:

- On "node ready" event a full state of the node is dumped including values. The new values were not stored and thus HA discovery was failing when a new node was added to the mesh.
- When a node is in the process of being added, first a partial node state is sent, missing most values. Once the interview progresses/completes these values come in. So basically all attributes for the Node model are optional to account for this behaviour.

Fixes HA issue: https://github.com/home-assistant/core/issues/45631