### PR TITLE
Support string for log level in get_log_config

### DIFF
--- a/test/model/test_driver.py
+++ b/test/model/test_driver.py
@@ -87,7 +87,7 @@ async def test_update_log_config(driver, uuid4, mock_command):
 
 
 async def test_get_log_config(driver, uuid4, mock_command):
-    """Test set value."""
+    """Test get_log_config."""
     ack_commands = mock_command(
         {"command": "get_log_config"},
         {
@@ -95,6 +95,33 @@ async def test_get_log_config(driver, uuid4, mock_command):
             "config": {
                 "enabled": True,
                 "level": 0,
+                "logToFile": False,
+                "filename": "/test.txt",
+                "forceConsole": False,
+            },
+        },
+    )
+    log_config = await driver.async_get_log_config()
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {"command": "get_log_config", "messageId": uuid4}
+
+    assert log_config.enabled
+    assert log_config.level == LogLevel.ERROR
+    assert log_config.log_to_file is False
+    assert log_config.filename == "/test.txt"
+    assert log_config.force_console is False
+
+
+async def test_get_log_config_string(driver, uuid4, mock_command):
+    """Test get_log_config with a string for a log level."""
+    ack_commands = mock_command(
+        {"command": "get_log_config"},
+        {
+            "success": True,
+            "config": {
+                "enabled": True,
+                "level": "error",
                 "logToFile": False,
                 "filename": "/test.txt",
                 "forceConsole": False,

--- a/zwave_js_server/model/driver.py
+++ b/zwave_js_server/model/driver.py
@@ -1,9 +1,10 @@
 """Provide a model for the Z-Wave JS Driver."""
 from typing import TYPE_CHECKING
-from zwave_js_server.model.log_config import LogConfig
 
+from ..const import LogLevel
 from ..event import Event, EventBase
 from .controller import Controller
+from .log_config import LogConfig
 
 if TYPE_CHECKING:
     from ..client import Client
@@ -53,4 +54,7 @@ class Driver(EventBase):
     async def async_get_log_config(self) -> LogConfig:
         """Return current log config for driver."""
         result = await self.client.async_send_command({"command": "get_log_config"})
-        return LogConfig.from_dict(result["config"])
+        config = result["config"]
+        if isinstance(config.get("level"), str):
+            config["level"] = LogLevel[config["level"].upper()]
+        return LogConfig.from_dict(config)


### PR DESCRIPTION
From the conversation here: https://discord.com/channels/330944238910963714/800356888827002880/816067582812618782

We should expect `get_log_config` to return a string in the future. This change supports both the current version and the future version.