### PR TITLE
Add hash magic method to driver, controller, nodes and values

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -167,6 +167,11 @@ async def test_stop_exclusion(controller, uuid4, mock_command):
     }
 
 
+async def test_hash(controller):
+    """Test node hash."""
+    assert hash(controller) == hash(controller.home_id)
+
+
 async def test_remove_failed_node(controller, uuid4, mock_command):
     """Test remove failed node."""
     ack_commands = mock_command(

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -86,6 +86,12 @@ async def test_values_without_property_key_name(multisensor_6):
     assert "52-112-0-101-16-00" in node.values
 
 
+async def test_hash(client, driver, controller, climate_radio_thermostat_ct100_plus):
+    """Test node hash."""
+    node = climate_radio_thermostat_ct100_plus
+    assert hash(node) == hash((controller, node.node_id))
+
+
 async def test_command_class_values(climate_radio_thermostat_ct100_plus):
     """Test node methods to get command class values."""
     node = climate_radio_thermostat_ct100_plus

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -86,10 +86,10 @@ async def test_values_without_property_key_name(multisensor_6):
     assert "52-112-0-101-16-00" in node.values
 
 
-async def test_hash(client, driver, controller, climate_radio_thermostat_ct100_plus):
+async def test_hash(climate_radio_thermostat_ct100_plus):
     """Test node hash."""
     node = climate_radio_thermostat_ct100_plus
-    assert hash(node) == hash((controller, node.node_id))
+    assert hash(node) == hash((node.client.driver, node.node_id))
 
 
 async def test_command_class_values(climate_radio_thermostat_ct100_plus):

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -51,6 +51,14 @@ class Controller(EventBase):
         """Return the representation."""
         return f"{type(self).__name__}(home_id={self.home_id})"
 
+    def __hash__(self) -> int:
+        """Return the hash."""
+        return hash(self.home_id)
+
+    def __eq__(self, other: "Controller") -> bool:
+        """Return whether this instance equals another."""
+        return self.home_id == other.home_id
+
     @property
     def library_version(self) -> Optional[str]:
         """Return library_version."""

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -55,8 +55,10 @@ class Controller(EventBase):
         """Return the hash."""
         return hash(self.home_id)
 
-    def __eq__(self, other: "Controller") -> bool:
+    def __eq__(self, other: object) -> bool:
         """Return whether this instance equals another."""
+        if not isinstance(other, Controller):
+            return False
         return self.home_id == other.home_id
 
     @property

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -47,6 +47,10 @@ class Controller(EventBase):
             node = Node(client, node_state)
             self.nodes[node.node_id] = node
 
+    def __repr__(self) -> str:
+        """Return the representation."""
+        return f"{type(self).__name__}(home_id={self.home_id})"
+
     @property
     def library_version(self) -> Optional[str]:
         """Return library_version."""

--- a/zwave_js_server/model/driver.py
+++ b/zwave_js_server/model/driver.py
@@ -18,6 +18,16 @@ class Driver(EventBase):
         self.client = client
         self.controller = Controller(client, state)
 
+    def __hash__(self) -> int:
+        """Return the hash."""
+        return hash(self.controller)
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether this instance equals another."""
+        if not isinstance(other, Driver):
+            return False
+        return self.controller == other.controller
+
     def receive_event(self, event: Event) -> None:
         """Receive an event."""
         if event.data["source"] != "driver":

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -83,15 +83,21 @@ class Node(EventBase):
 
     def __repr__(self) -> str:
         """Return the representation."""
+        assert self.client.driver
         controller = repr(self.client.driver.controller)
         return f"{type(self).__name__}(controller={controller}, node_id={self.node_id})"
 
     def __hash__(self) -> int:
         """Return the hash."""
-        return hash(self.client.driver.controller, self.node_id)
+        assert self.client.driver
+        return hash(self.client.driver.controller) + hash(self.node_id)
 
-    def __eq__(self, other: "Node") -> bool:
+    def __eq__(self, other: object) -> bool:
         """Return whether this instance equals another."""
+        if not isinstance(other, Node):
+            return False
+        assert self.client.driver
+        assert other.client.driver
         return (
             self.client.driver.controller == other.client.driver.controller
             and self.node_id == other.node_id

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -83,7 +83,8 @@ class Node(EventBase):
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"{type(self).__name__}(node_id={self.node_id})"
+        controller = repr(self.client.driver.controller)
+        return f"{type(self).__name__}(controller={controller}, node_id={self.node_id})"
 
     @property
     def node_id(self) -> int:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -86,6 +86,17 @@ class Node(EventBase):
         controller = repr(self.client.driver.controller)
         return f"{type(self).__name__}(controller={controller}, node_id={self.node_id})"
 
+    def __hash__(self) -> int:
+        """Return the hash."""
+        return hash(self.client.driver.controller, self.node_id)
+
+    def __eq__(self, other: "Node") -> bool:
+        """Return whether this instance equals another."""
+        return (
+            self.client.driver.controller == other.client.driver.controller
+            and self.node_id == other.node_id
+        )
+
     @property
     def node_id(self) -> int:
         """Return the node_id."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -84,13 +84,13 @@ class Node(EventBase):
     def __repr__(self) -> str:
         """Return the representation."""
         assert self.client.driver
-        controller = repr(self.client.driver.controller)
-        return f"{type(self).__name__}(controller={controller}, node_id={self.node_id})"
+        home_id = self.client.driver.controller.home_id
+        return f"{type(self).__name__}(home_id={home_id}, node_id={self.node_id})"
 
     def __hash__(self) -> int:
         """Return the hash."""
         assert self.client.driver
-        return hash(self.client.driver.controller) + hash(self.node_id)
+        return hash((self.client.driver.controller, self.node_id))
 
     def __eq__(self, other: object) -> bool:
         """Return whether this instance equals another."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -83,24 +83,18 @@ class Node(EventBase):
 
     def __repr__(self) -> str:
         """Return the representation."""
-        assert self.client.driver
-        home_id = self.client.driver.controller.home_id
-        return f"{type(self).__name__}(home_id={home_id}, node_id={self.node_id})"
+        return f"{type(self).__name__}(node_id={self.node_id})"
 
     def __hash__(self) -> int:
         """Return the hash."""
-        assert self.client.driver
-        return hash((self.client.driver.controller, self.node_id))
+        return hash((self.client.driver, self.node_id))
 
     def __eq__(self, other: object) -> bool:
         """Return whether this instance equals another."""
         if not isinstance(other, Node):
             return False
-        assert self.client.driver
-        assert other.client.driver
         return (
-            self.client.driver.controller == other.client.driver.controller
-            and self.node_id == other.node_id
+            self.client.driver == other.client.driver and self.node_id == other.node_id
         )
 
     @property

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -156,7 +156,7 @@ class Value:
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"{type(self).__name__}(value_id={self.value_id!r})"
+        return f"{type(self).__name__}(node={self.node!r}, value_id={self.value_id!r})"
 
     @property
     def value_id(self) -> str:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -160,7 +160,7 @@ class Value:
 
     def __hash__(self) -> int:
         """Return the hash."""
-        return hash(self.node) + hash(self.value_id)
+        return hash((self.node, self.value_id))
 
     def __eq__(self, other: object) -> bool:
         """Return whether this instance equals another."""

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -158,6 +158,14 @@ class Value:
         """Return the representation."""
         return f"{type(self).__name__}(node={self.node!r}, value_id={self.value_id!r})"
 
+    def __hash__(self) -> int:
+        """Return the hash."""
+        return hash(self.node, self.value_id)
+
+    def __eq__(self, other: "Value") -> bool:
+        """Return whether this instance equals another."""
+        return self.node == other.node and self.value_id == other.value_id
+
     @property
     def value_id(self) -> str:
         """Return value ID."""

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -156,7 +156,7 @@ class Value:
 
     def __repr__(self) -> str:
         """Return the representation."""
-        return f"{type(self).__name__}(node={self.node!r}, value_id={self.value_id!r})"
+        return f"{type(self).__name__}(value_id={self.value_id!r})"
 
     def __hash__(self) -> int:
         """Return the hash."""

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -160,10 +160,12 @@ class Value:
 
     def __hash__(self) -> int:
         """Return the hash."""
-        return hash(self.node, self.value_id)
+        return hash(self.node) + hash(self.value_id)
 
-    def __eq__(self, other: "Value") -> bool:
+    def __eq__(self, other: object) -> bool:
         """Return whether this instance equals another."""
+        if not isinstance(other, Value):
+            return False
         return self.node == other.node and self.value_id == other.value_id
 
     @property


### PR DESCRIPTION
As part of this discussion: https://github.com/home-assistant/core/pull/46673#discussion_r580845521 we realized that our representation for various models is not unique enough. This make controller, node, and value representations unique so they can be usefully hashed.

Without this, you cannot use the zwave_js.set_config_parameter on entities from two different config entries with the same node ID
