### PR TITLE
Default to empty container for optional model attributes

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -308,7 +308,7 @@ async def test_get_association_groups(controller, uuid4, mock_command):
     assert result[1].multi_channel is True
     assert result[1].label == "Association Group 1"
     assert result[1].profile is None
-    assert result[1].issued_commands is None
+    assert result[1].issued_commands == {}
 
     assert result[2].max_nodes == 30
     assert result[2].is_lifeline is False

--- a/zwave_js_server/model/association.py
+++ b/zwave_js_server/model/association.py
@@ -1,6 +1,6 @@
 """Provide a model for the association."""
 from typing import Dict, List, Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -12,7 +12,7 @@ class AssociationGroup:
     multi_channel: bool
     label: str
     profile: Optional[int] = None
-    issued_commands: Optional[Dict[int, List[int]]] = None
+    issued_commands: Dict[int, List[int]] = field(default_factory=dict)
 
 
 @dataclass

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -118,9 +118,9 @@ class Controller(EventBase):
         return self.data.get("productId")
 
     @property
-    def supported_function_types(self) -> Optional[List[int]]:
+    def supported_function_types(self) -> List[int]:
         """Return supported_function_types."""
-        return self.data.get("supportedFunctionTypes")
+        return self.data.get("supportedFunctionTypes", [])
 
     @property
     def suc_node_id(self) -> Optional[int]:
@@ -230,7 +230,7 @@ class Controller(EventBase):
                 multi_channel=group["multiChannel"],
                 label=group["label"],
                 profile=group.get("profile"),
-                issued_commands=group.get("issuedCommands"),
+                issued_commands=group.get("issuedCommands", {}),
             )
         return groups
 

--- a/zwave_js_server/model/device_config.py
+++ b/zwave_js_server/model/device_config.py
@@ -56,14 +56,14 @@ class DeviceConfig:
         return self.data.get("devices", [])
 
     @property
-    def firmware_version(self) -> Optional[Dict[str, str]]:
+    def firmware_version(self) -> Dict[str, str]:
         """Return firmware version range this config is valid for."""
-        return self.data.get("firmwareVersion")
+        return self.data.get("firmwareVersion", {})
 
     @property
-    def associations(self) -> Optional[Dict[str, dict]]:
+    def associations(self) -> Dict[str, dict]:
         """Return association groups the device supports."""
-        return self.data.get("associations")
+        return self.data.get("associations", {})
 
     @property
     def supports_zwave_plus(self) -> Optional[bool]:
@@ -71,16 +71,16 @@ class DeviceConfig:
         return self.data.get("supportsZWavePlus")
 
     @property
-    def proprietary(self) -> Optional[dict]:
+    def proprietary(self) -> dict:
         """Return dictionary of settings for the proprietary CC."""
-        return self.data.get("proprietary")
+        return self.data.get("proprietary", {})
 
     @property
-    def param_information(self) -> Optional[Dict[str, dict]]:
+    def param_information(self) -> Dict[str, dict]:
         """Return dictionary of the configuration parameters the device supports."""
-        return self.data.get("paramInformation")
+        return self.data.get("paramInformation", {})
 
     @property
-    def compat(self) -> Optional[Dict[str, dict]]:
+    def compat(self) -> Dict[str, dict]:
         """Return compatibility flags."""
-        return self.data.get("compat")
+        return self.data.get("compat", {})

--- a/zwave_js_server/model/notification.py
+++ b/zwave_js_server/model/notification.py
@@ -4,7 +4,7 @@ Model for a Zwave Node's Notification Event.
 https://zwave-js.github.io/node-zwave-js/#/api/node?id=quotnotificationquot
 """
 
-from typing import Literal, TYPE_CHECKING, Any, Dict, Optional, TypedDict
+from typing import Literal, TYPE_CHECKING, Any, Dict, TypedDict
 
 if TYPE_CHECKING:
     from .node import Node
@@ -39,6 +39,6 @@ class Notification:
         return self.data["notificationLabel"]
 
     @property
-    def parameters(self) -> Optional[Dict[str, Any]]:
+    def parameters(self) -> Dict[str, Any]:
         """Return installer icon property."""
-        return self.data.get("parameters")
+        return self.data.get("parameters", {})

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -91,14 +91,14 @@ class ValueMetadata:
         return self.data.get("unit")
 
     @property
-    def states(self) -> Optional[dict]:
+    def states(self) -> dict:
         """Return (optional) states."""
-        return self.data.get("states")
+        return self.data.get("states", {})
 
     @property
-    def cc_specific(self) -> Optional[Dict[str, Any]]:
+    def cc_specific(self) -> Dict[str, Any]:
         """Return ccSpecific."""
-        return self.data.get("ccSpecific")
+        return self.data.get("ccSpecific", {})
 
 
 class Value:


### PR DESCRIPTION
- By defaulting to an empty container, iteration works by default.