### PR TITLE
Assume value is on endpoint 0 when value notification is received without an endpoint and add find_value helper

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -306,7 +306,6 @@ async def test_value_notification(wallmote_central_scene: Node):
             "event": "value notification",
             "nodeId": 35,
             "args": {
-                "endpoint": 0,
                 "commandClass": 91,
                 "commandClassName": "Central Scene",
                 "property": "scene",

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -490,9 +490,7 @@ class Node(EventBase):
         if event.data["args"].get("endpoint") is None:
             event.data["args"]["endpoint"] = 0
 
-        value = self.values.get(
-            _get_value_id_from_dict(self, event.data["args"])
-        )
+        value = self.values.get(_get_value_id_from_dict(self, event.data["args"]))
 
         if value:
             value.update(event.data["args"])

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -491,7 +491,6 @@ class Node(EventBase):
             event.data["args"]["endpoint"] = 0
 
         value = self.values.get(_get_value_id_from_dict(self, event.data["args"]))
-
         if value:
             value.update(event.data["args"])
             value_notification = cast(ValueNotification, value)

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -1,6 +1,6 @@
 """Utility functions for Z-Wave JS nodes."""
 import json
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 from ..const import CommandClass, ConfigurationValueType
 from ..exceptions import InvalidNewValue, NotFoundError, SetValueFailed
@@ -25,17 +25,16 @@ async def async_set_config_parameter(
     # If a property name is provided, we have to search for the correct value since
     # we can't use value ID
     if isinstance(property_or_property_name, str):
-        try:
-            zwave_value = next(
-                config_value
-                for config_value in config_values.values()
-                if config_value.property_name == property_or_property_name
-            )
-        except StopIteration:
+        zwave_value = node.find_value(
+            command_class=CommandClass.CONFIGURATION,
+            property_name=property_or_property_name,
+        )
+        if not zwave_value:
             raise NotFoundError(
                 "Configuration parameter with parameter name "
                 f"{property_or_property_name} could not be found"
             ) from None
+        zwave_value = cast(ConfigurationValue, zwave_value)
     else:
         value_id = get_value_id(
             node,


### PR DESCRIPTION
https://github.com/home-assistant-libs/zwave-js-server-python/pull/147 was an attempt at fixing the issue users are facing in beta where the value notification is missing parameters because it is missing metadata (https://github.com/home-assistant/core/issues/47083 for context). The previous fix works when the endpoint is provided in the value notification, but from the examples posted (https://discord.com/channels/330944238910963714/800356888827002880/816498596924489768, https://github.com/home-assistant/core/issues/47083#issuecomment-789355704, and https://github.com/home-assistant/core/issues/47083#issuecomment-789357173) it appears that value notification events don't include an endpoint.

@kpine tested an earlier version of zwave-js-server and this appears to have always been the case. What changed is that we are now explicitly checking for `endpoint is None` before using `00` for the endpoint in the value ID, whereas before, `None` or `0` for the endpoint will result in `00` in the value ID. Reverting that change would be another breaking change. My proposed solution is to assume the endpoint is 0 if the endpoint is not provided, which from the docs () seems reasonable. I had originally implemented a value search when the endpoint wasn't provided but this solution is more targeted. I left the new helper in place because marcel indicated on Discord that he would have use for this function elsewhere

To test this, all I had to do was remove the endpoint from the `args` of a test event that was already being tested.