### PR TITLE
Add allowManualEntry metadata

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -77,6 +77,12 @@ def client_session_fixture(ws_client):
     return client_session
 
 
+@pytest.fixture(name="inovelli_switch_state", scope="session")
+def inovelli_switch_state_fixture():
+    """Load the bad string meta data node state fixture data."""
+    return json.loads(load_fixture("inovelli_switch_state.json"))
+
+
 def create_ws_message(result):
     """Return a mock WSMessage."""
     message = Mock(spec_set=WSMessage)
@@ -312,3 +318,11 @@ def controller_fixture(driver, controller_state):
     """Return a controller instance with a supporting client."""
     controller = Controller(driver.client, controller_state)
     return controller
+
+
+@pytest.fixture(name="inovelli_switch")
+def inovelli_switch_fixture(driver, inovelli_switch_state):
+    """Mock a radio thermostat node."""
+    node = Node(driver.client, inovelli_switch_state)
+    driver.controller.nodes[node.node_id] = node
+    return node

--- a/test/fixtures/inovelli_switch_state.json
+++ b/test/fixtures/inovelli_switch_state.json
@@ -1,0 +1,1048 @@
+{
+    "nodeId": 31,
+    "index": 0,
+    "installerIcon": 1793,
+    "userIcon": 1793,
+    "status": 4,
+    "ready": true,
+    "isListening": true,
+    "isFrequentListening": false,
+    "isRouting": true,
+    "maxBaudRate": 40000,
+    "isSecure": false,
+    "version": 4,
+    "isBeaming": true,
+    "manufacturerId": 798,
+    "productId": 1,
+    "productType": 2,
+    "firmwareVersion": "1.9",
+    "zwavePlusVersion": 1,
+    "nodeType": 0,
+    "roleType": 5,
+    "deviceConfig": {
+      "filename": "/usr/src/app/node_modules/@zwave-js/config/config/devices/0x031e/lzw30-sn.json",
+      "manufacturerId": 798,
+      "manufacturer": "Inovelli",
+      "label": "LZW30-SN",
+      "description": "Red Series On/Off switch",
+      "devices": [
+        {
+          "productType": "0x0002",
+          "productId": "0x0001"
+        }
+      ],
+      "firmwareVersion": {
+        "min": "0.0",
+        "max": "255.255"
+      },
+      "paramInformation": {
+        "_map": {}
+      }
+    },
+    "label": "LZW30-SN",
+    "neighbors": [
+      17,
+      32,
+      33,
+      36,
+      37,
+      38,
+      39,
+      41,
+      42
+    ],
+    "interviewAttempts": 1,
+    "interviewStage": 7,
+    "endpoints": [
+      {
+        "nodeId": 31,
+        "index": 0,
+        "installerIcon": 1793,
+        "userIcon": 1793
+      }
+    ],
+    "values": [
+      {
+        "endpoint": 0,
+        "commandClass": 37,
+        "commandClassName": "Binary Switch",
+        "property": "currentValue",
+        "propertyName": "currentValue",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "boolean",
+          "readable": true,
+          "writeable": false,
+          "label": "Current value"
+        },
+        "value": false
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 37,
+        "commandClassName": "Binary Switch",
+        "property": "targetValue",
+        "propertyName": "targetValue",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "boolean",
+          "readable": true,
+          "writeable": true,
+          "label": "Target value"
+        },
+        "value": false
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 50,
+        "commandClassName": "Meter",
+        "property": "value",
+        "propertyKey": 65537,
+        "propertyName": "value",
+        "propertyKeyName": "Electric_kWh_Consumed",
+        "ccVersion": 3,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "label": "Electric Consumed [kWh]",
+          "unit": "kWh",
+          "ccSpecific": {
+            "meterType": 1,
+            "rateType": 1,
+            "scale": 0
+          }
+        },
+        "value": 26.75
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 50,
+        "commandClassName": "Meter",
+        "property": "previousValue",
+        "propertyKey": 65537,
+        "propertyName": "previousValue",
+        "propertyKeyName": "Electric_kWh_Consumed",
+        "ccVersion": 3,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "label": "Electric Consumed [kWh] (prev. value)",
+          "unit": "kWh",
+          "ccSpecific": {
+            "meterType": 1,
+            "rateType": 1,
+            "scale": 0
+          }
+        },
+        "value": 26.75
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 50,
+        "commandClassName": "Meter",
+        "property": "deltaTime",
+        "propertyKey": 65537,
+        "propertyName": "deltaTime",
+        "propertyKeyName": "Electric_kWh_Consumed",
+        "ccVersion": 3,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "label": "Electric Consumed [kWh] (prev. time delta)",
+          "unit": "s",
+          "ccSpecific": {
+            "meterType": 1,
+            "rateType": 1,
+            "scale": 0
+          }
+        },
+        "value": 3600
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 50,
+        "commandClassName": "Meter",
+        "property": "value",
+        "propertyKey": 66049,
+        "propertyName": "value",
+        "propertyKeyName": "Electric_W_Consumed",
+        "ccVersion": 3,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "label": "Electric Consumed [W]",
+          "unit": "W",
+          "ccSpecific": {
+            "meterType": 1,
+            "rateType": 1,
+            "scale": 2
+          }
+        },
+        "value": 0
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 50,
+        "commandClassName": "Meter",
+        "property": "deltaTime",
+        "propertyKey": 66049,
+        "propertyName": "deltaTime",
+        "propertyKeyName": "Electric_W_Consumed",
+        "ccVersion": 3,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "label": "Electric Consumed [W] (prev. time delta)",
+          "unit": "s",
+          "ccSpecific": {
+            "meterType": 1,
+            "rateType": 1,
+            "scale": 2
+          }
+        },
+        "value": 0
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 50,
+        "commandClassName": "Meter",
+        "property": "reset",
+        "propertyName": "reset",
+        "ccVersion": 3,
+        "metadata": {
+          "type": "boolean",
+          "readable": false,
+          "writeable": true,
+          "label": "Reset accumulated values"
+        }
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 50,
+        "commandClassName": "Meter",
+        "property": "previousValue",
+        "propertyKey": 66049,
+        "propertyName": "previousValue",
+        "propertyKeyName": "Electric_W_Consumed",
+        "ccVersion": 3,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "label": "Electric Consumed [W] (prev. value)",
+          "unit": "W",
+          "ccSpecific": {
+            "meterType": 1,
+            "rateType": 1,
+            "scale": 2
+          }
+        }
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 91,
+        "commandClassName": "Central Scene",
+        "property": "slowRefresh",
+        "propertyName": "slowRefresh",
+        "ccVersion": 3,
+        "metadata": {
+          "type": "boolean",
+          "readable": true,
+          "writeable": true,
+          "label": "Send held down notifications at a slow rate",
+          "description": "When this is true, KeyHeldDown notifications are sent every 55s. When this is false, the notifications are sent every 200ms."
+        }
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 91,
+        "commandClassName": "Central Scene",
+        "property": "scene",
+        "propertyKey": "001",
+        "propertyName": "scene",
+        "propertyKeyName": "001",
+        "ccVersion": 3,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "min": 0,
+          "max": 255,
+          "label": "Scene 001",
+          "states": {
+            "0": "KeyPressed",
+            "1": "KeyReleased",
+            "2": "KeyHeldDown",
+            "3": "KeyPressed2x",
+            "4": "KeyPressed3x",
+            "5": "KeyPressed4x",
+            "6": "KeyPressed5x"
+          }
+        }
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 91,
+        "commandClassName": "Central Scene",
+        "property": "scene",
+        "propertyKey": "002",
+        "propertyName": "scene",
+        "propertyKeyName": "002",
+        "ccVersion": 3,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "min": 0,
+          "max": 255,
+          "label": "Scene 002",
+          "states": {
+            "0": "KeyPressed",
+            "1": "KeyReleased",
+            "2": "KeyHeldDown",
+            "3": "KeyPressed2x",
+            "4": "KeyPressed3x",
+            "5": "KeyPressed4x",
+            "6": "KeyPressed5x"
+          }
+        }
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 91,
+        "commandClassName": "Central Scene",
+        "property": "scene",
+        "propertyKey": "003",
+        "propertyName": "scene",
+        "propertyKeyName": "003",
+        "ccVersion": 3,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "min": 0,
+          "max": 255,
+          "label": "Scene 003",
+          "states": {
+            "0": "KeyPressed"
+          }
+        }
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 1,
+        "propertyName": "Power On State",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 1,
+          "min": 0,
+          "max": 2,
+          "default": 0,
+          "format": 0,
+          "allowManualEntry": false,
+          "states": {
+            "0": "Prior State",
+            "1": "On",
+            "2": "Off"
+          },
+          "label": "Power On State",
+          "isFromConfig": true
+        },
+        "value": 0
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 2,
+        "propertyName": "Invert Switch",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 1,
+          "min": 0,
+          "max": 1,
+          "default": 0,
+          "format": 0,
+          "allowManualEntry": false,
+          "states": {
+            "0": "Disabled",
+            "1": "Enabled"
+          },
+          "label": "Invert Switch",
+          "isFromConfig": true
+        },
+        "value": 0
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 3,
+        "propertyName": "Auto Off Timer",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 2,
+          "min": 0,
+          "max": 32767,
+          "default": 0,
+          "unit": "seconds",
+          "format": 0,
+          "allowManualEntry": true,
+          "label": "Auto Off Timer",
+          "isFromConfig": true
+        },
+        "value": 0
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 4,
+        "propertyName": "Association Behavior",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 1,
+          "min": 0,
+          "max": 15,
+          "default": 15,
+          "format": 0,
+          "allowManualEntry": true,
+          "label": "Association Behavior",
+          "isFromConfig": true
+        },
+        "value": 15
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 5,
+        "propertyName": "LED Indicator Color",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 2,
+          "min": 0,
+          "max": 255,
+          "default": 170,
+          "format": 0,
+          "allowManualEntry": true,
+          "states": {
+            "0": "Red",
+            "21": "Orange",
+            "42": "Yellow",
+            "85": "Green",
+            "127": "Cyan",
+            "170": "Blue",
+            "212": "Violet",
+            "234": "Pink"
+          },
+          "label": "LED Indicator Color",
+          "isFromConfig": true
+        },
+        "value": 170
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 6,
+        "propertyName": "LED Indicator Intensity",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 1,
+          "min": 0,
+          "max": 10,
+          "default": 5,
+          "format": 0,
+          "allowManualEntry": false,
+          "states": {
+            "0": "Off",
+            "1": "10%",
+            "2": "20%",
+            "3": "30%",
+            "4": "40%",
+            "5": "50%",
+            "6": "60%",
+            "7": "70%",
+            "8": "80%",
+            "9": "90%",
+            "10": "100%"
+          },
+          "label": "LED Indicator Intensity",
+          "isFromConfig": true
+        },
+        "value": 5
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 7,
+        "propertyName": "LED Indicator Intensity (When Off)",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 1,
+          "min": 0,
+          "max": 10,
+          "default": 1,
+          "format": 0,
+          "allowManualEntry": false,
+          "states": {
+            "0": "Off",
+            "1": "10%",
+            "2": "20%",
+            "3": "30%",
+            "4": "40%",
+            "5": "50%",
+            "6": "60%",
+            "7": "70%",
+            "8": "80%",
+            "9": "90%",
+            "10": "100%"
+          },
+          "label": "LED Indicator Intensity (When Off)",
+          "isFromConfig": true
+        },
+        "value": 1
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 9,
+        "propertyName": "LED Strip Timeout",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 1,
+          "min": 0,
+          "max": 10,
+          "default": 0,
+          "unit": "seconds",
+          "format": 0,
+          "allowManualEntry": false,
+          "states": {
+            "0": "Stay Off",
+            "1": "One Second",
+            "2": "Two Seconds",
+            "3": "Three Seconds",
+            "4": "Four Seconds",
+            "5": "Five Seconds",
+            "6": "Six Seconds",
+            "7": "Seven Seconds",
+            "8": "Eight Seconds",
+            "9": "Nine Seconds",
+            "10": "Ten Seconds"
+          },
+          "label": "LED Strip Timeout",
+          "isFromConfig": true
+        },
+        "value": 3
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 10,
+        "propertyName": "Active Power Reports",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 1,
+          "min": 0,
+          "max": 100,
+          "default": 10,
+          "unit": "percent",
+          "format": 0,
+          "allowManualEntry": true,
+          "label": "Active Power Reports",
+          "isFromConfig": true
+        },
+        "value": 10
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 11,
+        "propertyName": "Periodic Power & Energy Reports",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 2,
+          "min": 0,
+          "max": 32767,
+          "default": 3600,
+          "unit": "seconds",
+          "format": 0,
+          "allowManualEntry": true,
+          "label": "Periodic Power & Energy Reports",
+          "isFromConfig": true
+        },
+        "value": 3600
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 12,
+        "propertyName": "Energy Reports",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 1,
+          "min": 0,
+          "max": 100,
+          "default": 10,
+          "unit": "percent",
+          "format": 0,
+          "allowManualEntry": true,
+          "label": "Energy Reports",
+          "isFromConfig": true
+        },
+        "value": 10
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 8,
+        "propertyKey": 255,
+        "propertyName": "LED Strip Effect (Color)",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 4,
+          "min": 0,
+          "max": 255,
+          "default": 0,
+          "format": 0,
+          "allowManualEntry": true,
+          "states": {
+            "0": "Red",
+            "21": "Orange",
+            "42": "Yellow",
+            "85": "Green",
+            "127": "Cyan",
+            "170": "Blue",
+            "212": "Violet",
+            "234": "Pink"
+          },
+          "label": "LED Strip Effect (Color)",
+          "isFromConfig": true
+        },
+        "value": 180
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 8,
+        "propertyKey": 65280,
+        "propertyName": "LED Strip Effect (Brightness)",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 4,
+          "min": 0,
+          "max": 10,
+          "default": 0,
+          "format": 0,
+          "allowManualEntry": false,
+          "states": {
+            "0": "Off",
+            "1": "10%",
+            "2": "20%",
+            "3": "30%",
+            "4": "40%",
+            "5": "50%",
+            "6": "60%",
+            "7": "70%",
+            "8": "80%",
+            "9": "90%",
+            "10": "100%"
+          },
+          "label": "LED Strip Effect (Brightness)",
+          "isFromConfig": true
+        },
+        "value": 10
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 8,
+        "propertyKey": 16711680,
+        "propertyName": "LED Strip Effect (Duration)",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 4,
+          "min": 0,
+          "max": 255,
+          "default": 0,
+          "format": 0,
+          "allowManualEntry": true,
+          "label": "LED Strip Effect (Duration)",
+          "isFromConfig": true
+        },
+        "value": 255
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 112,
+        "commandClassName": "Configuration",
+        "property": 8,
+        "propertyKey": 2130706432,
+        "propertyName": "LED Strip Effect (Effect)",
+        "ccVersion": 1,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "valueSize": 4,
+          "min": 0,
+          "max": 4,
+          "default": 0,
+          "format": 0,
+          "allowManualEntry": false,
+          "states": {
+            "0": "Off",
+            "1": "Solid",
+            "2": "Fast Blink",
+            "3": "Slow Blink",
+            "4": "Pulse"
+          },
+          "label": "LED Strip Effect (Effect)",
+          "isFromConfig": true
+        },
+        "value": 4
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 114,
+        "commandClassName": "Manufacturer Specific",
+        "property": "manufacturerId",
+        "propertyName": "manufacturerId",
+        "ccVersion": 2,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "min": 0,
+          "max": 65535,
+          "label": "Manufacturer ID"
+        },
+        "value": 798
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 114,
+        "commandClassName": "Manufacturer Specific",
+        "property": "productType",
+        "propertyName": "productType",
+        "ccVersion": 2,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "min": 0,
+          "max": 65535,
+          "label": "Product type"
+        },
+        "value": 2
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 114,
+        "commandClassName": "Manufacturer Specific",
+        "property": "productId",
+        "propertyName": "productId",
+        "ccVersion": 2,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": false,
+          "min": 0,
+          "max": 65535,
+          "label": "Product ID"
+        },
+        "value": 1
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 117,
+        "commandClassName": "Protection",
+        "property": "local",
+        "propertyName": "local",
+        "ccVersion": 2,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "label": "Local protection state",
+          "states": {
+            "8": "unknown (0x08)",
+            "9": "unknown (0x09)",
+            "10": "unknown (0x0a)"
+          }
+        },
+        "value": 0
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 117,
+        "commandClassName": "Protection",
+        "property": "rf",
+        "propertyName": "rf",
+        "ccVersion": 2,
+        "metadata": {
+          "type": "number",
+          "readable": true,
+          "writeable": true,
+          "label": "RF protection state",
+          "states": {
+            "8": "unknown (0x08)",
+            "9": "unknown (0x09)",
+            "10": "unknown (0x0a)"
+          }
+        },
+        "value": 0
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 117,
+        "commandClassName": "Protection",
+        "property": "exclusiveControlNodeId",
+        "propertyName": "exclusiveControlNodeId",
+        "ccVersion": 2,
+        "metadata": {
+          "type": "any",
+          "readable": true,
+          "writeable": true
+        }
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 117,
+        "commandClassName": "Protection",
+        "property": "timeout",
+        "propertyName": "timeout",
+        "ccVersion": 2,
+        "metadata": {
+          "type": "any",
+          "readable": true,
+          "writeable": true
+        }
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 134,
+        "commandClassName": "Version",
+        "property": "libraryType",
+        "propertyName": "libraryType",
+        "ccVersion": 2,
+        "metadata": {
+          "type": "any",
+          "readable": true,
+          "writeable": false,
+          "label": "Library type"
+        },
+        "value": 3
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 134,
+        "commandClassName": "Version",
+        "property": "protocolVersion",
+        "propertyName": "protocolVersion",
+        "ccVersion": 2,
+        "metadata": {
+          "type": "any",
+          "readable": true,
+          "writeable": false,
+          "label": "Z-Wave protocol version"
+        },
+        "value": "6.4"
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 134,
+        "commandClassName": "Version",
+        "property": "firmwareVersions",
+        "propertyName": "firmwareVersions",
+        "ccVersion": 2,
+        "metadata": {
+          "type": "any",
+          "readable": true,
+          "writeable": false,
+          "label": "Z-Wave chip firmware versions"
+        },
+        "value": [
+          "1.9"
+        ]
+      },
+      {
+        "endpoint": 0,
+        "commandClass": 134,
+        "commandClassName": "Version",
+        "property": "hardwareVersion",
+        "propertyName": "hardwareVersion",
+        "ccVersion": 2,
+        "metadata": {
+          "type": "any",
+          "readable": true,
+          "writeable": false,
+          "label": "Z-Wave chip hardware version"
+        }
+      }
+    ],
+    "deviceClass": {
+      "basic": {
+        "key": 4,
+        "label": "Routing Slave"
+      },
+      "generic": {
+        "key": 16,
+        "label": "Binary Switch"
+      },
+      "specific": {
+        "key": 1,
+        "label": "Binary Power Switch"
+      },
+      "mandatorySupportedCCs": [
+        32,
+        37,
+        39
+      ],
+      "mandatoryControlledCCs": []
+    },
+    "commandClasses": [
+      {
+        "id": 37,
+        "name": "Binary Switch",
+        "version": 1,
+        "isSecure": false
+      },
+      {
+        "id": 50,
+        "name": "Meter",
+        "version": 3,
+        "isSecure": false
+      },
+      {
+        "id": 89,
+        "name": "Association Group Information",
+        "version": 1,
+        "isSecure": false
+      },
+      {
+        "id": 90,
+        "name": "Device Reset Locally",
+        "version": 1,
+        "isSecure": false
+      },
+      {
+        "id": 91,
+        "name": "Central Scene",
+        "version": 3,
+        "isSecure": false
+      },
+      {
+        "id": 94,
+        "name": "Z-Wave Plus Info",
+        "version": 2,
+        "isSecure": false
+      },
+      {
+        "id": 108,
+        "name": "Supervision",
+        "version": 1,
+        "isSecure": false
+      },
+      {
+        "id": 112,
+        "name": "Configuration",
+        "version": 1,
+        "isSecure": false
+      },
+      {
+        "id": 114,
+        "name": "Manufacturer Specific",
+        "version": 2,
+        "isSecure": false
+      },
+      {
+        "id": 117,
+        "name": "Protection",
+        "version": 2,
+        "isSecure": false
+      },
+      {
+        "id": 122,
+        "name": "Firmware Update Meta Data",
+        "version": 4,
+        "isSecure": false
+      },
+      {
+        "id": 133,
+        "name": "Association",
+        "version": 2,
+        "isSecure": false
+      },
+      {
+        "id": 134,
+        "name": "Version",
+        "version": 2,
+        "isSecure": false
+      },
+      {
+        "id": 152,
+        "name": "Security",
+        "version": 1,
+        "isSecure": true
+      }
+    ]
+  }

