### PR TITLE
Fix exception

### DIFF
--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -165,7 +165,7 @@ class Client:
 
             state_msg = await self._receive_json_or_raise()
 
-            if not state_msg["success"]:
+            if not state_msg.get("success"):
                 await self._client.close()
                 raise FailedCommand(state_msg["messageId"], state_msg["errorCode"])
 


### PR DESCRIPTION
Exception was:
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/zwave_js/__init__.py", line 374, in client_listen
    await client.listen(driver_ready)
  File "/usr/local/lib/python3.8/site-packages/zwave_js_server/client.py", line 168, in listen
    if not state_msg["success"]:
KeyError: 'success'
```