### PR TITLE
Handle unknown values by returning None for value.value

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,9 +41,15 @@ def lock_schlage_be469_state_fixture():
 
 
 @pytest.fixture(name="climate_radio_thermostat_ct100_plus_state", scope="session")
-def climate_radio_thermostat_ct100_plus_state():
+def climate_radio_thermostat_ct100_plus_state_fixture():
     """Load the radio thermostat node state fixture data."""
     return json.loads(load_fixture("climate_radio_thermostat_ct100_plus_state.json"))
+
+
+@pytest.fixture(name="cover_qubino_shutter_state", scope="session")
+def cover_qubino_shutter_state_fixture():
+    """Load the qubino shutter cover node state fixture data."""
+    return json.loads(load_fixture("cover_qubino_shutter_state.json"))
 
 
 @pytest.fixture(name="client_session")
@@ -249,6 +255,14 @@ def climate_radio_thermostat_ct100_plus_fixture(
 ):
     """Mock a radio thermostat node."""
     node = Node(driver.client, climate_radio_thermostat_ct100_plus_state)
+    driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="cover_qubino_shutter")
+def cover_qubino_shutter_fixture(driver, cover_qubino_shutter_state):
+    """Mock a qubino shutter cover node."""
+    node = Node(driver.client, cover_qubino_shutter_state)
     driver.controller.nodes[node.node_id] = node
     return node
 