--- a/test/model/test_value.py
+++ b/test/model/test_value.py
@@ -1,8 +1,7 @@
 """Test value model."""
-from zwave_js_server.const import CommandClass, ConfigurationValueType
+from zwave_js_server.const import ConfigurationValueType
 from zwave_js_server.model.node import Node
 from zwave_js_server.model.value import get_value_id
-from zwave_js_server.util.node import async_set_config_parameter
 
 
 def test_buffer_dict(client, idl_101_lock_state):

--- a/test/model/test_value.py
+++ b/test/model/test_value.py
@@ -1,6 +1,8 @@
 """Test value model."""
+from zwave_js_server.const import CommandClass, ConfigurationValueType
 from zwave_js_server.model.node import Node
 from zwave_js_server.model.value import get_value_id
+from zwave_js_server.util.node import async_set_config_parameter
 
 
 def test_buffer_dict(client, idl_101_lock_state):
@@ -25,3 +27,15 @@ def test_unparseable_value(client, unparseable_json_string_value_state):
 
     assert value_id == "20-99-0-userCode-4"
     assert value_id not in node.values
+
+
+def test_allow_manual_entry(client, inovelli_switch_state):
+    """Test that allow_manaual_entry works correctly."""
+    node = Node(client, inovelli_switch_state)
+
+    config_values = node.get_configuration_values()
+    value_id = get_value_id(node, 112, 8, 0, 255)
+
+    zwave_value = config_values[value_id]
+
+    assert zwave_value.configuration_value_type == ConfigurationValueType.RANGE

