### PR TITLE
Fix status updates for node

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -4,9 +4,9 @@ import json
 import pytest
 
 from zwave_js_server.const import CommandClass
+from zwave_js_server.event import Event
 from zwave_js_server.exceptions import UnwriteableValue
 from zwave_js_server.model import node as node_pkg
-from zwave_js_server.event import Event
 from zwave_js_server.model.node import NodeStatus
 
 from .. import load_fixture
@@ -292,5 +292,3 @@ async def test_node_status_events(multisensor_6):
     event = Event(type="sleep")
     node.handle_sleep(event)
     assert node.status == NodeStatus.ASLEEP
-
-    

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -273,7 +273,7 @@ def test_node_inclusion():
 
 
 async def test_node_status_events(multisensor_6):
-    """Test set value."""
+    """Test Node status events."""
     node = multisensor_6
     assert node.status == NodeStatus.ASLEEP
     # mock node wake up event

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -7,6 +7,7 @@ from zwave_js_server.const import CommandClass
 from zwave_js_server.exceptions import UnwriteableValue
 from zwave_js_server.model import node as node_pkg
 from zwave_js_server.event import Event
+from zwave_js_server.model.node import NodeStatus
 
 from .. import load_fixture
 
@@ -269,3 +270,27 @@ def test_node_inclusion():
     event = Event("ready", {"nodeState": state})
     node.receive_event(event)
     assert len(node.values) > 0
+
+
+async def test_node_status_events(multisensor_6):
+    """Test set value."""
+    node = multisensor_6
+    assert node.status == NodeStatus.ASLEEP
+    # mock node wake up event
+    event = Event(type="wake up")
+    node.handle_wake_up(event)
+    assert node.status == NodeStatus.AWAKE
+    # mock node dead event
+    event = Event(type="dead")
+    node.handle_dead(event)
+    assert node.status == NodeStatus.DEAD
+    # mock node alive event
+    event = Event(type="alive")
+    node.handle_alive(event)
+    assert node.status == NodeStatus.ALIVE
+    # mock node sleep event
+    event = Event(type="sleep")
+    node.handle_sleep(event)
+    assert node.status == NodeStatus.ASLEEP
+
+    

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -1,6 +1,7 @@
 """Provide a model for the Z-Wave JS node."""
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
 from zwave_js_server.const import CommandClass
+from enum import IntEnum
 
 from ..exceptions import UnparseableValue, UnwriteableValue
 from ..event import Event, EventBase
@@ -21,6 +22,20 @@ from .value import (
 
 if TYPE_CHECKING:
     from ..client import Client
+
+
+class NodeStatus(IntEnum):
+    """Enum with all Node status values.
+
+    https://zwave-js.github.io/node-zwave-js/#/api/node?id=status
+    """
+
+    UNKNOWN = 0
+    ASLEEP = 1
+    AWAKE = 2
+    DEAD = 3
+    ALIVE = 4
+
 
 
 class NodeDataType(TypedDict, total=False):
@@ -121,9 +136,9 @@ class Node(EventBase):
         return self.data.get("userIcon")
 
     @property
-    def status(self) -> int:
+    def status(self) -> NodeStatus:
         """Return the status."""
-        return self.data["status"]
+        return NodeStatus(self.data["status"])
 
     @property
     def ready(self) -> Optional[bool]:
@@ -376,15 +391,23 @@ class Node(EventBase):
 
     def handle_wake_up(self, event: Event) -> None:
         """Process a node wake up event."""
+        # pylint: disable=unused-argument
+        self.data["status"] = NodeStatus.AWAKE
 
     def handle_sleep(self, event: Event) -> None:
         """Process a node sleep event."""
+        # pylint: disable=unused-argument
+        self.data["status"] = NodeStatus.ASLEEP
 
     def handle_dead(self, event: Event) -> None:
         """Process a node dead event."""
+        # pylint: disable=unused-argument
+        self.data["status"] = NodeStatus.DEAD
 
     def handle_alive(self, event: Event) -> None:
         """Process a node alive event."""
+        # pylint: disable=unused-argument
+        self.data["status"] = NodeStatus.ALIVE
 
     def handle_interview_completed(self, event: Event) -> None:
         """Process a node interview completed event."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -1,10 +1,11 @@
 """Provide a model for the Z-Wave JS node."""
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
-from zwave_js_server.const import CommandClass
 from enum import IntEnum
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
 
-from ..exceptions import UnparseableValue, UnwriteableValue
+from zwave_js_server.const import CommandClass
+
 from ..event import Event, EventBase
+from ..exceptions import UnparseableValue, UnwriteableValue
 from .command_class import CommandClassInfo, CommandClassInfoDataType
 from .device_class import DeviceClass, DeviceClassDataType
 from .device_config import DeviceConfig, DeviceConfigDataType

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -38,7 +38,6 @@ class NodeStatus(IntEnum):
     ALIVE = 4
 
 
-
 class NodeDataType(TypedDict, total=False):
     """Represent a node data dict type."""
 


### PR DESCRIPTION
The frontend displays a node's status but it was never updated to reflect the correct value.
With this change we properly handle the status events and update this on the node instance.