### PR TITLE
Rename type attribute for configuration values

### DIFF
--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -282,7 +282,7 @@ class Node(EventBase):
 
         # Raise an exception if we are setting an invalid value on a configuration value
         if isinstance(val, ConfigurationValue):
-            if val.type == ConfigurationValueType.UNDEFINED:
+            if val.configuration_value_type == ConfigurationValueType.UNDEFINED:
                 # We need to use the Configuration CC API to set the value for this type
                 raise NotImplementedError(
                     "Configuration values of undefined type can't be set"
@@ -290,7 +290,7 @@ class Node(EventBase):
 
             max_ = val.metadata.max
             min_ = val.metadata.min
-            if val.type == ConfigurationValueType.RANGE and (
+            if val.configuration_value_type == ConfigurationValueType.RANGE and (
                 (max_ is not None and new_value > max_)
                 or (min_ is not None and new_value < min_)
             ):
@@ -304,7 +304,7 @@ class Node(EventBase):
                 )
 
             if (
-                val.type == ConfigurationValueType.ENUMERATED
+                val.configuration_value_type == ConfigurationValueType.ENUMERATED
                 and str(new_value) not in val.metadata.states
             ):
                 raise InvalidNewValue(

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -218,7 +218,7 @@ class ConfigurationValue(Value):
     """Model for a Configuration Value."""
 
     @property
-    def type(self) -> ConfigurationValueType:
+    def configuration_value_type(self) -> ConfigurationValueType:
         """Return configuration value type."""
         if self.metadata.type == "number":
             if self.metadata.states:


### PR DESCRIPTION
In reviewing https://github.com/home-assistant/core/pull/46463 I realized that the new `type` attribute for `ConfigurationValue`s may confuse people since `metadata` also has a `type` property. Renaming the attribute so that it is more clear