### PR TITLE
Use both property key and property key name in Value ID

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -21,6 +21,7 @@ disable=
   import-outside-toplevel,
   locally-disabled,
   too-few-public-methods,
+  too-many-arguments,
   too-many-public-methods,
   too-many-instance-attributes,
   too-many-branches,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -209,9 +209,9 @@ def driver_fixture(client, controller_state):
     return Driver(client, controller_state)
 
 
-@pytest.fixture(name="node")
-def node_fixture(driver, multisensor_6_state):
-    """Return a node instance with a supporting client."""
+@pytest.fixture(name="multisensor_6")
+def multisensor_6_fixture(driver, multisensor_6_state):
+    """Mock a multisensor 6 node."""
     node = Node(driver.client, multisensor_6_state)
     driver.controller.nodes[node.node_id] = node
     return node
@@ -221,14 +221,6 @@ def node_fixture(driver, multisensor_6_state):
 def lock_schlage_be469_fixture(driver, lock_schlage_be469_state):
     """Mock a schlage lock node."""
     node = Node(driver.client, lock_schlage_be469_state)
-    driver.controller.nodes[node.node_id] = node
-    return node
-
-
-@pytest.fixture(name="multisensor_6")
-def multisensor_6_fixture(driver, multisensor_6_state):
-    """Mock a multisensor 6 node."""
-    node = Node(driver.client, multisensor_6_state)
     driver.controller.nodes[node.node_id] = node
     return node
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -225,6 +225,14 @@ def lock_schlage_be469_fixture(driver, lock_schlage_be469_state):
     return node
 
 
+@pytest.fixture(name="multisensor_6")
+def multisensor_6_fixture(driver, multisensor_6_state):
+    """Mock a multisensor 6 node."""
+    node = Node(driver.client, multisensor_6_state)
+    driver.controller.nodes[node.node_id] = node
+    return node
+
+
 @pytest.fixture(name="climate_radio_thermostat_ct100_plus")
 def climate_radio_thermostat_ct100_plus_fixture(
     driver, climate_radio_thermostat_ct100_plus_state

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -70,8 +70,8 @@ def test_from_state():
 async def test_values_without_property_key_name(multisensor_6):
     """Test that values with property key and without property key name can be found."""
     node = multisensor_6
-    assert "52-112-00-101-1-00" in node.values
-    assert "52-112-00-101-16-00" in node.values
+    assert "52-112-0-101-1-00" in node.values
+    assert "52-112-0-101-16-00" in node.values
 
 
 async def test_command_class_values(climate_radio_thermostat_ct100_plus):
@@ -87,13 +87,13 @@ async def test_command_class_values(climate_radio_thermostat_ct100_plus):
         assert isinstance(value, ConfigurationValue)
 
     with pytest.raises(UnwriteableValue):
-        await node.async_set_value("13-112-00-2-00-00", 1)
+        await node.async_set_value("13-112-0-2-00-00", 1)
 
     with pytest.raises(InvalidNewValue):
-        await node.async_set_value("13-112-00-1-00-00", 5)
+        await node.async_set_value("13-112-0-1-00-00", 5)
 
     with pytest.raises(InvalidNewValue):
-        await node.async_set_value("13-112-00-10-00-00", 200)
+        await node.async_set_value("13-112-0-10-00-00", 200)
 
 
 async def test_set_value(multisensor_6, uuid4, mock_command):
@@ -103,7 +103,7 @@ async def test_set_value(multisensor_6, uuid4, mock_command):
         {"command": "node.set_value", "nodeId": node.node_id},
         {"success": True},
     )
-    value_id = "52-32-00-targetValue-00-00"
+    value_id = "52-32-0-targetValue-00-00"
     value = node.values[value_id]
     assert await node.async_set_value(value_id, 42)
 
@@ -124,7 +124,7 @@ async def test_poll_value(multisensor_6, uuid4, mock_command):
         {"command": "node.poll_value", "nodeId": node.node_id},
         {"result": "something"},
     )
