### PR TITLE
Make sure ValueNotification includes the latest event data

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1,5 +1,6 @@
 """Test the node model."""
 import json
+from zwave_js_server.model.value import get_value_id
 
 import pytest
 
@@ -322,6 +323,7 @@ async def test_value_notification(wallmote_central_scene: Node):
     assert event.data["value_notification"].metadata.states
     assert event.data["value_notification"].endpoint is not None
     assert event.data["value_notification"].value == 1
+    assert node.values["35-91-0-scene-002"].value is None
 
     # Validate that a value notification event for an unknown value gets returned as is
     event = Event(

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -323,6 +323,7 @@ async def test_value_notification(wallmote_central_scene: Node):
     assert event.data["value_notification"].metadata.states
     assert event.data["value_notification"].endpoint is not None
     assert event.data["value_notification"].value == 1
+    # Let's make sure that the Value was not updated by the value notification event
     assert node.values["35-91-0-scene-002"].value is None
 
     # Validate that a value notification event for an unknown value gets returned as is

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -313,6 +313,7 @@ async def test_value_notification(wallmote_central_scene: Node):
                 "propertyName": "scene",
                 "propertyKeyName": "002",
                 "ccVersion": 2,
+                "value": 1,
             },
         },
     )
@@ -320,6 +321,7 @@ async def test_value_notification(wallmote_central_scene: Node):
     node.handle_value_notification(event)
     assert event.data["value_notification"].metadata.states
     assert event.data["value_notification"].endpoint is not None
+    assert event.data["value_notification"].value == 1
 
     # Validate that a value notification event for an unknown value gets returned as is
     event = Event(
@@ -336,20 +338,19 @@ async def test_value_notification(wallmote_central_scene: Node):
                 "propertyName": "scene",
                 "propertyKeyName": "005",
                 "ccVersion": 2,
+                "value": 2,
             },
         },
     )
 
     node.handle_value_notification(event)
-    assert event.data["value_notification"].data == {
-        "commandClass": 91,
-        "commandClassName": "Central Scene",
-        "property": "scene",
-        "propertyKey": "005",
-        "propertyName": "scene",
-        "propertyKeyName": "005",
-        "ccVersion": 2,
-    }
+    assert event.data["value_notification"].command_class == 91
+    assert event.data["value_notification"].command_class_name == "Central Scene"
+    assert event.data["value_notification"].property_ == "scene"
+    assert event.data["value_notification"].property_name == "scene"
+    assert event.data["value_notification"].property_key == "005"
+    assert event.data["value_notification"].property_key_name == "005"
+    assert event.data["value_notification"].value == 2
 
 
 async def test_metadata_updated(climate_radio_thermostat_ct100_plus: Node):

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1,6 +1,5 @@
 """Test the node model."""
 import json
-from zwave_js_server.model.value import get_value_id
 
 import pytest
 

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -455,13 +455,12 @@ class Node(EventBase):
         """Process a node value notification event."""
         # if value is found, use value data as base and update what is provided
         # in the event, otherwise use the event data
-        if value := self.values.get(
-            _get_value_id_from_dict(self, event.data["args"])
-        ):
+        event_data = event.data["args"]
+        if value := self.values.get(_get_value_id_from_dict(self, event_data)):
             value_notification = ValueNotification(self, value.data)
-            value_notification.update(event.data["args"])
+            value_notification.update(event_data)
         else:
-            value_notification = ValueNotification(self, event.data["args"])
+            value_notification = ValueNotification(self, event_data)
 
         event.data["value_notification"] = value_notification
 

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -460,7 +460,7 @@ class Node(EventBase):
             _get_value_id_from_dict(self, value_notification.data)
         ):
             value_notification.metadata.update(value.metadata.data)
-            if value_notification.endpoint is None:
+            if value_notification.endpoint is None and value.endpoint is not None:
                 value_notification.data["endpoint"] = value.endpoint
         event.data["value_notification"] = value_notification
 

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -455,12 +455,10 @@ class Node(EventBase):
         """Process a node value notification event."""
         # append metadata if value metadata is available
         value_notification = ValueNotification(self, event.data["args"])
-        value = self.values.get(_get_value_id_from_dict(self, value_notification.data))
-        if value:
-            # We update the Value first so that we can merge the Value back into
-            # ValueNotification
-            value.update(value_notification.data)
-            value_notification.update(value.data)
+        if value := self.values.get(
+            _get_value_id_from_dict(self, value_notification.data)
+        ):
+            value_notification.metadata.update(value.metadata.data)
         event.data["value_notification"] = value_notification
 
     def handle_metadata_updated(self, event: Event) -> None:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -453,10 +453,9 @@ class Node(EventBase):
 
     def handle_value_notification(self, event: Event) -> None:
         """Process a node value notification event."""
