### PR TITLE
Add option to send a new value without waiting

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -112,7 +112,7 @@ async def test_set_value(multisensor_6, uuid4, mock_command):
     )
     value_id = "52-32-0-targetValue-00-00"
     value = node.values[value_id]
-    assert await node.async_set_value(value_id, 42)
+    assert await node.async_set_value(value_id, 42) is None
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
@@ -133,8 +133,7 @@ async def test_poll_value(multisensor_6, uuid4, mock_command):
     )
     value_id = "52-32-0-currentValue-00-00"
     value = node.values[value_id]
-    result = await node.async_poll_value(value_id)
-    assert result == "something"
+    assert await node.async_poll_value(value_id) is None
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -66,6 +66,11 @@ class Client:
         finally:
             self._result_futures.pop(message_id)
 
+    async def async_send_command_no_wait(self, message: Dict[str, Any]) -> None:
+        """Send a command without waiting for the response."""
+        message["messageId"] = uuid.uuid4().hex
+        await self._send_json_message(message)
+
     async def connect(self) -> None:
         """Connect to the websocket server."""
         if self.driver is not None:
@@ -222,9 +227,7 @@ class Client:
             future = self._result_futures.get(msg["messageId"])
 
             if future is None:
-                self._logger.warning(
-                    "Received result for unknown message with ID: %s", msg["messageId"]
-                )
+                # no listener for this result
                 return
 
             if msg["success"]:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -302,7 +302,7 @@ class Node(EventBase):
         }
         if no_wait:
             await self.client.async_send_command_no_wait(args)
-            return
+            return None
         result = await self.client.async_send_command(args)
         return cast(bool, result["success"])
 

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -282,7 +282,9 @@ class Node(EventBase):
 
         self.emit(event.type, event.data)
 
-    async def async_set_value(self, val: Union[Value, str], new_value: Any) -> bool:
+    async def async_set_value(
+        self, val: Union[Value, str], new_value: Any, no_wait: bool = False
+    ) -> bool:
         """Send setValue command to Node for given value (or value_id)."""
         # a value may be specified as value_id or the value itself
         if not isinstance(val, Value):
@@ -292,14 +294,16 @@ class Node(EventBase):
             raise UnwriteableValue
 
         # the value object needs to be send to the server
-        result = await self.client.async_send_command(
-            {
-                "command": "node.set_value",
-                "nodeId": self.node_id,
-                "valueId": val.data,
-                "value": new_value,
-            }
-        )
+        args = {
+            "command": "node.set_value",
+            "nodeId": self.node_id,
+            "valueId": val.data,
+            "value": new_value,
+        }
+        if no_wait:
+            await self.client.async_send_command_no_wait(args)
+            return
+        result = await self.client.async_send_command(args)
         return cast(bool, result["success"])
 
     async def async_refresh_info(self) -> None:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -282,7 +282,9 @@ class Node(EventBase):
 
         self.emit(event.type, event.data)
 
-    async def async_set_value(self, val: Union[Value, str], new_value: Any) -> None:
+    async def async_set_value(
+        self, val: Union[Value, str], new_value: Any, wait_for_result: bool = False
+    ) -> Optional[bool]:
         """Send setValue command to Node for given value (or value_id)."""
         # a value may be specified as value_id or the value itself
         if not isinstance(val, Value):
@@ -292,14 +294,16 @@ class Node(EventBase):
             raise UnwriteableValue
 
         # the value object needs to be send to the server
-        await self.client.async_send_command_no_wait(
-            {
-                "command": "node.set_value",
-                "nodeId": self.node_id,
-                "valueId": val.data,
-                "value": new_value,
-            }
-        )
+        args = {
+            "command": "node.set_value",
+            "nodeId": self.node_id,
+            "valueId": val.data,
+            "value": new_value,
+        }
+        if wait_for_result:
+            result = await self.client.async_send_command(args)
+            return cast(bool, result)
+        await self.client.async_send_command_no_wait(args)
 
     async def async_refresh_info(self) -> None:
         """Send refreshInfo command to Node."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -304,6 +304,7 @@ class Node(EventBase):
             result = await self.client.async_send_command(args)
             return cast(bool, result)
         await self.client.async_send_command_no_wait(args)
+        return None
 
     async def async_refresh_info(self) -> None:
         """Send refreshInfo command to Node."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -284,7 +284,7 @@ class Node(EventBase):
 
     async def async_set_value(
         self, val: Union[Value, str], new_value: Any, no_wait: bool = False
-    ) -> bool:
+    ) -> Optional[bool]:
         """Send setValue command to Node for given value (or value_id)."""
         # a value may be specified as value_id or the value itself
         if not isinstance(val, Value):

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -100,7 +100,7 @@ async def async_set_config_parameter(
         )
 
     # Finally attempt to set the value and return the Value object if successful
-    if not await node.async_set_value(zwave_value, new_value):
+    if not await node.async_set_value(zwave_value, new_value, wait_for_result=True):
         raise SetValueFailed(
             "Unable to set value, refer to "
             "https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue for "


### PR DESCRIPTION
I'm still not sure if this is really needed but PR it anyway so we can decide what to do.
We got some reports about the integration locking up for some users that can be pinpointed to battery powered devices, for example thermostat (valves).

You send a new value to the device but it will take (a long) time before it's processed and currently we're awaiting the result forever.

According to a little discord discussion with @AlCalzone awaiting the setValue should return the bool indicating the command is processed and the promise resolved to the actual result. So actually I can't explain the lockup because you'd think we get a bool back right away after sending the command (and it's been put in the wake up queue by zwave-js)...

Linked issues:

https://github.com/home-assistant/core/issues/46357

https://github.com/home-assistant/core/issues/46363

https://github.com/home-assistant/core/issues/46648