### PR TITLE
Add configuration value tools and guard Node.async_set_value

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -39,6 +39,12 @@ def lock_schlage_be469_state_fixture():
     return json.loads(load_fixture("lock_schlage_be469_state.json"))
 
 
+@pytest.fixture(name="climate_radio_thermostat_ct100_plus_state", scope="session")
+def climate_radio_thermostat_ct100_plus_state():
+    """Load the radio thermostat node state fixture data."""
+    return json.loads(load_fixture("climate_radio_thermostat_ct100_plus_state.json"))
+
+
 @pytest.fixture(name="client_session")
 def client_session_fixture(ws_client):
     """Mock an aiohttp client session."""
@@ -214,6 +220,16 @@ def node_fixture(driver, multisensor_6_state):
 def lock_schlage_be469_fixture(driver, lock_schlage_be469_state):
     """Mock a schlage lock node."""
     node = Node(driver.client, lock_schlage_be469_state)
+    driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="climate_radio_thermostat_ct100_plus")
+def climate_radio_thermostat_ct100_plus_fixture(
+    driver, climate_radio_thermostat_ct100_plus_state
+):
+    """Mock a radio thermostat node."""
+    node = Node(driver.client, climate_radio_thermostat_ct100_plus_state)
     driver.controller.nodes[node.node_id] = node
     return node
 

