### PR TITLE
Add poll_value command

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -78,6 +78,24 @@ async def test_set_value(node, uuid4, mock_command):
         "messageId": uuid4,
     }
 
+async def test_poll_value(node, uuid4, mock_command):
+    """Test poll value."""
+    ack_commands = mock_command(
+        {"command": "node.poll_value", "nodeId": node.node_id},
+        {"result": "something"},
+    )
+    value_id = "52-32-00-currentValue-00"
+    value = node.values[value_id]
+    assert await node.async_poll_value(value_id)
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.poll_value",
+        "nodeId": node.node_id,
+        "valueId": value.data,
+        "messageId": uuid4,
+    }
+
 
 async def test_refresh_info(node, uuid4, mock_command):
     """Test refresh info."""

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -87,7 +87,8 @@ async def test_poll_value(node, uuid4, mock_command):
     )
     value_id = "52-32-00-currentValue-00"
     value = node.values[value_id]
-    assert await node.async_poll_value(value_id)
+    result = await node.async_poll_value(value_id)
+    assert result == "something"
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -78,6 +78,7 @@ async def test_set_value(node, uuid4, mock_command):
         "messageId": uuid4,
     }
 
+
 async def test_poll_value(node, uuid4, mock_command):
     """Test poll value."""
     ack_commands = mock_command(

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -301,11 +301,7 @@ class Node(EventBase):
             val = self.values[val]
         # the value object needs to be send to the server
         result = await self.client.async_send_command(
-            {
-                "command": "node.poll_value",
-                "nodeId": self.node_id,
-                "valueId": val.data
-            }
+            {"command": "node.poll_value", "nodeId": self.node_id, "valueId": val.data}
         )
         # result may or may not be there
         return result.get("result")

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -294,6 +294,22 @@ class Node(EventBase):
             }
         )
 
+    async def async_poll_value(self, val: Union[Value, str]) -> Any:
+        """Send pollValue command to Node for given value (or value_id)."""
+        # a value may be specified as value_id or the value itself
+        if not isinstance(val, Value):
+            val = self.values[val]
+        # the value object needs to be send to the server
+        result = await self.client.async_send_command(
+            {
+                "command": "node.poll_value",
+                "nodeId": self.node_id,
+                "valueId": val.data
+            }
+        )
+        # result may or may not be there
+        return result.get("result")
+
     def handle_wake_up(self, event: Event) -> None:
         """Process a node wake up event."""
 


### PR DESCRIPTION
Add's a method to manually poll a Z-Wave value.
This is a best-effort service, allowing users to setup some automation or something to manually poll a value(ID).
It doesn't have a specific return value as it *might* return a value from the node (in any type) or simply nothing.

The idea is to implement this as a entity service in the HA integration with a big fat warning that polling too often is bad ;-)