--- a/test/fixtures/cover_qubino_shutter_state.json
+++ b/test/fixtures/cover_qubino_shutter_state.json
@@ -1,0 +1,770 @@
+{
+	"nodeId": 5,
+	"index": 0,
+	"installerIcon": 6656,
+	"userIcon": 6656,
+	"status": 4,
+	"ready": true,
+	"deviceClass": {
+		"basic": "Routing Slave",
+		"generic": "Multilevel Switch",
+		"specific": "Motor Control Class C",
+		"mandatorySupportedCCs": [
+			"Basic",
+			"Multilevel Switch",
+			"Binary Switch",
+			"Manufacturer Specific",
+			"Version"
+		],
+		"mandatoryControlCCs": []
+	},
+	"isListening": true,
+	"isFrequentListening": false,
+	"isRouting": true,
+	"maxBaudRate": 40000,
+	"isSecure": false,
+	"version": 4,
+	"isBeaming": true,
+	"manufacturerId": 345,
+	"productId": 83,
+	"productType": 3,
+	"firmwareVersion": "7.2",
+	"zwavePlusVersion": 1,
+	"nodeType": 0,
+	"roleType": 5,
+	"deviceConfig": {
+		"manufacturerId": 345,
+		"manufacturer": "Qubino",
+		"label": "ZMNHOD",
+		"description": "Flush Shutter DC",
+		"devices": [{ "productType": "0x0003", "productId": "0x0053" }],
+		"firmwareVersion": { "min": "0.0", "max": "255.255" },
+		"paramInformation": { "_map": {} }
+	},
+	"label": "ZMNHOD",
+	"neighbors": [1, 2],
+	"interviewAttempts": 1,
+	"endpoints": [
+		{ "nodeId": 5, "index": 0, "installerIcon": 6656, "userIcon": 6656 }
+	],
+	"values": [
+		{
+			"endpoint": 0,
+			"commandClass": 38,
+			"commandClassName": "Multilevel Switch",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"min": 0,
+				"max": 99,
+				"label": "Target value"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 38,
+			"commandClassName": "Multilevel Switch",
+			"property": "duration",
+			"propertyName": "duration",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "duration",
+				"readable": true,
+				"writeable": true,
+				"label": "Transition duration"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 38,
+			"commandClassName": "Multilevel Switch",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 99,
+				"label": "Current value"
+			},
+			"value": "unknown"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 38,
+			"commandClassName": "Multilevel Switch",
+			"property": "Up",
+			"propertyName": "Up",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": true,
+				"label": "Perform a level change (Up)",
+				"ccSpecific": { "switchType": 2 }
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 38,
+			"commandClassName": "Multilevel Switch",
+			"property": "Down",
+			"propertyName": "Down",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": true,
+				"label": "Perform a level change (Down)",
+				"ccSpecific": { "switchType": 2 }
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value"
+			},
+			"value": "unknown"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 65535,
+				"label": "Manufacturer ID"
+			},
+			"value": 345
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 65535,
+				"label": "Product type"
+			},
+			"value": 3
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 65535,
+				"label": "Product ID"
+			},
+			"value": 83
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			},
+			"value": 3
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			},
+			"value": "4.38"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			},
+			"value": ["7.2"]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "hardwareVersion",
+			"propertyName": "hardwareVersion",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip hardware version"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 50,
+			"commandClassName": "Meter",
+			"property": "value",
+			"propertyKey": 65537,
+			"propertyName": "value",
+			"propertyKeyName": "Electric_kWh_Consumed",
+			"ccVersion": 4,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Electric Consumed [kWh]",
+				"unit": "kWh",
+				"ccSpecific": { "meterType": 1, "rateType": 1, "scale": 0 }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 50,
+			"commandClassName": "Meter",
+			"property": "deltaTime",
+			"propertyKey": 65537,
+			"propertyName": "deltaTime",
+			"propertyKeyName": "Electric_kWh_Consumed",
+			"ccVersion": 4,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Electric Consumed [kWh] (prev. time delta)",
+				"unit": "s",
+				"ccSpecific": { "meterType": 1, "rateType": 1, "scale": 0 }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 50,
+			"commandClassName": "Meter",
+			"property": "value",
+			"propertyKey": 66049,
+			"propertyName": "value",
+			"propertyKeyName": "Electric_W_Consumed",
+			"ccVersion": 4,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Electric Consumed [W]",
+				"unit": "W",
+				"ccSpecific": { "meterType": 1, "rateType": 1, "scale": 2 }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 50,
+			"commandClassName": "Meter",
+			"property": "deltaTime",
+			"propertyKey": 66049,
+			"propertyName": "deltaTime",
+			"propertyKeyName": "Electric_W_Consumed",
+			"ccVersion": 4,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Electric Consumed [W] (prev. time delta)",
+				"unit": "s",
+				"ccSpecific": { "meterType": 1, "rateType": 1, "scale": 2 }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 50,
+			"commandClassName": "Meter",
+			"property": "reset",
+			"propertyName": "reset",
+			"ccVersion": 4,
+			"metadata": {
+				"type": "boolean",
+				"readable": false,
+				"writeable": true,
+				"label": "Reset accumulated values"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 50,
+			"commandClassName": "Meter",
+			"property": "previousValue",
+			"propertyKey": 65537,
+			"propertyName": "previousValue",
+			"propertyKeyName": "Electric_kWh_Consumed",
+			"ccVersion": 4,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Electric Consumed [kWh] (prev. value)",
+				"unit": "kWh",
+				"ccSpecific": { "meterType": 1, "rateType": 1, "scale": 0 }
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 50,
+			"commandClassName": "Meter",
+			"property": "previousValue",
+			"propertyKey": 66049,
+			"propertyName": "previousValue",
+			"propertyKeyName": "Electric_W_Consumed",
+			"ccVersion": 4,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Electric Consumed [W] (prev. value)",
+				"unit": "W",
+				"ccSpecific": { "meterType": 1, "rateType": 1, "scale": 2 }
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 113,
+			"commandClassName": "Notification",
+			"property": "alarmType",
+			"propertyName": "alarmType",
+			"ccVersion": 5,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 255,
+				"label": "Alarm Type"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 113,
+			"commandClassName": "Notification",
+			"property": "alarmLevel",
+			"propertyName": "alarmLevel",
+			"ccVersion": 5,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 255,
+				"label": "Alarm Level"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 113,
+			"commandClassName": "Notification",
+			"property": "Power Management",
+			"propertyKey": "Over-load status",
+			"propertyName": "Power Management",
+			"propertyKeyName": "Over-load status",
+			"ccVersion": 5,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 255,
+				"label": "Over-load status",
+				"states": { "0": "idle", "8": "Over-load detected" },
+				"ccSpecific": { "notificationType": 8 }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 10,
+			"propertyName": "Activate/deactivate functions ALL ON / ALL OFF",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 2,
+				"min": 0,
+				"max": 65535,
+				"default": 255,
+				"format": 1,
+				"allowManualEntry": false,
+				"states": {
+					"0": "ALL ON is not active, ALL OFF is not active",
+					"1": "ALL ON is not active ALL OFF active",
+					"2": "ALL ON is not active ALL OFF is not active",
+					"255": "ALL ON active, ALL OFF active"
+				},
+				"label": "Activate/deactivate functions ALL ON / ALL OFF",
+				"isFromConfig": true
+			},
+			"value": 255
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 40,
+			"propertyName": "Power report (Watts) on power change for Q1 or Q2",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 100,
+				"default": 1,
+				"format": 0,
+				"allowManualEntry": true,
+				"label": "Power report (Watts) on power change for Q1 or Q2",
+				"isFromConfig": true
+			},
+			"value": 10
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 42,
+			"propertyName": "Power report (Watts) by time interval for Q1 or Q2",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 2,
+				"min": 0,
+				"max": 32767,
+				"default": 300,
+				"format": 0,
+				"allowManualEntry": true,
+				"label": "Power report (Watts) by time interval for Q1 or Q2",
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 71,
+			"propertyName": "Operating modes",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 255,
+				"default": 0,
+				"format": 1,
+				"allowManualEntry": false,
+				"states": {
+					"0": "Shutter mode.",
+					"1": "Venetian mode (up/down and slate rotation)"
+				},
+				"label": "Operating modes",
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 72,
+			"propertyName": "Slats tilting full turn time",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 2,
+				"min": 0,
+				"max": 32767,
+				"default": 150,
+				"format": 0,
+				"allowManualEntry": true,
+				"label": "Slats tilting full turn time",
+				"isFromConfig": true
+			},
+			"value": 630
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 73,
+			"propertyName": "Slats position",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 255,
+				"default": 1,
+				"format": 1,
+				"allowManualEntry": false,
+				"states": {
+					"0": "Return to previous position only with Z-wave",
+					"1": "Return to previous position with Z-wave or button"
+				},
+				"label": "Slats position",
+				"isFromConfig": true
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 74,
+			"propertyName": "Motor moving up/down time",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 2,
+				"min": 0,
+				"max": 32767,
+				"default": 0,
+				"format": 0,
+				"allowManualEntry": true,
+				"label": "Motor moving up/down time",
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 76,
+			"propertyName": "Motor operation detection",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 100,
+				"default": 6,
+				"format": 0,
+				"allowManualEntry": true,
+				"label": "Motor operation detection",
+				"isFromConfig": true
+			},
+			"value": 10
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 78,
+			"propertyName": "Forced Shutter DC calibration",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 255,
+				"default": 0,
+				"format": 1,
+				"allowManualEntry": false,
+				"states": { "0": "Default", "1": "Start calibration process." },
+				"label": "Forced Shutter DC calibration",
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 85,
+			"propertyName": "Power consumption max delay time",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 3,
+				"max": 50,
+				"default": 8,
+				"format": 0,
+				"allowManualEntry": true,
+				"label": "Power consumption max delay time",
+				"isFromConfig": true
+			},
+			"value": 8
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 86,
+			"propertyName": "Power consumption at limit switch delay time",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 3,
+				"max": 50,
+				"default": 8,
+				"format": 0,
+				"allowManualEntry": true,
+				"label": "Power consumption at limit switch delay time",
+				"isFromConfig": true
+			},
+			"value": 8
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 90,
+			"propertyName": "Time delay for next motor movement",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 1,
+				"max": 30,
+				"default": 5,
+				"format": 0,
+				"allowManualEntry": true,
+				"label": "Time delay for next motor movement",
+				"isFromConfig": true
+			},
+			"value": 5
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 110,
+			"propertyName": "Temperature sensor offset settings",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 2,
+				"min": 1,
+				"max": 32536,
+				"default": 32536,
+				"format": 0,
+				"allowManualEntry": true,
+				"label": "Temperature sensor offset settings",
+				"isFromConfig": true
+			},
+			"value": 32536
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 120,
+			"propertyName": "Digital temperature sensor reporting",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 127,
+				"default": 5,
+				"format": 0,
+				"allowManualEntry": true,
+				"label": "Digital temperature sensor reporting",
+				"isFromConfig": true
+			},
+			"value": 5
+		}
+	]
+}

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -66,6 +66,19 @@ def test_from_state():
     assert node.endpoints[0].index == 0
 
 