--- a/test/fixtures/climate_radio_thermostat_ct100_plus_state.json
+++ b/test/fixtures/climate_radio_thermostat_ct100_plus_state.json
@@ -1,0 +1,693 @@
+{
+  "nodeId": 13,
+  "index": 0,
+  "installerIcon": 4608,
+  "userIcon": 4608,
+  "status": 4,
+  "ready": true,
+  "deviceClass": {
+    "basic": "Static Controller",
+    "generic": "Thermostat",
+    "specific": "Thermostat General V2",
+    "mandatorySupportedCCs": [
+      "Basic",
+      "Manufacturer Specific",
+      "Thermostat Mode",
+      "Thermostat Setpoint",
+      "Version"
+    ],
+    "mandatoryControlCCs": []
+  },
+  "isListening": true,
+  "isFrequentListening": false,
+  "isRouting": true,
+  "maxBaudRate": 40000,
+  "isSecure": false,
+  "version": 4,
+  "isBeaming": true,
+  "manufacturerId": 152,
+  "productId": 256,
+  "productType": 25602,
+  "firmwareVersion": "10.7",
+  "zwavePlusVersion": 1,
+  "nodeType": 0,
+  "roleType": 5,
+  "deviceConfig": {
+    "manufacturerId": 152,
+    "manufacturer": "Radio Thermostat Company of America (RTC)",
+    "label": "CT100 Plus",
+    "description": "Z-Wave Thermostat",
+    "devices": [{ "productType": "0x6402", "productId": "0x0100" }],
+    "firmwareVersion": { "min": "0.0", "max": "255.255" },
+    "paramInformation": { "_map": {} }
+  },
+  "label": "CT100 Plus",
+  "neighbors": [1, 2, 3, 4, 20],
+  "endpointCountIsDynamic": false,
+  "endpointsHaveIdenticalCapabilities": false,
+  "individualEndpointCount": 2,
+  "aggregatedEndpointCount": 0,
+  "interviewAttempts": 1,
+  "endpoints": [
+    {
+      "nodeId": 13,
+      "index": 0,
+      "installerIcon": 4608,
+      "userIcon": 4608
+    },
+    {
+      "nodeId": 13,
+      "index": 1,
+      "installerIcon": 4608,
+      "userIcon": 4608
+    },
+    { "nodeId": 13, "index": 2 }
+  ],
+  "values": [
+    {
+      "commandClassName": "Manufacturer Specific",
+      "commandClass": 114,
+      "endpoint": 0,
+      "property": "manufacturerId",
+      "propertyName": "manufacturerId",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 65535,
+        "label": "Manufacturer ID"
+      },
+      "value": 152
+    },
+    {
+      "commandClassName": "Manufacturer Specific",
+      "commandClass": 114,
+      "endpoint": 0,
+      "property": "productType",
+      "propertyName": "productType",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 65535,
+        "label": "Product type"
+      },
+      "value": 25602
+    },
+    {
+      "commandClassName": "Manufacturer Specific",
+      "commandClass": 114,
+      "endpoint": 0,
+      "property": "productId",
+      "propertyName": "productId",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 65535,
+        "label": "Product ID"
+      },
+      "value": 256
+    },
+    {
+      "commandClassName": "Version",
+      "commandClass": 134,
+      "endpoint": 0,
+      "property": "libraryType",
+      "propertyName": "libraryType",
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Library type"
+      },
+      "value": 3
+    },
+    {
+      "commandClassName": "Version",
+      "commandClass": 134,
+      "endpoint": 0,
+      "property": "protocolVersion",
+      "propertyName": "protocolVersion",
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol version"
+      },
+      "value": "4.24"
+    },
+    {
+      "commandClassName": "Version",
+      "commandClass": 134,
+      "endpoint": 0,
+      "property": "firmwareVersions",
+      "propertyName": "firmwareVersions",
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip firmware versions"
+      },
+      "value": ["10.7"]
+    },
+    {
+      "commandClassName": "Version",
+      "commandClass": 134,
+      "endpoint": 0,
+      "property": "hardwareVersion",
+      "propertyName": "hardwareVersion",
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip hardware version"
+      }
+    },
+    {
+      "commandClassName": "Indicator",
+      "commandClass": 135,
+      "endpoint": 0,
+      "property": "value",
+      "propertyName": "value",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "min": 0,
+        "max": 255,
+        "label": "Indicator value",
+        "ccSpecific": { "indicatorId": 0 }
+      },
+      "value": 0
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 1,
+      "propertyName": "Temperature Reporting Threshold",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 4,
+        "default": 2,
+        "format": 0,
+        "allowManualEntry": false,
+        "states": {
+          "0": "Disabled",
+          "1": "0.5° F",
+          "2": "1.0° F",
+          "3": "1.5° F",
+          "4": "2.0° F"
+        },
+        "label": "Temperature Reporting Threshold",
+        "description": "Reporting threshold for changes in the ambient temperature",
+        "isFromConfig": true
+      },
+      "value": 1
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 2,
+      "propertyName": "HVAC Settings",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "valueSize": 4,
+        "min": 0,
+        "max": 0,
+        "default": 0,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "HVAC Settings",
+        "description": "Configured HVAC settings",
+        "isFromConfig": true
+      },
+      "value": 17891329
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 4,
+      "propertyName": "Power Status",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "valueSize": 1,
+        "min": 0,
+        "max": 0,
+        "default": 0,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Power Status",
+        "description": "C-Wire / Battery Status",
+        "isFromConfig": true
+      },
+      "value": 1
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 7,
+      "propertyName": "Thermostat Swing Temperature",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 1,
+        "max": 8,
+        "default": 2,
+        "format": 0,
+        "allowManualEntry": false,
+        "states": {
+          "1": "0.5° F",
+          "2": "1.0° F",
+          "3": "1.5° F",
+          "4": "2.0° F",
+          "5": "2.5° F",
+          "6": "3.0° F",
+          "7": "3.5° F",
+          "8": "4.0° F"
+        },
+        "label": "Thermostat Swing Temperature",
+        "description": "Variance allowed from setpoint to engage HVAC",
+        "isFromConfig": true
+      },
+      "value": 1
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 8,
+      "propertyName": "Thermostat Diff Temperature",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 4,
+        "max": 12,
+        "default": 4,
+        "format": 0,
+        "allowManualEntry": false,
+        "states": { "4": "2.0° F", "8": "4.0° F", "12": "6.0° F" },
+        "label": "Thermostat Diff Temperature",
+        "description": "Configures additional stages",
+        "isFromConfig": true
+      },
+      "value": 1028
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 9,
+      "propertyName": "Thermostat Recovery Mode",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 1,
+        "max": 2,
+        "default": 2,
+        "format": 0,
+        "allowManualEntry": false,
+        "states": {
+          "1": "Fast recovery mode",
+          "2": "Economy recovery mode"
+        },
+        "label": "Thermostat Recovery Mode",
+        "description": "Fast or Economy recovery mode",
+        "isFromConfig": true
+      },
+      "value": 2
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 10,
+      "propertyName": "Temperature Reporting Filter",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 4,
+        "min": 0,
+        "max": 124,
+        "default": 124,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Temperature Reporting Filter",
+        "description": "Upper/Lower bounds for thermostat temperature reporting",
+        "isFromConfig": true
+      },
+      "value": 0
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 11,
+      "propertyName": "Simple UI Mode",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 1,
+        "default": 1,
+        "format": 0,
+        "allowManualEntry": false,
+        "states": {
+          "0": "Normal mode enabled",
+          "1": "Simple mode enabled"
+        },
+        "label": "Simple UI Mode",
+        "description": "Simple mode enable/disable",
+        "isFromConfig": true
+      },
+      "value": 1
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 12,
+      "propertyName": "Multicast",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 1,
+        "default": 0,
+        "format": 0,
+        "allowManualEntry": false,
+        "states": {
+          "0": "Multicast disabled",
+          "1": "Multicast enabled"
+        },
+        "label": "Multicast",
+        "description": "Enable or disables Multicast",
+        "isFromConfig": true
+      },
+      "value": 0
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 3,
+      "propertyName": "Utility Lock Enable/Disable",
+      "metadata": {
+        "type": "number",
+        "readable": false,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 255,
+        "default": 0,
+        "format": 1,
+        "allowManualEntry": false,
+        "states": {
+          "0": "Utility lock disabled",
+          "1": "Utility lock enabled"
+        },
+        "label": "Utility Lock Enable/Disable",
+        "description": "Prevents setpoint changes at thermostat",
+        "isFromConfig": true
+      }
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 5,
+      "propertyName": "Humidity Reporting Threshold",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 255,
+        "default": 0,
+        "format": 1,
+        "allowManualEntry": false,
+        "states": {
+          "0": "Disabled",
+          "1": "3% RH",
+          "2": "5% RH",
+          "3": "10% RH"
+        },
+        "label": "Humidity Reporting Threshold",
+        "description": "Reporting threshold for changes in the relative humidity",
+        "isFromConfig": true
+      }
+    },
+    {
+      "commandClassName": "Configuration",
+      "commandClass": 112,
+      "endpoint": 0,
+      "property": 6,
+      "propertyName": "Auxiliary/Emergency",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 255,
+        "default": 0,
+        "format": 1,
+        "allowManualEntry": false,
+        "states": {
+          "0": "Auxiliary/Emergency heat disabled",
+          "1": "Auxiliary/Emergency heat enabled"
+        },
+        "label": "Auxiliary/Emergency",
+        "description": "Enables or disables auxiliary / emergency heating",
+        "isFromConfig": true
+      }
+    },
+    {
+      "commandClassName": "Battery",
+      "commandClass": 128,
+      "endpoint": 0,
+      "property": "level",
+      "propertyName": "level",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 100,
+        "unit": "%",
+        "label": "Battery level"
+      },
+      "value": 100
+    },
+    {
+      "commandClassName": "Battery",
+      "commandClass": 128,
+      "endpoint": 0,
+      "property": "isLow",
+      "propertyName": "isLow",
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Low battery level"
+      },
+      "value": false
+    },
+    {
+      "commandClassName": "Indicator",
+      "commandClass": 135,
+      "endpoint": 1,
+      "property": "value",
+      "propertyName": "value",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "min": 0,
+        "max": 255,
+        "label": "Indicator value",
+        "ccSpecific": { "indicatorId": 0 }
+      },
+      "value": 0
+    },
+    {
+      "commandClassName": "Multilevel Sensor",
+      "commandClass": 49,
+      "endpoint": 1,
+      "property": "Air temperature",
+      "propertyName": "Air temperature",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "unit": "°F",
+        "label": "Air temperature",
+        "ccSpecific": { "sensorType": 1, "scale": 1 }
+      },
+      "value": 72
+    },
+    {
+      "commandClassName": "Multilevel Sensor",
+      "commandClass": 49,
+      "endpoint": 1,
+      "property": "Humidity",
+      "propertyName": "Humidity",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "unit": "%",
+        "label": "Humidity",
+        "ccSpecific": { "sensorType": 5, "scale": 0 }
+      },
+      "value": 30
+    },
+    {
+      "commandClassName": "Thermostat Mode",
+      "commandClass": 64,
+      "endpoint": 1,
+      "property": "mode",
+      "propertyName": "mode",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "min": 0,
+        "max": 31,
+        "label": "Thermostat mode",
+        "states": { "0": "Off", "1": "Heat", "2": "Cool", "3": "Auto" }
+      },
+      "value": 1
+    },
+    {
+      "commandClassName": "Thermostat Mode",
+      "commandClass": 64,
+      "endpoint": 1,
+      "property": "manufacturerData",
+      "propertyName": "manufacturerData",
+      "metadata": { "type": "any", "readable": true, "writeable": true }
+    },
+    {
+      "commandClassName": "Thermostat Operating State",
+      "commandClass": 66,
+      "endpoint": 1,
+      "property": "state",
+      "propertyName": "state",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 255,
+        "label": "Operating state",
+        "states": {
+          "0": "Idle",
+          "1": "Heating",
+          "2": "Cooling",
+          "3": "Fan Only",
+          "4": "Pending Heat",
+          "5": "Pending Cool",
+          "6": "Vent/Economizer",
+          "7": "Aux Heating",
+          "8": "2nd Stage Heating",
+          "9": "2nd Stage Cooling",
+          "10": "2nd Stage Aux Heat",
+          "11": "3rd Stage Aux Heat"
+        }
+      },
+      "value": 0
+    },
+    {
+      "commandClassName": "Thermostat Setpoint",
+      "commandClass": 67,
+      "endpoint": 1,
+      "property": "setpoint",
+      "propertyKey": 1,
+      "propertyName": "setpoint",
+      "propertyKeyName": "Heating",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "unit": "°F",
+        "ccSpecific": { "setpointType": 1 }
+      },
+      "value": 72
+    },
+    {
+      "commandClassName": "Thermostat Setpoint",
+      "commandClass": 67,
+      "endpoint": 1,
+      "property": "setpoint",
+      "propertyKey": 2,
+      "propertyName": "setpoint",
+      "propertyKeyName": "Cooling",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "unit": "°F",
+        "ccSpecific": { "setpointType": 2 }
+      },
+      "value": 73
+    },
+    {
+      "commandClassName": "Battery",
+      "commandClass": 128,
+      "endpoint": 1,
+      "property": "level",
+      "propertyName": "level",
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 100,
+        "unit": "%",
+        "label": "Battery level"
+      },
+      "value": 100
+    },
+    {
+      "commandClassName": "Battery",
+      "commandClass": 128,
+      "endpoint": 1,
+      "property": "isLow",
+      "propertyName": "isLow",
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Low battery level"
+      },
+      "value": false
+    }
+  ]
+}

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1,6 +1,11 @@
 """Test the node model."""
 import json
