### PR TITLE
Increase checkout fetch depth to 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2.2.1
         with:
@@ -40,6 +42,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 2
       - name: Download coverage data
         uses: actions/download-artifact@v2.0.8
         with:


### PR DESCRIPTION
- Try to solve the codecov CI action warning about not being able to detect the commit SHA.