+async def test_unknown_values(cover_qubino_shutter):
+    """Test that values that are unknown return as None."""
+    node = cover_qubino_shutter
+    assert (
+        "5-38-0-currentValue-00-00" in node.values
+        and node.values["5-38-0-currentValue-00-00"].value is None
+    )
+    assert (
+        "5-37-0-currentValue-00-00" in node.values
+        and node.values["5-37-0-currentValue-00-00"].value is None
+    )
+
+
 async def test_values_without_property_key_name(multisensor_6):
     """Test that values with property key and without property key name can be found."""
     node = multisensor_6

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -7,6 +7,8 @@ MIN_SERVER_VERSION = "1.0.0-beta.8"
 # Will be checked _excluding_
 MAX_SERVER_VERSION = "2.0.0"
 
+VALUE_UNKNOWN = "unknown"
+
 
 class LogLevel(IntEnum):
     """Enum for log levels used by node-zwave-js."""

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -2,7 +2,7 @@
 import json
 from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union
 
-from ..const import ConfigurationValueType
+from ..const import ConfigurationValueType, VALUE_UNKNOWN
 from ..exceptions import UnparseableValue
 from ..event import Event
 
@@ -171,6 +171,9 @@ class Value:
     @property
     def value(self) -> Optional[Any]:
         """Return value."""
+        # Treat unknown values like they are None
+        if self._value == VALUE_UNKNOWN:
+            return None
         return self._value
 
     @property


### PR DESCRIPTION
Sometimes a value is returned as "unknown". We have some values that also don't report a full value, so it makes sense to me to treat them the same way (return None) and let the consumer handle this scenario the same way in each case