### PR TITLE
Add selective wait for node command response when device is awake

### DIFF
--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -1,6 +1,5 @@
 """Provide a model for the Z-Wave JS node."""
 from enum import IntEnum
-import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
 
 from zwave_js_server.const import CommandClass
@@ -374,13 +373,13 @@ class Node(EventBase):
             "get_defined_value_ids", wait_for_result=True
         )
         if data is not None:
-            return [
-                Value(self, cast(ValueDataType, valueId))
-                for valueId in data["valueIds"]
-            ]
-        else:
             # We should never reach this code
             raise FailedCommand("Command failed", "failed_command")
+
+        return [
+            Value(self, cast(ValueDataType, valueId))
+            for valueId in data["valueIds"]
+        ]
 
     async def async_get_value_metadata(self, val: Union[Value, str]) -> ValueMetadata:
         """Send getValueMetadata command to Node."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -362,7 +362,7 @@ class Node(EventBase):
         if result is None:
             return None
 
-        return result["success"]
+        return cast(bool, result["success"])
 
     async def async_refresh_info(self) -> None:
         """Send refreshInfo command to Node."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -24,6 +24,7 @@ from .value import (
 if TYPE_CHECKING:
     from ..client import Client
 
+
 class NodeStatus(IntEnum):
     """Enum with all Node status values.
 

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -325,7 +325,7 @@ class Node(EventBase):
         """
         kwargs = {}
         message = {"command": f"node.{cmd}", "nodeId": self.node_id, **cmd_kwargs}
-
+        logging.getLogger(__name__).error(message)
         if require_schema is not None:
             kwargs["require_schema"] = require_schema
 
@@ -372,7 +372,7 @@ class Node(EventBase):
         data = await self._async_send_command(
             "get_defined_value_ids", wait_for_result=True
         )
-        if data is not None:
+        if data is None:
             # We should never reach this code
             raise FailedCommand("Command failed", "failed_command")
 

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -328,7 +328,9 @@ class Node(EventBase):
         if require_schema is not None:
             kwargs["require_schema"] = require_schema
 