+import logging
 
+import pytest
+
+from zwave_js_server.model.value import ConfigurationValue
+from zwave_js_server.const import CommandClass
 from zwave_js_server.model import node as node_pkg
 from zwave_js_server.event import Event
 
@@ -28,6 +33,8 @@ DEVICE_CONFIG_FIXTURE = {
     "associations": {},
     "param_information": {"_map": {}},
 }
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def test_from_state():
@@ -60,6 +67,22 @@ def test_from_state():
     assert node.interview_attempts == 1
     assert len(node.endpoints) == 1
     assert node.endpoints[0].index == 0
+
+
+async def test_command_class_values(climate_radio_thermostat_ct100_plus):
+    """Test node methods to get command class values."""
+    node = climate_radio_thermostat_ct100_plus
+    assert node.node_id == 13
+    switch_values = node.get_command_class_values(CommandClass.SENSOR_MULTILEVEL)
+    assert len(switch_values) == 2
+    config_values = node.get_configuration_values()
+    assert len(config_values) == 12
+
+    for value in config_values.values():
+        assert isinstance(value, ConfigurationValue)
+
+    with pytest.raises(TypeError):
+        await node.async_set_value("13-112-00-2-00", 1)
 
 
 async def test_set_value(node, uuid4, mock_command):

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1,6 +1,5 @@
 """Test the node model."""
 import json
