### PR TITLE
Handle metadata updated

### DIFF
--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -367,10 +367,16 @@ class Node(EventBase):
 
     def handle_value_notification(self, event: Event) -> None:
         """Process a node value notification event."""
+        # append metadata if value metadata is available
+        value = self.values.get(get_value_id(self, event.data["args"]))
+        if value and value.data.get("metadata"):
+            event.data["args"]["metadata"] = value.data["metadata"]
         event.data["value_notification"] = ValueNotification(self, event.data["args"])
 
     def handle_metadata_updated(self, event: Event) -> None:
         """Process a node metadata updated event."""
+        # handle metadata updated as value updated (a its a value object with included metadata)
+        self.handle_value_updated(event)
 
     def handle_notification(self, event: Event) -> None:
         """Process a node notification event."""

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -181,7 +181,10 @@ class Value:
     def update(self, data: ValueDataType) -> None:
         """Update data."""
         self.data.update(data)
-        self._value = data.get("newValue", data.get("value"))
+        if "newValue" in data:
+            self._value = data["newValue"]
+        if "value" in data:
+            self._value = data["value"]
 
 
 class ValueNotification(Value):


### PR DESCRIPTION
Belongs to https://github.com/zwave-js/zwave-js-server/pull/81
Fixes missing value.value for (scene activation) events.

This fix should be merged before HA release 2021.2