### PR TITLE
Fix update_log_config return value

### DIFF
--- a/test/model/test_driver.py
+++ b/test/model/test_driver.py
@@ -25,13 +25,15 @@ def test_from_state():
 
 async def test_update_log_config(driver, uuid4, mock_command):
     """Test update log config."""
+    # Update log level
     ack_commands = mock_command(
         {"command": "update_log_config", "config": {"level": 0}},
         {"success": True},
     )
+
     assert await driver.async_update_log_config(
         log_config_pkg.LogConfig(level=LogLevel.ERROR)
-    )
+    ) is None
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
@@ -40,6 +42,7 @@ async def test_update_log_config(driver, uuid4, mock_command):
         "messageId": uuid4,
     }
 
+    # Update all parameters
     ack_commands = mock_command(
         {
             "command": "update_log_config",
@@ -61,7 +64,7 @@ async def test_update_log_config(driver, uuid4, mock_command):
             filename="/test.txt",
             force_console=True,
         )
-    )
+    ) is None
 
     assert len(ack_commands) == 2
     assert ack_commands[1] == {

--- a/test/model/test_driver.py
+++ b/test/model/test_driver.py
@@ -31,9 +31,12 @@ async def test_update_log_config(driver, uuid4, mock_command):
         {"success": True},
     )
 
-    assert await driver.async_update_log_config(
-        log_config_pkg.LogConfig(level=LogLevel.ERROR)
-    ) is None
+    assert (
+        await driver.async_update_log_config(
+            log_config_pkg.LogConfig(level=LogLevel.ERROR)
+        )
+        is None
+    )
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
@@ -56,15 +59,18 @@ async def test_update_log_config(driver, uuid4, mock_command):
         },
         {"success": True},
     )
-    assert await driver.async_update_log_config(
-        log_config_pkg.LogConfig(
-            enabled=True,
-            level=LogLevel.ERROR,
-            log_to_file=True,
-            filename="/test.txt",
-            force_console=True,
+    assert (
+        await driver.async_update_log_config(
+            log_config_pkg.LogConfig(
+                enabled=True,
+                level=LogLevel.ERROR,
+                log_to_file=True,
+                filename="/test.txt",
+                force_console=True,
+            )
         )
-    ) is None
+        is None
+    )
 
     assert len(ack_commands) == 2
     assert ack_commands[1] == {

--- a/zwave_js_server/model/driver.py
+++ b/zwave_js_server/model/driver.py
@@ -41,7 +41,7 @@ class Driver(EventBase):
     def handle_all_nodes_ready(self, event: Event) -> None:
         """Process a driver all nodes ready event."""
 
-    async def async_update_log_config(self, log_config: LogConfig) -> bool:
+    async def async_update_log_config(self, log_config: LogConfig) -> None:
         """Update log config for driver."""
         await self.client.async_send_command(
             {
@@ -49,8 +49,6 @@ class Driver(EventBase):
                 "config": log_config.to_dict(),
             }
         )
-
-        return True
 
     async def async_get_log_config(self) -> LogConfig:
         """Return current log config for driver."""

--- a/zwave_js_server/model/driver.py
+++ b/zwave_js_server/model/driver.py
@@ -1,5 +1,5 @@
 """Provide a model for the Z-Wave JS Driver."""
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from zwave_js_server.model.log_config import LogConfig
 
 from ..event import Event, EventBase

--- a/zwave_js_server/model/driver.py
+++ b/zwave_js_server/model/driver.py
@@ -43,14 +43,14 @@ class Driver(EventBase):
 
     async def async_update_log_config(self, log_config: LogConfig) -> bool:
         """Update log config for driver."""
-        result = await self.client.async_send_command(
+        await self.client.async_send_command(
             {
                 "command": "update_log_config",
                 "config": log_config.to_dict(),
             }
         )
 
-        return cast(bool, result["success"])
+        return True
 
     async def async_get_log_config(self) -> LogConfig:
         """Return current log config for driver."""


### PR DESCRIPTION
The original logic assumed there was a `success` key in the result but that is not the case. We can always return `True` because any errors would not be related to the command itself and therefore the logic to receive a message from server should handle any issues that would arise