-import logging
 
 import pytest
 
@@ -33,8 +32,6 @@ DEVICE_CONFIG_FIXTURE = {
     "associations": {},
     "param_information": {"_map": {}},
 }
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def test_from_state():

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -5,6 +5,7 @@ import pytest
 
 from zwave_js_server.model.value import ConfigurationValue
 from zwave_js_server.const import CommandClass
+from zwave_js_server.exceptions import UnwriteableValue
 from zwave_js_server.model import node as node_pkg
 from zwave_js_server.event import Event
 
@@ -78,7 +79,7 @@ async def test_command_class_values(climate_radio_thermostat_ct100_plus):
     for value in config_values.values():
         assert isinstance(value, ConfigurationValue)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(UnwriteableValue):
         await node.async_set_value("13-112-00-2-00", 1)
 
 

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -5,7 +5,7 @@ import pytest
 
 from zwave_js_server.model.value import ConfigurationValue
 from zwave_js_server.const import CommandClass
-from zwave_js_server.exceptions import UnwriteableValue
+from zwave_js_server.exceptions import InvalidNewValue, UnwriteableValue
 from zwave_js_server.model import node as node_pkg
 from zwave_js_server.event import Event
 
@@ -81,6 +81,12 @@ async def test_command_class_values(climate_radio_thermostat_ct100_plus):
 
     with pytest.raises(UnwriteableValue):
         await node.async_set_value("13-112-00-2-00", 1)
