### PR TITLE
Parse non-ASCII lock usercodes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 aiohttp==3.7.3
 awesomeversion==21.2.2
-voluptuous>=0.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp==3.7.3
 awesomeversion==21.2.2
+voluptuous>=0.12.1

--- a/test/fixtures/lock_schlage_be469_state.json
+++ b/test/fixtures/lock_schlage_be469_state.json
@@ -391,7 +391,7 @@
                     "2": "Disabled"
                 }
             },
-            "value": 0
+            "value": 1
         },
         {
             "commandClassName": "User Code",
@@ -409,7 +409,7 @@
                 "maxLength": 10,
                 "label": "User Code (4)"
             },
-            "value": ""
+            "value": "{ \"type\": \"Buffer\", \"data\": [55, 48, 51, 48, 10, 13] }"
         },
         {
             "commandClassName": "User Code",

--- a/test/util/const.py
+++ b/test/util/const.py
@@ -23,9 +23,9 @@ CODE_SLOTS = [
     },
     {
         ATTR_CODE_SLOT: 4,
-        ATTR_IN_USE: False,
+        ATTR_IN_USE: True,
         ATTR_NAME: "User Code (4)",
-        ATTR_USERCODE: None,
+        ATTR_USERCODE: "7030\n\r",
     },
     {
         ATTR_CODE_SLOT: 5,

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -66,6 +66,10 @@ class FailedCommand(BaseZwaveJSServerError):
         self.error_code = error_code
 
 
+class UnparseableValue(BaseZwaveJSServerError):
+    """Exception raised when a value can't be parsed."""
+
+
 class UnwriteableValue(BaseZwaveJSServerError):
     """Exception raised when trying to change a read only Value."""
 

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -65,7 +65,9 @@ def _get_code_slots(
         if include_usercode:
             if not value.value:
                 slot[ATTR_USERCODE] = None
-            elif value.value[0] == "{":
+            elif value.value[0] != "{":
+                slot[ATTR_USERCODE] = value.value
+            else:
                 try:
                     parsed_val = json.loads(value.value)
                     if (
@@ -79,8 +81,6 @@ def _get_code_slots(
                     raise UnparseableValue(
                         f"Unparseable value for code slot {code_slot}: {value.value}"
                     )
-            else:
-                slot[ATTR_USERCODE] = value.value
 
         slots.append(slot)
         code_slot += 1

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -75,12 +75,12 @@ def _get_code_slots(
                         or parsed_val["type"] != "Buffer"
                         or "data" not in parsed_val
                     ):
-                        raise ValueError
+                        raise ValueError("JSON string does not match expected schema")
                     slot[ATTR_USERCODE] = "".join([chr(x) for x in parsed_val["data"]])
-                except (ValueError, json.decoder.JSONDecodeError):
+                except (ValueError, json.decoder.JSONDecodeError) as err:
                     raise UnparseableValue(
                         f"Unparseable value for code slot {code_slot}: {value.value}"
-                    )
+                    ) from err
 
         slots.append(slot)
         code_slot += 1

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -1,5 +1,4 @@
 """Utility functions for Z-Wave JS locks."""
-import json
 from typing import Dict, List, Optional, Union
 
 from ..const import (
@@ -12,7 +11,7 @@ from ..const import (
     CodeSlotStatus,
     CommandClass,
 )
-from ..exceptions import NotFoundError, UnparseableValue
+from ..exceptions import NotFoundError
 from ..model.node import Node
 from ..model.value import get_value_id, Value
 
@@ -63,24 +62,7 @@ def _get_code_slots(
             ATTR_IN_USE: status_value.value == CodeSlotStatus.ENABLED,
         }
         if include_usercode:
-            if not value.value:
-                slot[ATTR_USERCODE] = None
-            elif value.value[0] != "{":
-                slot[ATTR_USERCODE] = value.value
-            else:
-                try:
-                    parsed_val = json.loads(value.value)
-                    if (
-                        "type" not in parsed_val
-                        or parsed_val["type"] != "Buffer"
-                        or "data" not in parsed_val
-                    ):
-                        raise ValueError("JSON string does not match expected schema")
-                    slot[ATTR_USERCODE] = "".join([chr(x) for x in parsed_val["data"]])
-                except ValueError as err:
-                    raise UnparseableValue(
-                        f"Unparseable value for code slot {code_slot}: {value.value}"
-                    ) from err
+            slot[ATTR_USERCODE] = value.value if value.value else None
 
         slots.append(slot)
         code_slot += 1

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -77,7 +77,7 @@ def _get_code_slots(
                     ):
                         raise ValueError("JSON string does not match expected schema")
                     slot[ATTR_USERCODE] = "".join([chr(x) for x in parsed_val["data"]])
-                except (ValueError, json.decoder.JSONDecodeError) as err:
+                except ValueError as err:
                     raise UnparseableValue(
                         f"Unparseable value for code slot {code_slot}: {value.value}"
                     ) from err


### PR DESCRIPTION
Per a conversation with AlCalzone in Discord, usercodes will sometimes be returned as non-ASCII buffers. Per this conversation: https://discord.com/channels/330944238910963714/800356888827002880/807919548081766400 we should handle parsing in the case where such a buffer gets returned.

All three statements in the try block can raise an Exception which is why they are all in the try block.