### PR TITLE
Handle server schema version 2

### DIFF
--- a/test/model/test_value.py
+++ b/test/model/test_value.py
@@ -1,4 +1,6 @@
 """Test value model."""
+from copy import deepcopy
+
 from zwave_js_server.const import ConfigurationValueType
 from zwave_js_server.model.node import Node
 from zwave_js_server.model.value import get_value_id
@@ -6,7 +8,8 @@ from zwave_js_server.model.value import get_value_id
 
 def test_buffer_dict(client, idl_101_lock_state):
     """Test that we handle buffer dictionary correctly."""
-    node = Node(client, idl_101_lock_state)
+    node_data = deepcopy(idl_101_lock_state)
+    node = Node(client, node_data)
 
     value_id = get_value_id(node, 99, "userCode", 0, 3)
 
@@ -15,6 +18,12 @@ def test_buffer_dict(client, idl_101_lock_state):
     zwave_value = node.values[value_id]
 
     assert zwave_value.metadata.type == "string"
+    assert zwave_value.value == "¤\x0eªV"
+
+    zwave_value.data["metadata"]["type"] = "buffer"
+    zwave_value.update(zwave_value.data)
+
+    assert zwave_value.metadata.type == "buffer"
     assert zwave_value.value == "¤\x0eªV"
 
 

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 1
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 1
+MAX_SERVER_SCHEMA_VERSION = 2
 
 VALUE_UNKNOWN = "unknown"
 

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -239,8 +239,10 @@ class Value:
         if "metadata" in data:
             self._metadata.update(data["metadata"])
 
-        # handle buffer dict and json string in value
-        if self.metadata.type == "string":
+        # Handle buffer dict and json string in value.
+        # In schema version 1 this is type string,
+        # while in schema version 2 this is type buffer.
+        if self.metadata.type in ("string", "buffer"):
             if isinstance(self._value, dict):
                 self._value = parse_buffer(self._value)
             elif is_json_string(self._value):


### PR DESCRIPTION
- Bump max server schema version to 2.
- Handle buffer and string metadata types.
- Add test.

This PR requires a new release of the server.