+
+    with pytest.raises(InvalidNewValue):
+        await node.async_set_value("13-112-00-1-00", 5)
+
+    with pytest.raises(InvalidNewValue):
+        await node.async_set_value("13-112-00-10-00", 200)
 
 
 async def test_set_value(node, uuid4, mock_command):

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -281,6 +281,6 @@ THERMOSTAT_MODE_SETPOINT_MAP: Dict[int, List[ThermostatSetpointType]] = {
 class ConfigurationValueType(Enum):
     """Enum for configuration value types."""
 
-    ENUM = "enum"
+    ENUMERATED = "enumerated"
     RANGE = "range"
     UNDEFINED = "undefined"

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -276,3 +276,11 @@ THERMOSTAT_MODE_SETPOINT_MAP: Dict[int, List[ThermostatSetpointType]] = {
     ],
     ThermostatMode.FULL_POWER: [ThermostatSetpointType.FULL_POWER],
 }
+
+
+class ConfigurationValueType(Enum):
+    """Enum for configuration value types."""
+
+    ENUM = "enum"
+    RANGE = "range"
+    UNDEFINED = "undefined"

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -68,3 +68,7 @@ class FailedCommand(BaseZwaveJSServerError):
 
 class UnwriteableValue(BaseZwaveJSServerError):
     """Exception raised when trying to change a read only Value."""