--- a/test/model/test_value.py
+++ b/test/model/test_value.py
@@ -38,3 +38,8 @@ def test_allow_manual_entry(client, inovelli_switch_state):
     zwave_value = config_values[value_id]
 
     assert zwave_value.configuration_value_type == ConfigurationValueType.RANGE
+
+    value_id = get_value_id(node, 112, 8, 0, 65280)
+    zwave_value = config_values[value_id]
+
+    assert zwave_value.configuration_value_type == ConfigurationValueType.ENUMERATED

--- a/test/model/test_value.py
+++ b/test/model/test_value.py
@@ -37,7 +37,7 @@ def test_allow_manual_entry(client, inovelli_switch_state):
 
     zwave_value = config_values[value_id]
 
-    assert zwave_value.configuration_value_type == ConfigurationValueType.RANGE
+    assert zwave_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
 
     value_id = get_value_id(node, 112, 8, 0, 65280)
     zwave_value = config_values[value_id]

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -33,11 +33,11 @@ async def test_configuration_parameter_values(
     with pytest.raises(NotImplementedError):
         await async_set_config_parameter(node, 1, 2)
 
-    # Test setting an manual entry configuration parameter with an invalid value
+    # Test setting a manual entry configuration parameter with an invalid value
     with pytest.raises(InvalidNewValue):
         await async_set_config_parameter(node_2, "Purple", 8, 255)
 
-    # Test setting an manual entry configuration parameter with an valid value
+    # Test setting a manual entry configuration parameter with a valid value
     ack_commands_2 = mock_command(
         {"command": "node.set_value", "nodeId": node_2.node_id},
         {"success": True},

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -55,6 +55,18 @@ async def test_configuration_parameter_values(
         "messageId": uuid4,
     }
 
+    await async_set_config_parameter(node_2, "Blue", 8, 255)
+
+    value = node_2.values["31-112-0-8-255"]
+    assert len(ack_commands_2) == 2
+    assert ack_commands_2[1] == {
+        "command": "node.set_value",
+        "nodeId": node_2.node_id,
+        "valueId": value.data,
+        "value": 170,
+        "messageId": uuid4,
+    }
+
     # Test setting an enumerated configuration parameter with an invalid value
     with pytest.raises(InvalidNewValue):
         await async_set_config_parameter(node, 5, 1)
@@ -81,8 +93,8 @@ async def test_configuration_parameter_values(
     )
 
     value = node.values["13-112-0-1"]
-    assert len(ack_commands) == 2
-    assert ack_commands[1] == {
+    assert len(ack_commands) == 3
+    assert ack_commands[2] == {
         "command": "node.set_value",
         "nodeId": node.node_id,
         "valueId": value.data,

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -37,6 +37,24 @@ async def test_configuration_parameter_values(
     with pytest.raises(InvalidNewValue):
         await async_set_config_parameter(node_2, "Purple", 8, 255)
 
+    # Test setting an manual entry configuration parameter with an valid value
+    ack_commands_2 = mock_command(
+        {"command": "node.set_value", "nodeId": node_2.node_id},
+        {"success": True},
+    )
+
+    await async_set_config_parameter(node_2, 190, 8, 255)
+
+    value = node_2.values["31-112-0-8-255"]
+    assert len(ack_commands_2) == 1
+    assert ack_commands_2[0] == {
+        "command": "node.set_value",
+        "nodeId": node_2.node_id,
+        "valueId": value.data,
+        "value": 190,
+        "messageId": uuid4,
+    }
+
     # Test setting an enumerated configuration parameter with an invalid value
     with pytest.raises(InvalidNewValue):
         await async_set_config_parameter(node, 5, 1)
@@ -63,8 +81,8 @@ async def test_configuration_parameter_values(
     )
 
     value = node.values["13-112-0-1"]
-    assert len(ack_commands) == 1
-    assert ack_commands[0] == {
+    assert len(ack_commands) == 2
+    assert ack_commands[1] == {
         "command": "node.set_value",
         "nodeId": node.node_id,
         "valueId": value.data,

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -8,10 +8,11 @@ from zwave_js_server.util.node import async_set_config_parameter
 
 
 async def test_configuration_parameter_values(
-    climate_radio_thermostat_ct100_plus, uuid4, mock_command
+    climate_radio_thermostat_ct100_plus, inovelli_switch, uuid4, mock_command
 ):
     """Test node methods to get and set configuration parameter values."""
     node: Node = climate_radio_thermostat_ct100_plus
+    node_2: Node = inovelli_switch
     ack_commands = mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
         {"success": True},
@@ -21,12 +22,20 @@ async def test_configuration_parameter_values(
     config_values = node.get_configuration_values()
     assert len(config_values) == 12
 
+    assert node_2.node_id == 31
+    config_values_2 = node_2.get_configuration_values()
+    assert len(config_values_2) == 15
+
     for value in config_values.values():
         assert isinstance(value, ConfigurationValue)
 
     # Test setting a configuration parameter that has no metadata
     with pytest.raises(NotImplementedError):
         await async_set_config_parameter(node, 1, 2)
+
+    # Test setting an manual entry configuration parameter with an invalid value
+    with pytest.raises(InvalidNewValue):
+        await async_set_config_parameter(node_2, "Purple", 8, 255)
 
     # Test setting an enumerated configuration parameter with an invalid value
     with pytest.raises(InvalidNewValue):

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -312,6 +312,7 @@ class ConfigurationValueType(Enum):
     """Enum for configuration value types."""
 
     ENUMERATED = "enumerated"
+    MANUAL_ENTRY = "manual_entry"
     RANGE = "range"
     UNDEFINED = "undefined"
 

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -264,7 +264,12 @@ class ConfigurationValue(Value):
     def configuration_value_type(self) -> ConfigurationValueType:
         """Return configuration value type."""
         if self.metadata.type == "number":
-            if self.metadata.states and not self.metadata.allow_manual_entry:
+            if (
+                self.metadata.allow_manual_entry
+                and not self.metadata.max == self.metadata.min == 0
+            ):
+                return ConfigurationValueType.MANUAL_ENTRY
+            if self.metadata.states:
                 return ConfigurationValueType.ENUMERATED
             if (
                 self.metadata.max is not None or self.metadata.min is not None

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -130,7 +130,7 @@ class ValueMetadata:
     @property
     def allowManualEntry(self) -> Optional[bool]:
         """Return allowManualEntry."""
-        return self.data.get("allowManualEntry", {})
+        return self.data.get("allowManualEntry")
 
     def update(self, data: MetaDataType) -> None:
         """Update data."""

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -128,7 +128,7 @@ class ValueMetadata:
         return self.data.get("ccSpecific", {})
 
     @property
-    def allowmanualentry(self) -> Optional[bool]:
+    def allow_manual_entry(self) -> Optional[bool]:
         """Return allowManualEntry."""
         return self.data.get("allowManualEntry")
 

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -264,7 +264,7 @@ class ConfigurationValue(Value):
     def configuration_value_type(self) -> ConfigurationValueType:
         """Return configuration value type."""
         if self.metadata.type == "number":
-            if self.metadata.states and not self.metadata.allowmanualentry:
+            if self.metadata.states and not self.metadata.allow_manual_entry:
                 return ConfigurationValueType.ENUMERATED
             if (
                 self.metadata.max is not None or self.metadata.min is not None

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -22,6 +22,7 @@ class MetaDataType(TypedDict, total=False):
     unit: str
     states: Dict[int, str]
     ccSpecific: Dict[str, Any]
+    allowManualEntry: bool
 
 
 class ValueDataType(TypedDict, total=False):
@@ -125,6 +126,11 @@ class ValueMetadata:
     def cc_specific(self) -> Dict[str, Any]:
         """Return ccSpecific."""
         return self.data.get("ccSpecific", {})
+
+    @property
+    def allowManualEntry(self) -> Optional[bool]:
+        """Return allowManualEntry."""
+        return self.data.get("allowManualEntry", {})
 
     def update(self, data: MetaDataType) -> None:
         """Update data."""
@@ -258,7 +264,7 @@ class ConfigurationValue(Value):
     def configuration_value_type(self) -> ConfigurationValueType:
         """Return configuration value type."""
         if self.metadata.type == "number":
-            if self.metadata.states:
+            if self.metadata.states and not self.metadata.allowManualEntry:
                 return ConfigurationValueType.ENUMERATED
             if (
                 self.metadata.max is not None or self.metadata.min is not None

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -128,7 +128,7 @@ class ValueMetadata:
         return self.data.get("ccSpecific", {})
 
     @property
-    def allowManualEntry(self) -> Optional[bool]:
+    def allowmanualentry(self) -> Optional[bool]:
         """Return allowManualEntry."""
         return self.data.get("allowManualEntry")
 
@@ -264,7 +264,7 @@ class ConfigurationValue(Value):
     def configuration_value_type(self) -> ConfigurationValueType:
         """Return configuration value type."""
         if self.metadata.type == "number":
-            if self.metadata.states and not self.metadata.allowManualEntry:
+            if self.metadata.states and not self.metadata.allowmanualentry:
                 return ConfigurationValueType.ENUMERATED
             if (
                 self.metadata.max is not None or self.metadata.min is not None

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -86,13 +86,13 @@ async def async_set_config_parameter(
     # Validate that new value for range configuration parameter is within bounds
     max_ = zwave_value.metadata.max
     min_ = zwave_value.metadata.min
-    if (
+    value_ = (
         zwave_value.configuration_value_type == ConfigurationValueType.RANGE
         or zwave_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
-        and (
-            (max_ is not None and new_value > max_)
-            or (min_ is not None and new_value < min_)
-        )
+    )
+    if value_ and (
+        (max_ is not None and new_value > max_)
+        or (min_ is not None and new_value < min_)
     ):
         bounds = []
         if min_ is not None:

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -68,6 +68,21 @@ async def async_set_config_parameter(
             f"{json.dumps(zwave_value.metadata.states)}"
         )
 
+    # Validate that new value for manual entry configuration parameter is a valid state
+    # key or label
+    if (
+        zwave_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
+        and str(new_value)
+        not in [
+            *zwave_value.metadata.states,
+            *zwave_value.metadata.states.values(),
+        ]
+    ):
+        raise InvalidNewValue(
+            "Must provide a value that represents a valid state key or label from "
+            f"{json.dumps(zwave_value.metadata.states)}"
+        )
+
     # If needed, convert a state label to its key. We know the state exists because
     # of the validation above.
     if isinstance(new_value, str):

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -71,12 +71,9 @@ async def async_set_config_parameter(
     # Validate that new value for manual entry configuration parameter is a valid state
     # key or label
     if (
-        zwave_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
-        and str(new_value)
-        not in [
-            *zwave_value.metadata.states,
-            *zwave_value.metadata.states.values(),
-        ]
+        isinstance(new_value, str)
+        and zwave_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
+        and str(new_value) not in [*zwave_value.metadata.states.values()]
     ):
         raise InvalidNewValue(
             "Must provide a value that represents a valid state key or label from "

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -77,7 +77,7 @@ async def async_set_config_parameter(
     ):
         raise InvalidNewValue(
             "Must provide a value that represents a valid state from "
-            f"{json.dumps(zwave_value.metadata.states.values())}"
+            f"{list(zwave_value.metadata.states.values())}"
         )
 
     # If needed, convert a state label to its key. We know the state exists because

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -86,9 +86,13 @@ async def async_set_config_parameter(
     # Validate that new value for range configuration parameter is within bounds
     max_ = zwave_value.metadata.max
     min_ = zwave_value.metadata.min
-    if zwave_value.configuration_value_type == ConfigurationValueType.RANGE and (
-        (max_ is not None and new_value > max_)
-        or (min_ is not None and new_value < min_)
+    if (
+        zwave_value.configuration_value_type == ConfigurationValueType.RANGE
+        or zwave_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
+        and (
+            (max_ is not None and new_value > max_)
+            or (min_ is not None and new_value < min_)
+        )
     ):
         bounds = []
         if min_ is not None:

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -73,11 +73,11 @@ async def async_set_config_parameter(
     if (
         isinstance(new_value, str)
         and zwave_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
-        and str(new_value) not in [*zwave_value.metadata.states.values()]
+        and str(new_value) not in zwave_value.metadata.states.values()
     ):
         raise InvalidNewValue(
-            "Must provide a value that represents a valid state key or label from "
-            f"{json.dumps(zwave_value.metadata.states)}"
+            "Must provide a value that represents a valid state from "
+            f"{json.dumps(zwave_value.metadata.states.values())}"
         )
 
     # If needed, convert a state label to its key. We know the state exists because

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -101,11 +101,11 @@ async def async_set_config_parameter(
     # Validate that new value for range configuration parameter is within bounds
     max_ = zwave_value.metadata.max
     min_ = zwave_value.metadata.min
-    value_ = (
+    check_ = (
         zwave_value.configuration_value_type == ConfigurationValueType.RANGE
         or zwave_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
     )
-    if value_ and (
+    if check_ and (
         (max_ is not None and new_value > max_)
         or (min_ is not None and new_value < min_)
     ):


### PR DESCRIPTION
## Proposed change
Allow configuration values with the `allowManualEntry` metadata bool to be set to a range rather than be locked to the values from the `states` list.

Example:
```json
              {
                "endpoint": 0,
                "commandClass": 112,
                "commandClassName": "Configuration",
                "property": 8,
                "propertyKey": 255,
                "propertyName": "LED Strip Effect (Color)",
                "ccVersion": 1,
                "metadata": {
                  "type": "number",
                  "readable": true,
                  "writeable": true,
                  "valueSize": 4,
                  "min": 0,
                  "max": 255,
                  "default": 0,
                  "format": 0,
                  "allowManualEntry": true,
                  "states": {
                    "0": "Red",
                    "21": "Orange",
                    "42": "Yellow",
                    "85": "Green",
                    "127": "Cyan",
                    "170": "Blue",
                    "212": "Violet",
                    "234": "Pink"
                  },
                  "label": "LED Strip Effect (Color)",
                  "isFromConfig": true
                },
                "value": 180
              },
```