### PR TITLE
Make send JSON message internal

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -187,7 +187,7 @@ def mock_command_fixture(ws_client, client, uuid4):
                     "result": response,
                     "success": success,
                 }
-                client.async_handle_message(received_message)
+                client._handle_incoming_message(received_message)
                 return
 
         raise RuntimeError("Command not mocked!")

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -70,7 +70,7 @@ async def test_send_json_when_disconnected(client_session, url):
     assert not client.connected
 
     with pytest.raises(NotConnected):
-        await client.async_send_json_message({"test": None})
+        await client._send_json_message({"test": None})
 
 
 async def test_connect_with_existing_driver(

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -167,7 +167,7 @@ class Controller(EventBase):
 
     async def async_remove_failed_node(self, node_id: int) -> None:
         """Send removeFailedNode command to Controller."""
-        await self.client.async_send_json_message(
+        await self.client.async_send_command(
             {"command": "controller.remove_failed_node", "nodeId": node_id}
         )
 
@@ -270,7 +270,7 @@ class Controller(EventBase):
         self, node_id: int, group: int, associations: List[Association]
     ) -> None:
         """Send addAssociations command to Controller."""
-        await self.client.async_send_json_message(
+        await self.client.async_send_command(
             {
                 "command": "controller.add_associations",
                 "nodeId": node_id,
@@ -289,7 +289,7 @@ class Controller(EventBase):
         self, node_id: int, group: int, associations: List[Association]
     ) -> None:
         """Send removeAssociations command to Controller."""
-        await self.client.async_send_json_message(
+        await self.client.async_send_command(
             {
                 "command": "controller.remove_associations",
                 "nodeId": node_id,
@@ -306,7 +306,7 @@ class Controller(EventBase):
 
     async def async_remove_node_from_all_assocations(self, node_id: int) -> None:
         """Send removeNodeFromAllAssocations command to Controller."""
-        await self.client.async_send_json_message(
+        await self.client.async_send_command(
             {
                 "command": "controller.remove_node_from_all_assocations",
                 "nodeId": node_id,

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -259,7 +259,7 @@ class Node(EventBase):
 
     async def async_refresh_info(self) -> None:
         """Send refreshInfo command to Node."""
-        await self.client.async_send_json_message(
+        await self.client.async_send_command(
             {
                 "command": "node.refresh_info",
                 "nodeId": self.node_id,
@@ -295,7 +295,7 @@ class Node(EventBase):
 
     async def async_abort_firmware_update(self) -> None:
         """Send abortFirmwareUpdate command to Node."""
-        await self.client.async_send_json_message(
+        await self.client.async_send_command(
             {
                 "command": "node.abort_firmware_update",
                 "nodeId": self.node_id,


### PR DESCRIPTION
This makes send JSON message command on the client internal. It found a bunch of places where we weren't using the send command version and so didn't wait until the command was considered done by the driver.