### PR TITLE
Rework client

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(
     packages=find_packages(exclude=["test.*", "test"]),
     python_requires=">=3.8",
     install_requires=["aiohttp>3", "packaging"],
+    entry_points={
+        "console_scripts": ["zwave-js-server-python = zwave_js_server.__main__:main"]
+    },
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -46,9 +46,11 @@ def client_session_fixture(ws_client):
 
 
 @pytest.fixture(name="ws_client")
-def ws_client_fixture():
+def ws_client_fixture(version_data):
     """Mock a websocket client."""
-    return AsyncMock(spec_set=ClientWebSocketResponse)
+    ws_client = AsyncMock(spec_set=ClientWebSocketResponse)
+    ws_client.receive_json.return_value = version_data
+    return ws_client
 
 
 @pytest.fixture(name="version_data")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -65,8 +65,9 @@ async def ws_client_fixture(loop, version_data, ws_message):
 
     ws_client.receive.side_effect = receive
 
-    def close_client(*args):
+    async def close_client(*args):
         """Close the client."""
+        await asyncio.sleep(0)
         ws_client.closed = True
         receive_event.set()
 
@@ -139,18 +140,6 @@ async def client_fixture(loop, client_session, ws_client, uuid4):
     client.state = STATE_CONNECTED
     client.client = ws_client
     return client
-
-
-@pytest.fixture(name="await_other")
-async def await_other_fixture(loop):
-    """Await all tasks except the current task."""
-
-    async def wait_for_tasks(current_task):
-        """Await the tasks."""
-        tasks = asyncio.all_tasks() - {current_task}
-        await asyncio.gather(*tasks)
-
-    return wait_for_tasks
 
 
 @pytest.fixture(name="mock_command")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,6 +13,8 @@ from zwave_js_server.model.node import Node
 
 from . import load_fixture
 
+# pylint: disable=unused-argument
+
 
 @pytest.fixture(name="controller_state", scope="session")
 def controller_state_fixture():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 """Provide common pytest fixtures."""
+import asyncio
 import json
 from typing import List, Tuple
 from unittest.mock import AsyncMock, patch
@@ -89,6 +90,18 @@ async def client_fixture(loop, client_session, ws_client, uuid4):
     client.state = STATE_CONNECTED
     client.client = ws_client
     return client
+
+
+@pytest.fixture(name="await_other")
+async def await_other_fixture(loop):
+    """Await all tasks except the current task."""
+
+    async def wait_for_tasks(current_task):
+        """Await the tasks."""
+        tasks = asyncio.all_tasks() - {current_task}
+        await asyncio.gather(*tasks)
+
+    return wait_for_tasks
 
 
 @pytest.fixture(name="mock_command")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -83,6 +83,24 @@ async def ws_client_fixture(loop, version_data, ws_message):
     return ws_client
 
 
+@pytest.fixture(name="await_other")
+async def await_other_fixture(loop):
+    """Await all other task but the current task."""
+
+    async def wait_for_tasks(current_task):
+        """Wait for the tasks."""
+        tasks = asyncio.all_tasks() - {current_task}
+        await asyncio.gather(*tasks)
+
+    return wait_for_tasks
+
+
+@pytest.fixture(name="driver_ready")
+async def driver_ready_fixture(loop):
+    """Return an asyncio.Event for driver ready."""
+    return asyncio.Event()
+
+
 @pytest.fixture(name="version_data")
 def version_data_fixture():
     """Return mock version data."""

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -51,3 +51,17 @@ async def test_on_connect(client_session, url, await_other):
 
     assert client.connected
     on_connect.assert_awaited()
+
+
+async def test_on_connect_exception(client_session, url, await_other, caplog):
+    """Test client on connect callback."""
+    on_connect_test = AsyncMock(side_effect=Exception("Boom"))
+    client = Client(url, client_session, start_listening_on_connect=False)
+    client.register_on_connect(on_connect_test)
+
+    await client.connect()
+    await await_other(asyncio.current_task())
+
+    assert client.connected
+    on_connect_test.assert_awaited()
+    assert "Unexpected error in on_connect" in caplog.text

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -44,13 +44,27 @@ async def test_on_connect(client_session, url, await_other):
     """Test client on connect callback."""
     on_connect = AsyncMock()
     client = Client(url, client_session, start_listening_on_connect=False)
-    client.register_on_connect(on_connect)
+    unsubscribe_on_connect = client.register_on_connect(on_connect)
 
     await client.connect()
     await await_other(asyncio.current_task())
 
     assert client.connected
     on_connect.assert_awaited()
+
+    on_connect.reset_mock()
+
+    await client.disconnect()
+
+    assert not client.connected
+
+    unsubscribe_on_connect()
+
+    await client.connect()
+    await await_other(asyncio.current_task())
+
+    assert client.connected
+    on_connect.assert_not_awaited()
 
 
 async def test_on_connect_exception(client_session, url, await_other, caplog):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -6,7 +6,7 @@ from aiohttp.client_exceptions import ClientError
 import pytest
 
 from zwave_js_server.client import Client
-from zwave_js_server.exceptions import CannotConnect, InvalidServerVersion
+from zwave_js_server.exceptions import CannotConnect, InvalidServerVersion, NotConnected
 
 
 async def test_connect(client_session, url):
@@ -38,6 +38,16 @@ async def test_invalid_server_version(client_session, url, version_data):
         await client.connect()
 
     assert not client.connected
+
+
+async def test_send_json_when_disconnected(client_session, url):
+    """Test send json message when disconnected."""
+    client = Client(url, client_session, start_listening_on_connect=False)
+
+    assert not client.connected
+
+    with pytest.raises(NotConnected):
+        await client.async_send_json_message({"test": None})
 
 
 async def test_on_connect_on_disconnect(client_session, url, await_other):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -177,3 +177,19 @@ async def test_listen_error_message_types(
 
     with pytest.raises(exception):
         await client.listen()
+
+
+@pytest.mark.parametrize("message_type", [WSMsgType.CLOSED, WSMsgType.CLOSING])
+async def test_listen_disconnect_message_types(
+    client_session, url, ws_client, ws_message, message_type
+):
+    """Test different websocket message types that stop listen."""
+    ws_message.type = message_type
+
+    # This should break out of the listen loop before handling the received message.
+    # Otherwise there will be an error.
+    async with Client(url, client_session, start_listening_on_connect=True) as client:
+        await client.listen()
+
+    # Assert that we received a message.
+    ws_client.receive.assert_awaited()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -153,6 +153,7 @@ async def test_listen_disconnect_message_types(
     async with Client(url, client_session) as client:
         assert client.connected
         ws_message.type = message_type
+        ws_client.closed = False
 
         # This should break out of the listen loop before handling the received message.
         # Otherwise there will be an error.

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -193,3 +193,14 @@ async def test_listen_disconnect_message_types(
 
     # Assert that we received a message.
     ws_client.receive.assert_awaited()
+
+
+async def test_listen_invalid_message_data(client_session, url, ws_message):
+    """Test websocket message data that should raise on listen."""
+    client = Client(url, client_session, start_listening_on_connect=True)
+    await client.connect()
+
+    ws_message.json.side_effect = ValueError("Boom")
+
+    with pytest.raises(InvalidMessage):
+        await client.listen()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -118,6 +118,7 @@ async def test_listen_client_error(client_session, url, ws_client, ws_message):
 
     ws_client.receive.side_effect = asyncio.CancelledError()
     ws_message.reset_mock()
+    ws_client.closed = False
 
     # This should break out of the listen loop before any message is received.
     await client.listen()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,0 +1,12 @@
+"""Test the client."""
+from zwave_js_server.client import Client
+
+
+async def test_connect(client_session, ws_client, url, version_data):
+    """Test client connect."""
+    ws_client.receive_json.return_value = version_data
+    client = Client(url, client_session)
+
+    await client.connect()
+
+    assert client.connected

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -55,13 +55,13 @@ async def test_on_connect(client_session, url, await_other):
 
 async def test_on_connect_exception(client_session, url, await_other, caplog):
     """Test client on connect callback."""
-    on_connect_test = AsyncMock(side_effect=Exception("Boom"))
+    on_connect = AsyncMock(side_effect=Exception("Boom"))
     client = Client(url, client_session, start_listening_on_connect=False)
-    client.register_on_connect(on_connect_test)
+    client.register_on_connect(on_connect)
 
     await client.connect()
     await await_other(asyncio.current_task())
 
     assert client.connected
-    on_connect_test.assert_awaited()
+    on_connect.assert_awaited()
     assert "Unexpected error in on_connect" in caplog.text

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -3,7 +3,7 @@ from aiohttp.client_exceptions import ClientError
 import pytest
 
 from zwave_js_server.client import Client
-from zwave_js_server.exceptions import CannotConnect
+from zwave_js_server.exceptions import CannotConnect, InvalidServerVersion
 
 
 async def test_connect(client_session, ws_client, url, version_data):
@@ -22,6 +22,18 @@ async def test_cannot_connect(client_session, url):
     client = Client(url, client_session)
 
     with pytest.raises(CannotConnect):
+        await client.connect()
+
+    assert not client.connected
+
+
+async def test_invalid_server_version(client_session, ws_client, url, version_data):
+    """Test client connect with invalid server version."""
+    version_data["serverVersion"] = "invalid"
+    ws_client.receive_json.return_value = version_data
+    client = Client(url, client_session)
+
+    with pytest.raises(InvalidServerVersion):
         await client.connect()
 
     assert not client.connected

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -11,6 +11,7 @@ from zwave_js_server.client import Client
 from zwave_js_server.exceptions import (
     CannotConnect,
     ConnectionFailed,
+    FailedCommand,
     InvalidMessage,
     InvalidServerVersion,
     InvalidState,
@@ -240,6 +241,18 @@ async def test_listen_invalid_message_data(client_session, url, ws_message):
 
     with pytest.raises(InvalidMessage):
         await client.listen()
+
+
+async def test_listen_not_success(client_session, url, result, await_other):
+    """Test receive result message with success False on listen."""
+    result["success"] = False
+    result["errorCode"] = "error_code"
+    client = Client(url, client_session, start_listening_on_connect=True)
+    await client.connect()
+
+    await client.listen()
+    with pytest.raises(FailedCommand):
+        await await_other(asyncio.current_task())
 
 
 async def test_listen_invalid_state(client_session, url, result):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -203,12 +203,12 @@ async def test_listen_invalid_state(client_session, url, result):
             "propertyName": "currentValue",
         },
     }
-    client = Client(url, client_session, start_listening_on_connect=True)
-    await client.connect()
+    client = Client(url, client_session)
 
     with pytest.raises(InvalidState):
-        await client.listen()
+        await client.connect()
 
+    assert client.connected
 
 
 async def test_listen_event(client_session, url, ws_client, ws_message, result):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -44,7 +44,7 @@ async def test_cannot_connect(client_session, url, error):
     assert not client.connected
 
 
-async def test_invalid_server_version(client_session, url, version_data):
+async def test_invalid_server_version(client_session, url, version_data, caplog):
     """Test client connect with invalid server version."""
     version_data["serverVersion"] = "invalid"
     client = Client(url, client_session, start_listening_on_connect=False)
@@ -53,6 +53,13 @@ async def test_invalid_server_version(client_session, url, version_data):
         await client.connect()
 
     assert not client.connected
+
+    version_data["serverVersion"] = "99999.0.0"
+
+    await client.connect()
+
+    assert client.connected
+    assert "Connected to a Zwave JS Server with an untested version" in caplog.text
 
 
 async def test_send_json_when_disconnected(client_session, url):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -10,6 +10,7 @@ from aiohttp.http_websocket import WSMsgType
 from zwave_js_server.client import Client
 from zwave_js_server.exceptions import (
     CannotConnect,
+    ConnectionClosed,
     ConnectionFailed,
     FailedCommand,
     InvalidMessage,
@@ -128,7 +129,11 @@ async def test_listen_client_error(client_session, url, ws_client, ws_message):
 
 @pytest.mark.parametrize(
     "message_type, exception",
-    [(WSMsgType.ERROR, ConnectionFailed), (WSMsgType.BINARY, InvalidMessage)],
+    [
+        (WSMsgType.ERROR, ConnectionFailed),
+        (WSMsgType.BINARY, InvalidMessage),
+        (WSMsgType.CLOSE, ConnectionClosed),
+    ],
 )
 async def test_listen_error_message_types(
     client_session, url, ws_client, ws_message, message_type, exception

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,4 +1,7 @@
 """Test the client."""
+import asyncio
+from unittest.mock import AsyncMock
+
 from aiohttp.client_exceptions import ClientError
 import pytest
 
@@ -35,3 +38,16 @@ async def test_invalid_server_version(client_session, url, version_data):
         await client.connect()
 
     assert not client.connected
+
+
+async def test_on_connect(client_session, url, await_other):
+    """Test client on connect callback."""
+    on_connect = AsyncMock()
+    client = Client(url, client_session, start_listening_on_connect=False)
+    client.register_on_connect(on_connect)
+
+    await client.connect()
+    await await_other(asyncio.current_task())
+
+    assert client.connected
+    on_connect.assert_awaited()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,5 +1,9 @@
 """Test the client."""
+from aiohttp.client_exceptions import ClientError
+import pytest
+
 from zwave_js_server.client import Client
+from zwave_js_server.exceptions import CannotConnect
 
 
 async def test_connect(client_session, ws_client, url, version_data):
@@ -10,3 +14,14 @@ async def test_connect(client_session, ws_client, url, version_data):
     await client.connect()
 
     assert client.connected
+
+
+async def test_cannot_connect(client_session, url):
+    """Test cannot connect."""
+    client_session.ws_connect.side_effect = ClientError
+    client = Client(url, client_session)
+
+    with pytest.raises(CannotConnect):
+        await client.connect()
+
+    assert not client.connected

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -218,6 +218,15 @@ async def test_listen_invalid_state(client_session, url, result):
     assert client.connected
 
 
+async def test_listen_without_connect(client_session, url):
+    """Test listen without first being connected."""
+    client = Client(url, client_session)
+    assert not client.connected
+
+    with pytest.raises(InvalidState):
+        await client.listen()
+
+
 async def test_listen_event(client_session, url, ws_client, ws_message, result):
     """Test receiving event result type on listen."""
     client = Client(url, client_session)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -6,10 +6,9 @@ from zwave_js_server.client import Client
 from zwave_js_server.exceptions import CannotConnect, InvalidServerVersion
 
 
-async def test_connect(client_session, ws_client, url, version_data):
+async def test_connect(client_session, url):
     """Test client connect."""
-    ws_client.receive_json.return_value = version_data
-    client = Client(url, client_session)
+    client = Client(url, client_session, start_listening_on_connect=False)
 
     await client.connect()
 
@@ -19,7 +18,7 @@ async def test_connect(client_session, ws_client, url, version_data):
 async def test_cannot_connect(client_session, url):
     """Test cannot connect."""
     client_session.ws_connect.side_effect = ClientError
-    client = Client(url, client_session)
+    client = Client(url, client_session, start_listening_on_connect=False)
 
     with pytest.raises(CannotConnect):
         await client.connect()
@@ -27,11 +26,10 @@ async def test_cannot_connect(client_session, url):
     assert not client.connected
 
 
-async def test_invalid_server_version(client_session, ws_client, url, version_data):
+async def test_invalid_server_version(client_session, url, version_data):
     """Test client connect with invalid server version."""
     version_data["serverVersion"] = "invalid"
-    ws_client.receive_json.return_value = version_data
-    client = Client(url, client_session)
+    client = Client(url, client_session, start_listening_on_connect=False)
 
     with pytest.raises(InvalidServerVersion):
         await client.connect()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -326,7 +326,7 @@ async def test_listen_event(
 async def test_listen_unknown_result_type(
     client_session, url, ws_client, ws_message, result, await_other
 ):
-    """Test websocket message with unknown result on listen."""
+    """Test websocket message with unknown type on listen."""
     client = Client(url, client_session, start_listening_on_connect=True)
     await client.connect()
     await client.listen()
@@ -346,7 +346,7 @@ async def test_listen_unknown_result_type(
     ws_client.receive.side_effect = receive
     result["type"] = "unknown"
 
-    # Receiving an unknown result type should not error.
+    # Receiving an unknown message type should not error.
     await client.listen()
 
     ws_client.receive.assert_awaited()

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,19 +1,12 @@
 """Test the server version helper."""
-from unittest.mock import AsyncMock, call
+from unittest.mock import call
 
 from zwave_js_server.version import get_server_version
 
 
-async def test_get_server_version(client_session, ws_client):
+async def test_get_server_version(client_session, ws_client, url, version_data):
     """Test the get server version helper."""
-    version_data = {
-        "driverVersion": "test_driver_version",
-        "serverVersion": "test_server_version",
-        "homeId": "test_home_id",
-    }
-    client_session.ws_connect.side_effect = AsyncMock(return_value=ws_client)
     ws_client.receive_json.return_value = version_data
-    url = "ws://test.org:3000"
 
     version_info = await get_server_version(url, client_session)
 

--- a/zwave_js_server/__main__.py
+++ b/zwave_js_server/__main__.py
@@ -38,7 +38,7 @@ def get_arguments() -> argparse.Namespace:
     return arguments
 
 
-async def main() -> None:
+async def start_cli() -> None:
     """Run main."""
     args = get_arguments()
     level = logging.DEBUG if args.debug else logging.INFO
@@ -126,8 +126,13 @@ async def register_controller_listeners(client: Client) -> None:
     await is_initialized.wait()
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Run main."""
     try:
-        asyncio.run(main())
+        asyncio.run(start_cli())
     except KeyboardInterrupt:
         pass
+
+
+if __name__ == "__main__":
+    main()

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -101,8 +101,9 @@ class Client:
         if msg["type"] != "event":
             # Can't handle
             self._logger.debug(
-                "Received message with unknown result type with ID: %s",
-                msg["messageId"],
+                "Received message with unknown type '%s': %s",
+                msg["type"],
+                msg,
             )
             return
 

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -224,11 +224,8 @@ class Client:
         while not self.client.closed:
             try:
                 msg = await self.client.receive()
-            except (
-                client_exceptions.WSServerHandshakeError,
-                client_exceptions.ClientError,
-            ) as err:
-                raise ConnectionFailed(err) from err
+            except asyncio.CancelledError:
+                break
 
             if msg.type in (WSMsgType.CLOSED, WSMsgType.CLOSING):
                 break

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -66,7 +66,6 @@ class Client:
         self._on_initialized: List[Callable[[], Awaitable[None]]] = []
         self._logger = logging.getLogger(__package__)
         self._result_futures: Dict[str, asyncio.Future] = {}
-        self._loop = asyncio.get_running_loop()
 
         if start_listening_on_connect:
             self.register_on_connect(self._start_listening)
@@ -152,7 +151,8 @@ class Client:
 
     async def async_send_command(self, message: Dict[str, Any]) -> dict:
         """Send a command and get a response."""
-        future: "asyncio.Future[dict]" = self._loop.create_future()
+        loop = asyncio.get_running_loop()
+        future: "asyncio.Future[dict]" = loop.create_future()
         message_id = message["messageId"] = uuid.uuid4().hex
         self._result_futures[message_id] = future
         await self.async_send_json_message(message)

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -251,14 +251,13 @@ class Client:
             try:
                 self.async_handle_message(msg_)
             except InvalidState:
-                await self.client.close()
+                await self._close()
                 raise
 
     async def disconnect(self) -> None:
         """Disconnect the client."""
         if self.client is not None:
-            self._logger.debug("Closing client connection")
-            await self.client.close()
+            await self._close()
 
         self.state = STATE_DISCONNECTED
 
@@ -266,6 +265,12 @@ class Client:
             asyncio.create_task(
                 gather_callbacks(self._logger, "on_disconnect", self._on_disconnect)
             )
+
+    async def _close(self) -> None:
+        """Close the client connection."""
+        self._logger.debug("Closing client connection")
+        assert self.client
+        await self.client.close()
 
     async def _start_listening(self) -> None:
         """When connected, start listening."""

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -83,7 +83,7 @@ class Client:
 
             if future is None:
                 self._logger.warning(
-                    "Received result for unknown message: %s", msg["messageId"]
+                    "Received result for unknown message with ID: %s", msg["messageId"]
                 )
                 return
 
@@ -99,6 +99,10 @@ class Client:
 
         if msg["type"] != "event":
             # Can't handle
+            self._logger.debug(
+                "Received message with unknown result type with ID: %s",
+                msg["messageId"],
+            )
             return
 
         event = Event(type=msg["event"]["event"], data=msg["event"])

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -26,7 +26,6 @@ from .model.version import VersionInfo
 STATE_CONNECTED = "connected"
 STATE_DISCONNECTED = "disconnected"
 
-
 SIZE_PARSE_JSON_EXECUTOR = 8192
 
 

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -13,6 +13,7 @@ from .const import MIN_SERVER_VERSION
 from .event import Event
 from .exceptions import (
     CannotConnect,
+    ConnectionClosed,
     ConnectionFailed,
     FailedCommand,
     InvalidMessage,
@@ -232,6 +233,9 @@ class Client:
 
             if msg.type in (WSMsgType.CLOSED, WSMsgType.CLOSING):
                 break
+
+            if msg.type == WSMsgType.CLOSE:
+                raise ConnectionClosed()
 
             if msg.type == WSMsgType.ERROR:
                 raise ConnectionFailed()

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -12,6 +12,7 @@ from packaging.version import parse as parse_version
 
 from .const import MIN_SERVER_VERSION
 from .event import Event
+from .exceptions import FailedCommand, InvalidServerVersion, InvalidState, NotConnected
 from .model.driver import Driver
 from .model.version import VersionInfo
 
@@ -32,28 +33,6 @@ async def gather_callbacks(
         if not isinstance(result, Exception):
             continue
         logger.error("Unexpected error in %s %s", name, callback, exc_info=result)
-
-
-class NotConnected(Exception):
-    """Exception raised when trying to handle unknown handler."""
-
-
-class InvalidState(Exception):
-    """Exception raised when data gets in invalid state."""
-
-
-class InvalidServerVersion(Exception):
-    """Exception raised when connected to server with incompatible version."""
-
-
-class FailedCommand(Exception):
-    """When a command has failed."""
-
-    def __init__(self, message_id: str, error_code: str):
-        """Initialize a failed command error."""
-        super().__init__(f"Command failed: {error_code}")
-        self.message_id = message_id
-        self.error_code = error_code
 
 
 class Client:

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -7,3 +7,25 @@ class BaseZwaveJSServerError(Exception):
 
 class NotFoundError(BaseZwaveJSServerError):
     """Exception that is raised when an entity can't be found."""
+
+
+class NotConnected(BaseZwaveJSServerError):
+    """Exception raised when trying to handle unknown handler."""
+
+
+class InvalidState(BaseZwaveJSServerError):
+    """Exception raised when data gets in invalid state."""
+
+
+class InvalidServerVersion(BaseZwaveJSServerError):
+    """Exception raised when connected to server with incompatible version."""
+
+
+class FailedCommand(BaseZwaveJSServerError):
+    """When a command has failed."""
+
+    def __init__(self, message_id: str, error_code: str):
+        """Initialize a failed command error."""
+        super().__init__(f"Command failed: {error_code}")
+        self.message_id = message_id
+        self.error_code = error_code

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -22,7 +22,7 @@ class CannotConnect(TransportError):
 
     def __init__(self, error: Exception) -> None:
         """Initialize a cannot connect error."""
-        super().__init__(f"Cannot connect: {error}", error)
+        super().__init__(f"{error}", error)
 
 
 class ConnectionFailed(TransportError):
@@ -33,7 +33,7 @@ class ConnectionFailed(TransportError):
         if error is None:
             super().__init__("Connection failed.")
             return
-        super().__init__(f"Connection failed: {error}", error)
+        super().__init__(f"{error}", error)
 
 
 class NotFoundError(BaseZwaveJSServerError):

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -25,6 +25,14 @@ class CannotConnect(TransportError):
         super().__init__(f"{error}", error)
 
 
+class ConnectionClosed(TransportError):
+    """Exception raised when the connection is closed by the server."""
+
+    def __init__(self) -> None:
+        """Initialize a connection closed error."""
+        super().__init__("Connection closed by server.")
+
+
 class ConnectionFailed(TransportError):
     """Exception raised when an established connection fails."""
 

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -1,8 +1,39 @@
 """Exceptions for zwave-js-server."""
 
 
+from typing import Optional
+
+
 class BaseZwaveJSServerError(Exception):
     """Base Zwave JS Server exception."""
+
+
+class TransportError(BaseZwaveJSServerError):
+    """Exception raised to represent transport errors."""
+
+    def __init__(self, message: str, error: Optional[Exception] = None) -> None:
+        """Initialize a transport error."""
+        super().__init__(message)
+        self.error = error
+
+
+class CannotConnect(TransportError):
+    """Exception raised when failed to connect the client."""
+
+    def __init__(self, error: Exception) -> None:
+        """Initialize a cannot connect error."""
+        super().__init__(f"Cannot connect: {error}", error)
+
+
+class ConnectionFailed(TransportError):
+    """Exception raised when an established connection fails."""
+
+    def __init__(self, error: Optional[Exception] = None) -> None:
+        """Initialize a connection failed error."""
+        if error is None:
+            super().__init__("Connection failed.")
+            return
+        super().__init__(f"Connection failed: {error}", error)
 
 
 class NotFoundError(BaseZwaveJSServerError):
@@ -15,6 +46,10 @@ class NotConnected(BaseZwaveJSServerError):
 
 class InvalidState(BaseZwaveJSServerError):
     """Exception raised when data gets in invalid state."""
+
+
+class InvalidMessage(BaseZwaveJSServerError):
+    """Exception raised when an invalid message is received."""
 
 
 class InvalidServerVersion(BaseZwaveJSServerError):


### PR DESCRIPTION
I recommend reviewing with hidden white space changes:
https://github.com/home-assistant-libs/zwave-js-server-python/pull/78/files?diff=unified&w=1

- Remove connection re-try feature from client. The library user will be responsible for re-connecting.
- The main methods for connecting, receiving messages and disconnecting are now `Client.connect`, `Client.listen` and `Client.disconnect`, respectively. The library user is responsible for calling these in the correct order, `connect` (1), `listen` (2), `disconnect` (3).
- `Client.listen` now accepts a `driver_ready` `asyncio.Event` parameter to allow the caller to wait for driver to get ready.
- The client callback methods and events have been removed. The library user is responsible for handling connection state propagation.
- Raise `InvalidState` if the client is connected with existing driver state.
- All library exceptions now inherit from `BaseZwaveJSServerError`.
- Adapt CLI script for new client interface.
- Add setup.py entrypoint to install CLI script.

```sh
(zwave-js-server-python) x$ zwave-js-server-python --help
usage: zwave-js-server-python [-h] [--debug] [--server-version] [--dump-state] [--event-timeout EVENT_TIMEOUT] url

Z-Wave JS Server Python

positional arguments:
  url                   URL of server, ie ws://localhost:3000

optional arguments:
  -h, --help            show this help message and exit
  --debug               Log with debug level
  --server-version      Print the version of the server
  --dump-state          Dump the driver state
  --event-timeout EVENT_TIMEOUT
                        How long to listen for events when dumping state
```

- Add client tests.

fixes #66, fixes #84