### PR TITLE
Add driver support for get_log_config command

### DIFF
--- a/test/model/test_driver.py
+++ b/test/model/test_driver.py
@@ -75,3 +75,30 @@ async def test_update_log_config(driver, uuid4, mock_command):
         },
         "messageId": uuid4,
     }
+
+
+async def test_get_log_config(driver, uuid4, mock_command):
+    """Test set value."""
+    ack_commands = mock_command(
+        {"command": "get_log_config"},
+        {
+            "success": True,
+            "config": {
+                "enabled": True,
+                "level": 0,
+                "logToFile": False,
+                "filename": "/test.txt",
+                "forceConsole": False,
+            },
+        },
+    )
+    log_config = await driver.async_get_log_config()
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {"command": "get_log_config", "messageId": uuid4}
+
+    assert log_config.enabled
+    assert log_config.level == LogLevel.ERROR
+    assert log_config.log_to_file is False
+    assert log_config.filename == "/test.txt"
+    assert log_config.force_console is False

--- a/zwave_js_server/model/driver.py
+++ b/zwave_js_server/model/driver.py
@@ -41,3 +41,8 @@ class Driver(EventBase):
         )
 
         return cast(bool, result["success"])
+
+    async def async_get_log_config(self) -> LogConfig:
+        """Return current log config for driver."""
+        result = await self.client.async_send_command({"command": "get_log_config"})
+        return LogConfig.from_dict(result["config"])

--- a/zwave_js_server/model/log_config.py
+++ b/zwave_js_server/model/log_config.py
@@ -1,5 +1,4 @@
 """Provide a model for the log config."""
-from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, TypedDict, cast
 

--- a/zwave_js_server/model/log_config.py
+++ b/zwave_js_server/model/log_config.py
@@ -1,4 +1,5 @@
 """Provide a model for the log config."""
+from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, TypedDict, cast
 


### PR DESCRIPTION
Follow on to https://github.com/home-assistant-libs/zwave-js-server-python/pull/120 and https://github.com/zwave-js/node-zwave-js/pull/1770 to add library support for a new command