-    value_id = "52-32-00-currentValue-00-00"
+    value_id = "52-32-0-currentValue-00-00"
     value = node.values[value_id]
     result = await node.async_poll_value(value_id)
     assert result == "something"
@@ -217,7 +217,7 @@ async def test_get_value_metadata(multisensor_6, uuid4, mock_command):
         },
     )
 
-    value_id = "52-32-00-targetValue-00-00"
+    value_id = "52-32-0-targetValue-00-00"
     value = node.values[value_id]
     result = await node.async_get_value_metadata(value)
 

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -96,8 +96,9 @@ async def test_command_class_values(climate_radio_thermostat_ct100_plus):
         await node.async_set_value("13-112-00-10-00", 200)
 
 
-async def test_set_value(node, uuid4, mock_command):
+async def test_set_value(multisensor_6, uuid4, mock_command):
     """Test set value."""
+    node = multisensor_6
     ack_commands = mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
         {"success": True},
@@ -116,8 +117,9 @@ async def test_set_value(node, uuid4, mock_command):
     }
 
 
-async def test_poll_value(node, uuid4, mock_command):
+async def test_poll_value(multisensor_6, uuid4, mock_command):
     """Test poll value."""
+    node = multisensor_6
     ack_commands = mock_command(
         {"command": "node.poll_value", "nodeId": node.node_id},
         {"result": "something"},
@@ -136,8 +138,9 @@ async def test_poll_value(node, uuid4, mock_command):
     }
 
 
-async def test_refresh_info(node, uuid4, mock_command):
+async def test_refresh_info(multisensor_6, uuid4, mock_command):
     """Test refresh info."""
+    node = multisensor_6
     ack_commands = mock_command(
         {"command": "node.refresh_info", "nodeId": node.node_id},
         {},
@@ -152,8 +155,9 @@ async def test_refresh_info(node, uuid4, mock_command):
     }
 
 
-async def test_get_defined_value_ids(node, uuid4, mock_command):
+async def test_get_defined_value_ids(multisensor_6, uuid4, mock_command):
     """Test get defined value ids."""
+    node = multisensor_6
     ack_commands = mock_command(
         {"command": "node.get_defined_value_ids", "nodeId": node.node_id},
         {
@@ -199,8 +203,9 @@ async def test_get_defined_value_ids(node, uuid4, mock_command):
     }
 
 
-async def test_get_value_metadata(node, uuid4, mock_command):
+async def test_get_value_metadata(multisensor_6, uuid4, mock_command):
     """Test get value metadata."""
+    node = multisensor_6
     ack_commands = mock_command(
         {"command": "node.get_value_metadata", "nodeId": node.node_id},
         {
@@ -231,8 +236,9 @@ async def test_get_value_metadata(node, uuid4, mock_command):
     }
 
 
-async def test_abort_firmware_update(node, uuid4, mock_command):
+async def test_abort_firmware_update(multisensor_6, uuid4, mock_command):
     """Test abort firmware update."""
+    node = multisensor_6
     ack_commands = mock_command(
         {"command": "node.abort_firmware_update", "nodeId": node.node_id},
         {},

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -70,8 +70,8 @@ def test_from_state():
 async def test_values_without_property_key_name(multisensor_6):
     """Test that values with property key and without property key name can be found."""
     node = multisensor_6
-    assert "52-112-00-101-1" in node.values
-    assert "52-112-00-101-16" in node.values
+    assert "52-112-00-101-1-00" in node.values
+    assert "52-112-00-101-16-00" in node.values
 
 
 async def test_command_class_values(climate_radio_thermostat_ct100_plus):
@@ -87,13 +87,13 @@ async def test_command_class_values(climate_radio_thermostat_ct100_plus):
         assert isinstance(value, ConfigurationValue)
 
     with pytest.raises(UnwriteableValue):
-        await node.async_set_value("13-112-00-2-00", 1)
+        await node.async_set_value("13-112-00-2-00-00", 1)
 
     with pytest.raises(InvalidNewValue):
-        await node.async_set_value("13-112-00-1-00", 5)
+        await node.async_set_value("13-112-00-1-00-00", 5)
 
     with pytest.raises(InvalidNewValue):
-        await node.async_set_value("13-112-00-10-00", 200)
+        await node.async_set_value("13-112-00-10-00-00", 200)
 
 
 async def test_set_value(multisensor_6, uuid4, mock_command):
@@ -103,7 +103,7 @@ async def test_set_value(multisensor_6, uuid4, mock_command):
         {"command": "node.set_value", "nodeId": node.node_id},
         {"success": True},
     )
-    value_id = "52-32-00-targetValue-00"
+    value_id = "52-32-00-targetValue-00-00"
     value = node.values[value_id]
     assert await node.async_set_value(value_id, 42)
 
@@ -124,7 +124,7 @@ async def test_poll_value(multisensor_6, uuid4, mock_command):
         {"command": "node.poll_value", "nodeId": node.node_id},
         {"result": "something"},
     )
-    value_id = "52-32-00-currentValue-00"
+    value_id = "52-32-00-currentValue-00-00"
     value = node.values[value_id]
     result = await node.async_poll_value(value_id)
     assert result == "something"
@@ -217,7 +217,7 @@ async def test_get_value_metadata(multisensor_6, uuid4, mock_command):
         },
     )
 