-        # append metadata if value metadata is available
         value_notification = ValueNotification(self, event.data["args"])
-        # If we find a Value associated with this value notification, include its
-        # metadata and endpoint if needed
+        # append metadata if value metadata is available and endpoint
+        # if value notification endpoint isn't provided
         if value := self.values.get(
             _get_value_id_from_dict(self, value_notification.data)
         ):

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -454,11 +454,13 @@ class Node(EventBase):
     def handle_value_notification(self, event: Event) -> None:
         """Process a node value notification event."""
         # append metadata if value metadata is available
-        value_notification = ValueNotification(self, event.data["args"])
         value = self.values.get(_get_value_id_from_dict(self, event.data["args"]))
         if value:
-            value_notification.update(value.data)
+            value_notification = ValueNotification(self, value.data)
+            value_notification.update(event.data["args"])
             value.update(event.data["args"])
+        else:
+            value_notification = ValueNotification(self, event.data["args"])
         event.data["value_notification"] = value_notification
 
     def handle_metadata_updated(self, event: Event) -> None:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -453,15 +453,16 @@ class Node(EventBase):
 
     def handle_value_notification(self, event: Event) -> None:
         """Process a node value notification event."""
-        value_notification = ValueNotification(self, event.data["args"])
-        # append metadata if value metadata is available and endpoint
-        # if value notification endpoint isn't provided
+        # if value is found, use value data as base and update what is provided
+        # in the event, otherwise use the event data
         if value := self.values.get(
-            _get_value_id_from_dict(self, value_notification.data)
+            _get_value_id_from_dict(self, event.data["args"])
         ):
-            value_notification.metadata.update(value.metadata.data)
-            if value_notification.endpoint is None and value.endpoint is not None:
-                value_notification.data["endpoint"] = value.endpoint
+            value_notification = ValueNotification(self, value.data)
+            value_notification.update(event.data["args"])
+        else:
+            value_notification = ValueNotification(self, event.data["args"])
+
         event.data["value_notification"] = value_notification
 
     def handle_metadata_updated(self, event: Event) -> None:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -455,15 +455,20 @@ class Node(EventBase):
         """Process a node value notification event."""
         # append metadata if value metadata is available
         value_notification = ValueNotification(self, event.data["args"])
+        # If we find a Value associated with this value notification, include its
+        # metadata and endpoint if needed
         if value := self.values.get(
             _get_value_id_from_dict(self, value_notification.data)
         ):
             value_notification.metadata.update(value.metadata.data)
+            if value_notification.endpoint is None:
+                value_notification.data["endpoint"] = value.endpoint
         event.data["value_notification"] = value_notification
 
     def handle_metadata_updated(self, event: Event) -> None:
         """Process a node metadata updated event."""
-        # handle metadata updated as value updated (as its a value object with included metadata)
+        # handle metadata updated as value updated (as its a value object with
+        # included metadata)
         self.handle_value_updated(event)
 
     def handle_notification(self, event: Event) -> None:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -454,13 +454,13 @@ class Node(EventBase):
     def handle_value_notification(self, event: Event) -> None:
         """Process a node value notification event."""
         # append metadata if value metadata is available
-        value = self.values.get(_get_value_id_from_dict(self, event.data["args"]))
+        value_notification = ValueNotification(self, event.data["args"])
+        value = self.values.get(_get_value_id_from_dict(self, value_notification.data))
         if value:
-            value_notification = ValueNotification(self, value.data)
-            value_notification.update(event.data["args"])
-            value.update(event.data["args"])
-        else:
-            value_notification = ValueNotification(self, event.data["args"])
+            # We update the Value first so that we can merge the Value back into
+            # ValueNotification
+            value.update(value_notification.data)
+            value_notification.update(value.data)
         event.data["value_notification"] = value_notification
 
     def handle_metadata_updated(self, event: Event) -> None:


### PR DESCRIPTION
In #154 the order of operations for creating the `ValueNotification` was wrong and led to the value that came in the notification being returned as the value that we was previously in the state (see https://github.com/home-assistant/core/issues/47432). This fixes the order of operations.


I could use some help writing some good test cases for this one, I don't think we have enough given all the issues that have occurred as we try to fix this