### PR TITLE
Metadata can be optional

### DIFF
--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -122,7 +122,7 @@ class Value:
     @property
     def metadata(self) -> ValueMetadata:
         """Return value metadata."""
-        return ValueMetadata(self.data["metadata"])
+        return ValueMetadata(self.data.get("metadata", {"type": "unknown"}))
 
     @property
     def value(self) -> Optional[Any]:


### PR DESCRIPTION
Due to a small bug in Z-Wave JS the metadata can be missing for a CommandClass Value.
This fix will at least prevent the KeyError when accessing metadata of a value. I've decided to initialize it with an (almost) empty dict to keep compatibility.

We can remove it once the upstream issue is resolved.


https://github.com/zwave-js/node-zwave-js/issues/1560
