### PR TITLE
Bump zwave-js-server to 1.0.0-beta.2

### DIFF
--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -2,7 +2,7 @@
 from enum import Enum, IntEnum
 from typing import Dict, List
 
-MIN_SERVER_VERSION = "1.0.0-beta.1"
+MIN_SERVER_VERSION = "1.0.0-beta.2"
 
 
 class CommandClass(IntEnum):


### PR DESCRIPTION
This will bump the minimal required version of the WS server to 1.0.0-beta.2 as that contains the fix for the value in the dump.