+
+
+class InvalidNewValue(BaseZwaveJSServerError):
+    """Exception raised when target new value is invalid based on Value metadata."""

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -64,3 +64,7 @@ class FailedCommand(BaseZwaveJSServerError):
         super().__init__(f"Command failed: {error_code}")
         self.message_id = message_id
         self.error_code = error_code
+
+
+class UnwriteableValue(BaseZwaveJSServerError):
+    """Exception raised when trying to change a read only Value."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -288,19 +288,19 @@ class Node(EventBase):
                     "Configuration values of undefined type can't be set"
                 )
 
-            max = val.metadata.max
-            min = val.metadata.min
+            max_ = val.metadata.max
+            min_ = val.metadata.min
             if val.type == ConfigurationValueType.RANGE and (
-                (max is not None and new_value > max)
-                or (min is not None and new_value < min)
+                (max_ is not None and new_value > max_)
+                or (min_ is not None and new_value < min_)
             ):
                 bounds = []
-                if min is not None:
-                    bounds.append(f"Min: {min}")
-                if max is not None:
-                    bounds.append(f"Max: {max}")
+                if min_ is not None:
+                    bounds.append(f"Min: {min_}")
+                if max_ is not None:
+                    bounds.append(f"Max: {max_}")
                 raise InvalidNewValue(
-                    f"Must provide a value within the target range ({", ".join(bounds)})"
+                    f"Must provide a value within the target range ({', '.join(bounds)})"
                 )
 
             if (
@@ -308,7 +308,8 @@ class Node(EventBase):
                 and str(new_value) not in val.metadata.states
             ):
                 raise InvalidNewValue(
-                    f"Must provide a value that represents a valid state ({json.dumps(val.metadata.states)})"
+                    "Must provide a value that represents a valid state "
+                    f"({json.dumps(val.metadata.states)})"
                 )
 
         # the value object needs to be send to the server

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -305,7 +305,7 @@ class Node(EventBase):
 
             if (
                 val.type == ConfigurationValueType.ENUMERATED
-                and str(new_value) != val.metadata.states
+                and str(new_value) not in val.metadata.states
             ):
                 raise InvalidNewValue(
                     f"Must provide a value that represents a valid state ({json.dumps(val.metadata.states)})"

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -242,7 +242,7 @@ class Node(EventBase):
 
     def get_command_class_values(
         self, command_class: CommandClass, endpoint: int = None
-    ) -> Dict[str, Value]:
+    ) -> Dict[str, Union[ConfigurationValue, Value]]:
         """Return all values for a given command class."""
         return {
             value_id: value

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -69,7 +69,7 @@ class Node(EventBase):
         super().__init__()
         self.client = client
         self.data = data
-        self.values = {}
+        self.values: Dict[str, Union[Value, ConfigurationValue]] = {}
         for val in data["values"]:
             value_id = get_value_id(self, val)
             if val["commandClass"] == CommandClass.CONFIGURATION:
@@ -256,8 +256,11 @@ class Node(EventBase):
         self, endpoint: int = None
     ) -> Dict[str, ConfigurationValue]:
         """Return all configuration values for a node."""
-        return self.get_command_class_values(
-            CommandClass.CONFIGURATION, endpoint=endpoint
+        return cast(
+            Dict[str, ConfigurationValue],
+            self.get_command_class_values(
+                CommandClass.CONFIGURATION, endpoint=endpoint
+            ),
         )
 
     def receive_event(self, event: Event) -> None:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -277,7 +277,7 @@ class Node(EventBase):
         if not isinstance(val, Value):
             val = self.values[val]
 
-        if not val.metadata.writeable:
+        if val.metadata.writeable is False:
             raise UnwriteableValue
 
         # Raise an exception if we are setting an invalid value on a configuration value

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -2,6 +2,7 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
 from zwave_js_server.const import CommandClass, ConfigurationValueType
 
+from ..exceptions import UnwriteableValue
 from ..event import Event, EventBase
 from .device_class import DeviceClass, DeviceClassDataType
 from .device_config import DeviceConfig, DeviceConfigDataType
@@ -273,7 +274,7 @@ class Node(EventBase):
             val = self.values[val]
 
         if not val.metadata.writeable:
-            raise TypeError("This configuration value is read only")
+            raise UnwriteableValue
 
         if (
             isinstance(val, ConfigurationValue)

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -242,7 +242,7 @@ class Node(EventBase):
 
     def get_command_class_values(
         self, command_class: CommandClass, endpoint: int = None
-    ) -> Optional[Dict[str, Value]]:
+    ) -> Dict[str, Value]:
         """Return all values for a given command class."""
         return {
             value_id: value

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -294,13 +294,13 @@ class Node(EventBase):
                 (max is not None and new_value > max)
                 or (min is not None and new_value < min)
             ):
-                msg = ""
+                bounds = []
                 if min is not None:
-                    msg += f"Min: {min}, "
+                    bounds.append(f"Min: {min}")
                 if max is not None:
-                    msg += f"Max: {max}"
+                    bounds.append(f"Max: {max}")
                 raise InvalidNewValue(
-                    f"Must provide a value within the target range ({msg.strip()})"
+                    f"Must provide a value within the target range ({", ".join(bounds)})"
                 )
 
             if (

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -253,7 +253,7 @@ class Node(EventBase):
 
     def get_configuration_values(
         self, endpoint: int = None
-    ) -> Optional[Dict[str, ConfigurationValue]]:
+    ) -> Dict[str, ConfigurationValue]:
         """Return all configuration values for a node."""
         return self.get_command_class_values(
             CommandClass.CONFIGURATION, endpoint=endpoint

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -1,6 +1,7 @@
 """Provide a model for the Z-Wave JS value."""
 from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union
 
+from ..const import ConfigurationValueType
 from ..event import Event
 
 if TYPE_CHECKING:
@@ -195,3 +196,20 @@ class ValueNotification(Value):
     """
 
     # format is the same as a Value message, subclassed for easier identifying and future use