-        if wait_for_result or self.status != NodeStatus.ASLEEP:
+        if wait_for_result or (
+            wait_for_result is None and self.status != NodeStatus.ASLEEP
+        ):
             result = await self.client.async_send_command(message, **kwargs)
             return result
 

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -24,7 +24,6 @@ from .value import (
 if TYPE_CHECKING:
     from ..client import Client
 
-
 class NodeStatus(IntEnum):
     """Enum with all Node status values.
 
@@ -314,9 +313,9 @@ class Node(EventBase):
         self,
         cmd: str,
         require_schema: Optional[int] = None,
-        wait_for_result: bool = None,
+        wait_for_result: Optional[bool] = None,
         **cmd_kwargs: Any,
-    ) -> Optional[Any]:
+    ) -> Optional[Dict[str, Any]]:
         """
         Send a node command. For internal use only.
 
@@ -362,7 +361,7 @@ class Node(EventBase):
         if result is None:
             return None
 
-        return cast(bool, result)
+        return isinstance(result, dict) and result.get("success", False)
 
     async def async_refresh_info(self) -> None:
         """Send refreshInfo command to Node."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -325,7 +325,6 @@ class Node(EventBase):
         """
         kwargs = {}
         message = {"command": f"node.{cmd}", "nodeId": self.node_id, **cmd_kwargs}
-        logging.getLogger(__name__).error(message)
         if require_schema is not None:
             kwargs["require_schema"] = require_schema
 
@@ -372,13 +371,12 @@ class Node(EventBase):
         data = await self._async_send_command(
             "get_defined_value_ids", wait_for_result=True
         )
+
         if data is None:
             # We should never reach this code
             raise FailedCommand("Command failed", "failed_command")
-
         return [
-            Value(self, cast(ValueDataType, valueId))
-            for valueId in data["valueIds"]
+            Value(self, cast(ValueDataType, valueId)) for valueId in data["valueIds"]
         ]
 
     async def async_get_value_metadata(self, val: Union[Value, str]) -> ValueMetadata:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -362,7 +362,7 @@ class Node(EventBase):
         if result is None:
             return None
 
-        return isinstance(result, dict) and result.get("success", False)
+        return result["success"]
 
     async def async_refresh_info(self) -> None:
         """Send refreshInfo command to Node."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -311,15 +311,15 @@ class Node(EventBase):
 
         self.emit(event.type, event.data)
 
-    async def async_send_command(
+    async def _async_send_command(
         self,
         cmd: str,
         require_schema: Optional[int] = None,
         wait_for_result: bool = None,
-        **cmd_kwargs,
+        **cmd_kwargs: Any,
     ) -> Optional[Any]:
         """
-        Send a node command.
+        Send a node command. For internal use only.
 
         If wait_for_result is not None, it will take precedence, otherwise we will decide to wait
         or not based on the node status.
@@ -352,7 +352,7 @@ class Node(EventBase):
             raise UnwriteableValue
 
         # the value object needs to be send to the server
-        result = await self.async_send_command(
+        result = await self._async_send_command(
             "set_value",
             valueId=val.data,
             value=new_value,
@@ -366,11 +366,11 @@ class Node(EventBase):
 
     async def async_refresh_info(self) -> None:
         """Send refreshInfo command to Node."""
-        await self.async_send_command("refresh_info", wait_for_result=False)
+        await self._async_send_command("refresh_info", wait_for_result=False)
 
     async def async_get_defined_value_ids(self) -> List[Value]:
         """Send getDefinedValueIDs command to Node."""
-        data = await self.async_send_command(
+        data = await self._async_send_command(
             "get_defined_value_ids", wait_for_result=True
         )
         if data is not None:
@@ -388,21 +388,21 @@ class Node(EventBase):
         if not isinstance(val, Value):
             val = self.values[val]
         # the value object needs to be send to the server
-        data = await self.async_send_command(
+        data = await self._async_send_command(
             "get_value_metadata", valueId=val.data, wait_for_result=True
         )
         return ValueMetadata(cast(MetaDataType, data))
 
     async def async_abort_firmware_update(self) -> None:
         """Send abortFirmwareUpdate command to Node."""
-        await self.async_send_command("abort_firmware_update", wait_for_result=False)
+        await self._async_send_command("abort_firmware_update", wait_for_result=False)
 
     async def async_poll_value(self, val: Union[Value, str]) -> None:
         """Send pollValue command to Node for given value (or value_id)."""
         # a value may be specified as value_id or the value itself
         if not isinstance(val, Value):
             val = self.values[val]
-        await self.async_send_command("poll_value", valueId=val.data, require_schema=1)
+        await self._async_send_command("poll_value", valueId=val.data, require_schema=1)
 
     def handle_wake_up(self, event: Event) -> None:
         """Process a node wake up event."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -351,16 +351,12 @@ class Node(EventBase):
         if val.metadata.writeable is False:
             raise UnwriteableValue
 
-        params = {
-            "valueId": val.data,
-            "value": new_value,
-        }
-
         # the value object needs to be send to the server
         result = await self.async_send_command(
             "set_value",
+            valueId=val.data,
+            value=new_value,
             wait_for_result=wait_for_result,
-            **params,
         )
 
         if result is None:

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -100,7 +100,7 @@ async def async_set_config_parameter(
         )
 
     # Finally attempt to set the value and return the Value object if successful
-    if not await node.async_set_value(zwave_value, new_value, wait_for_result=True):
+    if await node.async_set_value(zwave_value, new_value) is False:
         raise SetValueFailed(
             "Unable to set value, refer to "
             "https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue for "


### PR DESCRIPTION
It was easier to write the code to make this proposal than to discuss it on Discord, but this is just an idea that I am looking for feedback on.

Right now, we have updated `node.async_set_value` to support selectively waiting and not waiting for the result of the command, but this distinction has value for other commands as well (like `async_poll_value`). In this PR, I created an internal node function `node._async_send_command` that optionally allows the caller to force a wait or non-wait but can also decide what to do based on the node status.