### PR TITLE
Handle TypeError on connect

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -31,7 +31,11 @@ async def test_connect_disconnect(client_session, url):
 
 @pytest.mark.parametrize(
     "error",
-    [ClientError, WSServerHandshakeError(Mock(RequestInfo), (Mock(ClientResponse),))],
+    [
+        ClientError,
+        WSServerHandshakeError(Mock(RequestInfo), (Mock(ClientResponse),)),
+        TypeError,
+    ],
 )
 async def test_cannot_connect(client_session, url, error):
     """Test cannot connect."""

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -31,11 +31,7 @@ async def test_connect_disconnect(client_session, url):
 
 @pytest.mark.parametrize(
     "error",
-    [
-        ClientError,
-        WSServerHandshakeError(Mock(RequestInfo), (Mock(ClientResponse),)),
-        TypeError,
-    ],
+    [ClientError, WSServerHandshakeError(Mock(RequestInfo), (Mock(ClientResponse),))],
 )
 async def test_cannot_connect(client_session, url, error):
     """Test cannot connect."""

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -65,4 +65,4 @@ def test_connect(client_session, url, ws_client):
         main()
 
     assert sys_exit.value.code == 0
-    assert ws_client.receive.call_count == 1
+    assert ws_client.receive.call_count == 2

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -83,7 +83,6 @@ class Client:
         except (
             client_exceptions.WSServerHandshakeError,
             client_exceptions.ClientError,
-            TypeError,  # TypeError if the client receives non string
         ) as err:
             raise CannotConnect(err) from err
 

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -83,6 +83,7 @@ class Client:
         except (
             client_exceptions.WSServerHandshakeError,
             client_exceptions.ClientError,
+            TypeError,  # TypeError if the client receives non string
         ) as err:
             raise CannotConnect(err) from err
 

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -187,7 +187,7 @@ class Client:
         await self._shutdown_complete_event.wait()
 
     async def _receive_json_or_raise(self) -> dict:
-        """Receive json or raise InvalidMessage."""
+        """Receive json or raise."""
         assert self._client
         msg = await self._client.receive()
 

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -17,6 +17,10 @@ class TransportError(BaseZwaveJSServerError):
         self.error = error
 
 
+class ConnectionClosed(TransportError):
+    """Exception raised when the connection is closed."""
+
+
 class CannotConnect(TransportError):
     """Exception raised when failed to connect the client."""
 
@@ -41,7 +45,7 @@ class NotFoundError(BaseZwaveJSServerError):
 
 
 class NotConnected(BaseZwaveJSServerError):
-    """Exception raised when trying to handle unknown handler."""
+    """Exception raised when not connected to client."""
 
 
 class InvalidState(BaseZwaveJSServerError):


### PR DESCRIPTION
- If we connect before the server is ready, we may get a TypeError when trying to parse the websocket message data as json.
- Refactor the websocket message reception to always use `client.receive` instead of `client.receive_json`. This way we make sure to handle messages with incorrect type.

fixes https://github.com/home-assistant/core/issues/46180