### PR TITLE
Clean up client connection

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -23,6 +23,7 @@ disable=
   too-few-public-methods,
   too-many-public-methods,
   too-many-instance-attributes,
+  too-many-branches,
   no-self-use
 
 [REPORTS]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,6 @@
 """Provide common pytest fixtures."""
 import asyncio
 import json
-import logging
 from typing import List, Tuple
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -16,8 +15,6 @@ from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node
 
 from . import load_fixture
-
-logging.basicConfig(level=logging.DEBUG)
 
 # pylint: disable=unused-argument
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from aiohttp import ClientSession, ClientWebSocketResponse
 from aiohttp.http_websocket import WSMessage, WSMsgType
 
-from zwave_js_server.client import STATE_CONNECTED, Client
+from zwave_js_server.client import Client
 from zwave_js_server.const import MIN_SERVER_VERSION
 from zwave_js_server.model.controller import Controller
 from zwave_js_server.model.driver import Driver
@@ -158,7 +158,6 @@ async def client_fixture(loop, client_session, ws_client, uuid4):
     when creating the client.
     """
     client = Client("ws://test.org", client_session)
-    client.state = STATE_CONNECTED
     client._client = ws_client
     return client
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -54,7 +54,11 @@ async def test_invalid_server_version(client_session, url, version_data, caplog)
 
     assert not client.connected
 
+
+async def test_newer_server_version(client_session, url, version_data, caplog):
+    """Test client connect with invalid server version."""
     version_data["serverVersion"] = "99999.0.0"
+    client = Client(url, client_session)
 
     await client.connect()
 
@@ -72,35 +76,9 @@ async def test_send_json_when_disconnected(client_session, url):
         await client._send_json_message({"test": None})
 
 
-async def test_connect_with_existing_driver(
-    client_session, url, ws_client, driver_ready, await_other
-):
-    """Test connecting again with an existing driver raises."""
-    client = Client(url, client_session)
-    assert not client.connected
-    assert not client.driver
-
-    await client.connect()
-
-    assert client.connected
-
-    await client.listen(driver_ready)
-    await await_other(asyncio.current_task())
-
-    assert client.driver
-
-    ws_client.receive.reset_mock()
-    ws_client.closed = False
-
-    with pytest.raises(InvalidState):
-        await client.connect()
-
-    ws_client.receive.assert_not_awaited()
-
-
-async def test_listen(client_session2, url, driver_ready):
+async def test_listen(client_session, url, driver_ready):
     """Test client listen."""
-    client = Client(url, client_session2)
+    client = Client(url, client_session)
 
     assert not client.driver
 
@@ -165,7 +143,6 @@ async def test_listen_disconnect_message_types(
     async with Client(url, client_session) as client:
         assert client.connected
         ws_message.type = message_type
-        # ws_client.closed = False
 
         # This should break out of the listen loop before handling the received message.
         # Otherwise there will be an error.
@@ -190,9 +167,7 @@ async def test_listen_invalid_message_data(
         await client.listen(driver_ready)
 
 
-async def test_listen_not_success(
-    client_session, url, result, driver_ready, await_other
-):
+async def test_listen_not_success(client_session, url, result, driver_ready):
     """Test receive result message with success False on listen."""
     result["success"] = False
     result["errorCode"] = "error_code"
@@ -201,36 +176,6 @@ async def test_listen_not_success(
 
     with pytest.raises(FailedCommand):
         await client.listen(driver_ready)
-        await await_other(asyncio.current_task())
-
-    assert client.connected
-
-
-async def test_listen_invalid_state(
-    client_session, url, result, driver_ready, await_other
-):
-    """Test missing driver state on listen."""
-    result["type"] = "event"
-    result["event"] = {
-        "source": "node",
-        "event": "value updated",
-        "nodeId": 52,
-        "args": {
-            "commandClassName": "Basic",
-            "commandClass": 32,
-            "endpoint": 0,
-            "property": "currentValue",
-            "newValue": 255,
-            "prevValue": 255,
-            "propertyName": "currentValue",
-        },
-    }
-    client = Client(url, client_session)
-    await client.connect()
-
-    with pytest.raises(InvalidState):
-        await client.listen(driver_ready)
-        await await_other(asyncio.current_task())
 
     assert client.connected
 
@@ -252,11 +197,7 @@ async def test_listen_event(
     await client.connect()
 
     assert client.connected
-    await client.listen(driver_ready)
-    await await_other(asyncio.current_task())
-    assert client.driver
 
-    result.clear()
     result["type"] = "event"
     result["event"] = {
         "source": "node",
@@ -273,18 +214,7 @@ async def test_listen_event(
         },
     }
 
-    ws_client.receive.reset_mock()
-    ws_client.closed = False
-
-    async def receive():
-        """Return a websocket message."""
-        ws_client.closed = True
-        return ws_message
-
-    ws_client.receive.side_effect = receive
-
     await client.listen(driver_ready)
-
     ws_client.receive.assert_awaited()
 
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -177,7 +177,7 @@ async def test_listen_not_success(client_session, url, result, driver_ready):
     with pytest.raises(FailedCommand):
         await client.listen(driver_ready)
 
-    assert client.connected
+    assert not client.connected
 
 
 async def test_listen_without_connect(client_session, url, driver_ready):

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -46,8 +46,8 @@ class Client:
 
     def __repr__(self) -> str:
         """Return the representation."""
-        conn_prefix = "" if self.connected else "not "
-        return f"{type(self).__name__}(ws_server_url={self.ws_server_url!r}, {conn_prefix}connected)"
+        prefix = "" if self.connected else "not "
+        return f"{type(self).__name__}(ws_server_url={self.ws_server_url!r}, {prefix}connected)"
 
     @property
     def connected(self) -> bool:

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -13,7 +13,6 @@ from .const import MIN_SERVER_VERSION
 from .event import Event
 from .exceptions import (
     CannotConnect,
-    ConnectionClosed,
     ConnectionFailed,
     FailedCommand,
     InvalidMessage,
@@ -39,7 +38,7 @@ class Client:
         self.aiohttp_session = aiohttp_session
         self.driver: Optional[Driver] = None
         # The WebSocket client
-        self.client: Optional[ClientWebSocketResponse] = None
+        self._client: Optional[ClientWebSocketResponse] = None
         # Current state of the connection
         self.state = STATE_DISCONNECTED
         # Version of the connected server
@@ -47,11 +46,13 @@ class Client:
         self._logger = logging.getLogger(__package__)
         self._loop = asyncio.get_running_loop()
         self._result_futures: Dict[str, asyncio.Future] = {}
-        self._start_listen_task: Optional[asyncio.Task] = None
+        self._shutdown_complete_event: Optional[asyncio.Event] = None
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"{type(self).__name__}(ws_server_url={self.ws_server_url!r})"
+        return (
+            f"{type(self).__name__}(ws_server_url={self.ws_server_url!r}, {self.state})"
+        )
 
     @property
     def connected(self) -> bool:
@@ -77,7 +78,7 @@ class Client:
         client = None
         self._logger.debug("Trying to connect")
         try:
-            self.client = client = await self.aiohttp_session.ws_connect(
+            self._client = client = await self.aiohttp_session.ws_connect(
                 self.ws_server_url,
                 heartbeat=55,
             )
@@ -107,80 +108,82 @@ class Client:
         if self.state != STATE_CONNECTED:
             raise InvalidState("Not connected when start listening")
 
-        self._start_listen_task = asyncio.create_task(self._start_listen(driver_ready))
+        start_listen_task = asyncio.create_task(self._start_listen(driver_ready))
 
-        assert self.client
+        assert self._client
 
-        while not self.client.closed:
+        try:
+            while not self._client.closed:
+                msg = await self._client.receive()
+
+                if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
+                    break
+
+                if msg.type == WSMsgType.ERROR:
+                    await self._client.close()
+                    raise ConnectionFailed()
+
+                if msg.type != WSMsgType.TEXT:
+                    raise InvalidMessage(f"Received non-Text message: {msg.type}")
+
+                try:
+                    if len(msg.data) > SIZE_PARSE_JSON_EXECUTOR:
+                        msg: dict = await self._loop.run_in_executor(None, msg.json)
+                    else:
+                        msg = msg.json()
+                except ValueError as err:
+                    raise InvalidMessage("Received invalid JSON.") from err
+
+                if self._logger.isEnabledFor(logging.DEBUG):
+                    self._logger.debug("Received message:\n%s\n", pprint.pformat(msg))
+
+                self._handle_incoming_message(msg)
+
+        finally:
+            self._logger.debug("Listen completed. Cleaning up")
+
+            for future in self._result_futures.values():
+                future.cancel()
+
+            start_listen_task.cancel()
             try:
-                msg = await self.client.receive()
+                await start_listen_task
             except asyncio.CancelledError:
-                break
+                pass
 
-            if msg.type in (WSMsgType.CLOSED, WSMsgType.CLOSING):
-                await self._close()
-                break
+            if not self._client.closed:
+                await self._client.close()
 
-            if msg.type == WSMsgType.CLOSE:
-                raise ConnectionClosed()
+            self.state = STATE_DISCONNECTED
 
-            if msg.type == WSMsgType.ERROR:
-                raise ConnectionFailed()
-
-            if msg.type != WSMsgType.TEXT:
-                raise InvalidMessage(f"Received non-Text message: {msg.type}")
-
-            try:
-                if len(msg.data) > SIZE_PARSE_JSON_EXECUTOR:
-                    msg = await self._loop.run_in_executor(None, msg.json)
-                else:
-                    msg = msg.json()
-            except ValueError as err:
-                raise InvalidMessage("Received invalid JSON.") from err
-
-            if self._logger.isEnabledFor(logging.DEBUG):
-                self._logger.debug("Received message:\n%s\n", pprint.pformat(msg))
-
-            msg_ = cast(dict, msg)
-
-            self._handle_incoming_message(msg_)
+            if self._shutdown_complete_event:
+                self._shutdown_complete_event.set()
 
     async def disconnect(self) -> None:
         """Disconnect the client."""
-        if self.client is not None:
-            await self._close()
-
-        self.state = STATE_DISCONNECTED
-
-    async def _close(self) -> None:
-        """Close the client connection."""
         self._logger.debug("Closing client connection")
-        assert self.client
-        await self.client.close()
-        if self._start_listen_task:
-            self._start_listen_task.cancel()
-            await self._start_listen_task
-        for future in self._result_futures.values():
-            future.cancel()
-        self.driver = None
+
+        if self._client is None or self._client.closed:
+            return
+
+        self._shutdown_complete_event = asyncio.Event()
+        await self._client.close()
+        await self._shutdown_complete_event.wait()
 
     async def _start_listen(self, driver_ready: asyncio.Event) -> None:
         """Send start_listening command to initialize the driver."""
-        try:
-            result = await self.async_send_command({"command": "start_listening"})
-        except asyncio.CancelledError:
-            return
+        result = await self.async_send_command({"command": "start_listening"})
 
         self.driver = cast(
             Driver,
             await self._loop.run_in_executor(None, Driver, self, result["state"]),
         )
+
         driver_ready.set()
 
         self._logger.info(
             "Z-Wave JS initialized. %s nodes", len(self.driver.controller.nodes)
         )
-        self._start_listen_task = None
 
     def _check_server_version(self, server_version: str) -> None:
         """Perform a basic check on the server version compatability."""
@@ -215,8 +218,12 @@ class Client:
             future.set_exception(FailedCommand(msg["messageId"], msg["errorCode"]))
             return
 
+        # Cannot happen but testing just in case.
         if self.driver is None:
-            raise InvalidState("Did not receive state as first message")
+            self._logger.error(
+                "Did not receive state as first message. Closing connection."
+            )
+            asyncio.create_task(self._client.close())
 
         if msg["type"] != "event":
             # Can't handle
@@ -241,10 +248,10 @@ class Client:
         if self._logger.isEnabledFor(logging.DEBUG):
             self._logger.debug("Publishing message:\n%s\n", pprint.pformat(message))
 
-        assert self.client
-        if "messageId" not in message:
-            message["messageId"] = uuid.uuid4().hex
-        await self.client.send_json(message)
+        assert self._client
+        assert "messageId" in message
+
+        await self._client.send_json(message)
 
     async def __aenter__(self) -> "Client":
         """Connect to the websocket."""

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -148,7 +148,6 @@ class Client:
                     break
 
                 if msg.type == WSMsgType.ERROR:
-                    await self._client.close()
                     raise ConnectionFailed()
 
                 if msg.type != WSMsgType.TEXT:
@@ -195,12 +194,7 @@ class Client:
 
         self._shutdown_complete_event = asyncio.Event()
         await self._client.close()
-
-        # Driver is set if we made it into "listen"
-        if self.driver is not None:
-            await self._shutdown_complete_event.wait()
-        else:
-            self.state = STATE_DISCONNECTED
+        await self._shutdown_complete_event.wait()
 
     def _handle_incoming_message(self, msg: dict) -> None:
         """Handle incoming message.

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -36,7 +36,6 @@ class Client:
         self.driver: Optional[Driver] = None
         # The WebSocket client
         self._client: Optional[ClientWebSocketResponse] = None
-        # Current state of the connection
         # Version of the connected server
         self.version: Optional[VersionInfo] = None
         self._logger = logging.getLogger(__package__)

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -25,14 +25,6 @@ class CannotConnect(TransportError):
         super().__init__(f"{error}", error)
 
 
-class ConnectionClosed(TransportError):
-    """Exception raised when the connection is closed by the server."""
-
-    def __init__(self) -> None:
-        """Initialize a connection closed error."""
-        super().__init__("Connection closed by server.")
-
-
 class ConnectionFailed(TransportError):
     """Exception raised when an established connection fails."""
 


### PR DESCRIPTION
This cleans up the `listen` command. When the listen phase ends for whatever reason (error, server closing down, disconnect requested), we clean it up right away as we don't allow the object to be used anymore. This way we're sure.

I got stuck with this PR on the tests. There are too many fixtures and it looks like everything is happening somewhere else. So putting this up as draft.