-    value_id = "52-32-00-targetValue-00"
+    value_id = "52-32-00-targetValue-00-00"
     value = node.values[value_id]
     result = await node.async_get_value_metadata(value)
 

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -67,6 +67,13 @@ def test_from_state():
     assert node.endpoints[0].index == 0
 
 
+async def test_values_without_property_key_name(multisensor_6):
+    """Test that values with property key and without property key name can be found."""
+    node = multisensor_6
+    assert "52-112-00-101-1" in node.values
+    assert "52-112-00-101-16" in node.values
+
+
 async def test_command_class_values(climate_radio_thermostat_ct100_plus):
     """Test node methods to get command class values."""
     node = climate_radio_thermostat_ct100_plus

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -230,7 +230,7 @@ class ThermostatOperatingState(IntEnum):
 class ThermostatSetpointType(Enum):
     """
     Enum with all (known/used) Z-Wave Thermostat Setpoint Types.
-    
+
     Returns tuple of (property_key, property_key_name).
     """
 

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -228,7 +228,11 @@ class ThermostatOperatingState(IntEnum):
 
 
 class ThermostatSetpointType(Enum):
-    """Enum with all (known/used) Z-Wave Thermostat Setpoint Types."""
+    """
+    Enum with all (known/used) Z-Wave Thermostat Setpoint Types.
+    
+    Returns tuple of (property_key, property_key_name).
+    """
 
     # https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts#L53-L66
     NA = (0, "N/A")

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -231,18 +231,18 @@ class ThermostatSetpointType(Enum):
     """Enum with all (known/used) Z-Wave Thermostat Setpoint Types."""
 
     # https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts#L53-L66
