### PR TITLE
Fix value get right key

### DIFF
--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -106,6 +106,7 @@ class Value:
         """Initialize value."""
         self.node = node
         self.data = data
+        self._value = data.get("newValue", data.get("value"))
 
     def __repr__(self) -> str:
         """Return the representation."""
@@ -124,7 +125,7 @@ class Value:
     @property
     def value(self) -> Optional[Any]:
         """Return value."""
-        return self.data.get("value")
+        return self._value
 
     @property
     def command_class_name(self) -> str:
@@ -178,6 +179,7 @@ class Value:
     def update(self, data: ValueDataType) -> None:
         """Update data."""
         self.data.update(data)
+        self._value = data.get("newValue", data.get("value"))
 
 
 class ValueNotification(Value):

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -33,6 +33,8 @@ class ValueDataType(TypedDict, total=False):
     propertyKey: Union[str, int]
     propertyKeyName: str
     value: Any
+    newValue: Any
+    prevValue: Any
     metadata: MetaDataType
     ccVersion: int
 


### PR DESCRIPTION
value_added and value_updated events will issue the value in newValue attribute while value_added, value_notification and a full node dump's value has it in the "value" attribute. Pick the right one.

This belongs to https://github.com/zwave-js/zwave-js-server/pull/72