+
+
+class ConfigurationValue(Value):
+    """Model for a Configuration Value."""
+
+    @property
+    def type(self) -> ConfigurationValueType:
+        """Return configuration value type."""
+        if self.metadata.type == "number":
+            if self.metadata.states:
+                return ConfigurationValueType.ENUM
+            elif (
+                self.metadata.max is not None or self.metadata.min is not None
+            ) and not self.metadata.max == self.metadata.min == 0:
+                return ConfigurationValueType.RANGE
+
+        return ConfigurationValueType.UNDEFINED

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -206,8 +206,8 @@ class ConfigurationValue(Value):
         """Return configuration value type."""
         if self.metadata.type == "number":
             if self.metadata.states:
-                return ConfigurationValueType.ENUM
-            elif (
+                return ConfigurationValueType.ENUMERATED
+            if (
                 self.metadata.max is not None or self.metadata.min is not None
             ) and not self.metadata.max == self.metadata.min == 0:
                 return ConfigurationValueType.RANGE

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -1,4 +1,4 @@
-"""Utility functions for OpenZWave locks."""
+"""Utility functions for Z-Wave JS locks."""
 from typing import Dict, List, Optional, Union
 
 from ..const import (


### PR DESCRIPTION
A couple of changes in this PR:

- There's a new `Value` subclass called `ConfigurationValue` which provides additional metadata about a configuration value.
- Added node helper methods to get values for a specific command class and to get configuration values
- Added guard logic to `async_set_value` for values that aren't writeable and for configuration values that are unbound in the metadata. Per AlCalzone, for unbound configuration values, we need to use the Configuration CC API directly instead of `set_value` which the library doesn't support yet

I'm not sure if this is the best architectural approach to handle configuration values and am open to input there