-    NA = "N/A"
-    HEATING = "Heating"
-    COOLING = "Cooling"
-    FURNACE = "Furnace"
-    DRY_AIR = "Dry Air"
-    MOIST_AIR = "Moist Air"
-    AUTO_CHANGEOVER = "Auto Changeover"
-    ENERGY_SAVE_HEATING = "Energy Save Heating"
-    ENERGY_SAVE_COOLING = "Energy Save Cooling"
-    AWAY_HEATING = "Away Heating"
-    AWAY_COOLING = "Away Cooling"
-    FULL_POWER = "Full Power"
+    NA = (0, "N/A")
+    HEATING = (1, "Heating")
+    COOLING = (2, "Cooling")
+    FURNACE = (7, "Furnace")
+    DRY_AIR = (8, "Dry Air")
+    MOIST_AIR = (9, "Moist Air")
+    AUTO_CHANGEOVER = (10, "Auto Changeover")
+    ENERGY_SAVE_HEATING = (11, "Energy Save Heating")
+    ENERGY_SAVE_COOLING = (12, "Energy Save Cooling")
+    AWAY_HEATING = (13, "Away Heating")
+    AWAY_COOLING = (14, "Away Cooling")
+    FULL_POWER = (15, "Full Power")
 
 
 # In Z-Wave the modes and presets are both in ThermostatMode.

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -16,7 +16,6 @@ from .value import (
     ValueDataType,
     ValueMetadata,
     ValueNotification,
-    get_value_id,
     get_value_id_from_dict,
 )
 

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -16,7 +16,7 @@ from .value import (
     ValueDataType,
     ValueMetadata,
     ValueNotification,
-    get_value_id_from_dict,
+    _get_value_id_from_dict,
 )
 
 if TYPE_CHECKING:
@@ -72,7 +72,7 @@ class Node(EventBase):
         self.data = data
         self.values: Dict[str, Union[Value, ConfigurationValue]] = {}
         for val in data["values"]:
-            value_id = get_value_id_from_dict(self, val)
+            value_id = _get_value_id_from_dict(self, val)
             if val["commandClass"] == CommandClass.CONFIGURATION:
                 self.values[value_id] = ConfigurationValue(self, val)
             else:
@@ -404,7 +404,7 @@ class Node(EventBase):
         self.data.update(event.data["nodeState"])
         # update/add values
         for value_state in event.data["nodeState"]["values"]:
-            value_id = get_value_id_from_dict(self, value_state)
+            value_id = _get_value_id_from_dict(self, value_state)
             value = self.values.get(value_id)
             if value is None:
                 self.values[value_id] = Value(self, value_state)
@@ -418,7 +418,7 @@ class Node(EventBase):
 
     def handle_value_updated(self, event: Event) -> None:
         """Process a node value updated event."""
-        value = self.values.get(get_value_id_from_dict(self, event.data["args"]))
+        value = self.values.get(_get_value_id_from_dict(self, event.data["args"]))
         if value is None:
             # received update for unknown value
             # should not happen but just in case, treat like added value
@@ -430,13 +430,13 @@ class Node(EventBase):
     def handle_value_removed(self, event: Event) -> None:
         """Process a node value removed event."""
         event.data["value"] = self.values.pop(
-            get_value_id_from_dict(self, event.data["args"])
+            _get_value_id_from_dict(self, event.data["args"])
         )
 
     def handle_value_notification(self, event: Event) -> None:
         """Process a node value notification event."""
         # append metadata if value metadata is available
-        value = self.values.get(get_value_id_from_dict(self, event.data["args"]))
+        value = self.values.get(_get_value_id_from_dict(self, event.data["args"]))
         if value and value.data.get("metadata"):
             event.data["args"]["metadata"] = value.data["metadata"]
         event.data["value_notification"] = ValueNotification(self, event.data["args"])

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -2,7 +2,7 @@
 import json
 from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union
 
-from ..const import CommandClass, ConfigurationValueType
+from ..const import ConfigurationValueType
 from ..exceptions import UnparseableValue
 from ..event import Event
 

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -47,8 +47,12 @@ def get_value_id(node: "Node", event_data: ValueDataType) -> str:
     command_class = event_data["commandClass"]
     endpoint = event_data.get("endpoint") or "00"
     property_ = event_data["property"]
