### PR TITLE
Don't store unparseable values

### DIFF
--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -1,5 +1,4 @@
 """Provide a model for the Z-Wave JS node."""
-import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
 from zwave_js_server.const import CommandClass
 
@@ -21,8 +20,6 @@ from .value import (
 
 if TYPE_CHECKING:
     from ..client import Client
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class NodeDataType(TypedDict, total=False):
@@ -81,12 +78,8 @@ class Node(EventBase):
                 else:
                     self.values[value_id] = Value(self, val)
             except UnparseableValue:
-                # If we can't parse the value, don't store it but log it for later
-                _LOGGER.info(
-                    "Unable to parse value %s (%s) so it will not be stored",
-                    value_id,
-                    val,
-                )
+                # If we can't parse the value, don't store it
+                pass
 
     def __repr__(self) -> str:
         """Return the representation."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -83,7 +83,9 @@ class Node(EventBase):
             except UnparseableValue:
                 # If we can't parse the value, don't store it but log it for later
                 _LOGGER.info(
-                    "Skipping unparseable value %s (raw value data: %s)", value_id, val
+                    "Unable to parse value %s (%s) so it will not be stored",
+                    value_id,
+                    val,
                 )
 
     def __repr__(self) -> str:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -1,4 +1,5 @@
 """Provide a model for the Z-Wave JS node."""
+import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
 from zwave_js_server.const import CommandClass
 
@@ -20,6 +21,8 @@ from .value import (
 
 if TYPE_CHECKING:
     from ..client import Client
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class NodeDataType(TypedDict, total=False):
@@ -78,8 +81,10 @@ class Node(EventBase):
                 else:
                     self.values[value_id] = Value(self, val)
             except UnparseableValue:
-                # If we can't parse the value, don't store it
-                pass
+                # If we can't parse the value, don't store it but log it for later
+                _LOGGER.info(
+                    "Skipping unparseable value %s (raw value data: %s)", value_id, val
+                )
 
     def __repr__(self) -> str:
         """Return the representation."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -2,7 +2,7 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
 from zwave_js_server.const import CommandClass
 
-from ..exceptions import UnwriteableValue
+from ..exceptions import UnparseableValue, UnwriteableValue
 from ..event import Event, EventBase
 from .device_class import DeviceClass, DeviceClassDataType
 from .device_config import DeviceConfig, DeviceConfigDataType
@@ -72,10 +72,14 @@ class Node(EventBase):
         self.values: Dict[str, Union[Value, ConfigurationValue]] = {}
         for val in data["values"]:
             value_id = _get_value_id_from_dict(self, val)
-            if val["commandClass"] == CommandClass.CONFIGURATION:
-                self.values[value_id] = ConfigurationValue(self, val)
-            else:
-                self.values[value_id] = Value(self, val)
+            try:
+                if val["commandClass"] == CommandClass.CONFIGURATION:
+                    self.values[value_id] = ConfigurationValue(self, val)
+                else:
+                    self.values[value_id] = Value(self, val)
+            except UnparseableValue:
+                # If we can't parse the value, don't store it
+                pass
 
     def __repr__(self) -> str:
         """Return the representation."""


### PR DESCRIPTION
~~Reverting a change I made earlier. Thinking about it again, it doesn't make sense to raise an exception when a value can't be parsed, it just means that the library is not smart enough (yet!) to parse it. We should store the value as is if we can't parse it and let the client make a decision on how to handle the value~~

If we can't parse a value, we shouldn't store it