-    property_key_name = event_data.get("propertyKeyName") or "00"
-    return f"{node.node_id}-{command_class}-{endpoint}-{property_}-{property_key_name}"
+    # Some values that have a property key don't have a property key name, so we will
+    # fall back to property key if it exists
+    property_key = (
+        event_data.get("propertyKeyName") or event_data.get("propertyKey") or "00"
+    )
+    return f"{node.node_id}-{command_class}-{endpoint}-{property_}-{property_key}"
 
 
 class ValueMetadata:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -58,7 +58,7 @@ def get_value_id(
     node: "Node",
     command_class: int,
     property_: Union[str, int],
-    endpoint: int = None,
+    endpoint: Optional[int] = None,
     property_key: Union[str, int] = None,
     property_key_name: str = None,
 ) -> str:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -2,7 +2,7 @@
 import json
 from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union
 
-from ..const import ConfigurationValueType
+from ..const import CommandClass, ConfigurationValueType
 from ..exceptions import UnparseableValue
 from ..event import Event
 
@@ -42,17 +42,31 @@ class ValueDataType(TypedDict, total=False):
     ccVersion: int
 
 
-def get_value_id(node: "Node", event_data: ValueDataType) -> str:
-    """Return ID of value."""
-    command_class = event_data["commandClass"]
-    endpoint = event_data.get("endpoint") or "00"
-    property_ = event_data["property"]
-    # Some values that have a property key don't have a property key name, so we will
-    # fall back to property key if it exists
-    property_key = (
-        event_data.get("propertyKeyName") or event_data.get("propertyKey") or "00"
+def get_value_id_from_dict(node: "Node", val: ValueDataType):
+    """Return ID of value from ValueDataType dict."""
+    return get_value_id(
+        node,
+        val["commandClass"],
+        val["property"],
+        val.get("endpoint"),
+        val.get("propertyKey"),
+        val.get("propertyKeyName"),
     )
-    return f"{node.node_id}-{command_class}-{endpoint}-{property_}-{property_key}"
+
+
+def get_value_id(
+    node: "Node",
+    command_class: CommandClass,
+    property_: Union[str, int],
+    endpoint: int = None,
+    property_key: Union[str, int] = None,
+    property_key_name: str = None,
+) -> str:
+    """Return ID of value."""
+    endpoint = endpoint or "00"
+    property_key = property_key or "00"
+    property_key_name = property_key_name or "00"
+    return f"{node.node_id}-{command_class}-{endpoint}-{property_}-{property_key}-{property_key_name}"
 
 
 class ValueMetadata:
@@ -143,7 +157,7 @@ class Value:
     @property
     def value_id(self) -> str:
         """Return value ID."""
-        return get_value_id(self.node, self.data)
+        return get_value_id_from_dict(self.node, self.data)
 
     @property
     def metadata(self) -> ValueMetadata:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -58,18 +58,17 @@ def get_value_id(
     node: "Node",
     command_class: int,
     property_: Union[str, int],
-    endpoint: Optional[Union[str, int]] = None,
+    endpoint: Optional[int] = None,
     property_key: Optional[Union[str, int]] = None,
     property_key_name: Optional[str] = None,
 ) -> str:
     """Return ID of value."""
-    if endpoint is None:
-        endpoint = "00"
+    endpoint_ = "00" if endpoint is None else endpoint
     if property_key is None:
         property_key = "00"
     property_key_name = property_key_name or "00"
     return (
-        f"{node.node_id}-{command_class}-{endpoint}-"
+        f"{node.node_id}-{command_class}-{endpoint_}-"
         f"{property_}-{property_key}-{property_key_name}"
     )
 

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -42,7 +42,7 @@ class ValueDataType(TypedDict, total=False):
     ccVersion: int
 
 
-def get_value_id_from_dict(node: "Node", val: ValueDataType) -> str:
+def _get_value_id_from_dict(node: "Node", val: ValueDataType) -> str:
     """Return ID of value from ValueDataType dict."""
     return get_value_id(
         node,
@@ -58,15 +58,17 @@ def get_value_id(
     node: "Node",
     command_class: int,
     property_: Union[str, int],
-    endpoint: Optional[int] = None,
-    property_key: Union[str, int] = None,
-    property_key_name: str = None,
+    endpoint: Optional[Union[str, int]] = None,
+    property_key: Optional[Union[str, int]] = None,
+    property_key_name: Optional[str] = None,
 ) -> str:
     """Return ID of value."""
-    endpoint_ = endpoint or "00"
-    property_key = property_key or "00"
+    if endpoint is None:
+        endpoint = "00"
+    if property_key is None:
+        property_key = "00"
     property_key_name = property_key_name or "00"
-    return f"{node.node_id}-{command_class}-{endpoint_}-{property_}-{property_key}-{property_key_name}"
+    return f"{node.node_id}-{command_class}-{endpoint}-{property_}-{property_key}-{property_key_name}"
 
 
 class ValueMetadata:
@@ -157,7 +159,7 @@ class Value:
     @property
     def value_id(self) -> str:
         """Return value ID."""
-        return get_value_id_from_dict(self.node, self.data)
+        return _get_value_id_from_dict(self.node, self.data)
 
     @property
     def metadata(self) -> ValueMetadata:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -68,7 +68,9 @@ def get_value_id(
     if property_key is None:
         property_key = "00"
     property_key_name = property_key_name or "00"
-    return f"{node.node_id}-{command_class}-{endpoint}-{property_}-{property_key}-{property_key_name}"
+    return (
+        f"{node.node_id}-{command_class}-{endpoint}-{property_}-{property_key}-{property_key_name}"
+    )
 
 
 class ValueMetadata:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -42,7 +42,7 @@ class ValueDataType(TypedDict, total=False):
     ccVersion: int
 
 
-def get_value_id_from_dict(node: "Node", val: ValueDataType):
+def get_value_id_from_dict(node: "Node", val: ValueDataType) -> str:
     """Return ID of value from ValueDataType dict."""
     return get_value_id(
         node,
@@ -56,17 +56,17 @@ def get_value_id_from_dict(node: "Node", val: ValueDataType):
 
 def get_value_id(
     node: "Node",
-    command_class: CommandClass,
+    command_class: int,
     property_: Union[str, int],
     endpoint: int = None,
     property_key: Union[str, int] = None,
     property_key_name: str = None,
 ) -> str:
     """Return ID of value."""
-    endpoint = endpoint or "00"
+    endpoint_ = endpoint or "00"
     property_key = property_key or "00"
     property_key_name = property_key_name or "00"
-    return f"{node.node_id}-{command_class}-{endpoint}-{property_}-{property_key}-{property_key_name}"
+    return f"{node.node_id}-{command_class}-{endpoint_}-{property_}-{property_key}-{property_key_name}"
 
 
 class ValueMetadata:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -69,7 +69,8 @@ def get_value_id(
         property_key = "00"
     property_key_name = property_key_name or "00"
     return (
-        f"{node.node_id}-{command_class}-{endpoint}-{property_}-{property_key}-{property_key_name}"
+        f"{node.node_id}-{command_class}-{endpoint}-"
+        f"{property_}-{property_key}-{property_key_name}"
     )
 
 

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -21,11 +21,10 @@ def get_code_slot_value(node: Node, code_slot: int, property_name: str) -> Value
     value = node.values.get(
         get_value_id(
             node,
-            {
-                "commandClass": CommandClass.USER_CODE,
-                "property": property_name,
-                "propertyKeyName": str(code_slot),
-            },
+            CommandClass.USER_CODE,
+            property_name,
+            property_key=code_slot,
+            property_key_name=str(code_slot),
         )
     )
 

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -23,6 +23,7 @@ def get_code_slot_value(node: Node, code_slot: int, property_name: str) -> Value
             node,
             CommandClass.USER_CODE,
             property_name,
+            endpoint=0,
             property_key=code_slot,
             property_key_name=str(code_slot),
         )


### PR DESCRIPTION
## Breaking Change
The format of value ID's has changed, as has the parameters for `get_value_id`. 

Resolves https://github.com/home-assistant-libs/zwave-js-server-python/issues/122 (see issue for more context)