### PR TITLE
Exclude static type checking from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,4 @@ exclude_lines =
     def __repr__
     raise AssertionError
     raise NotImplementedError
+    if TYPE_CHECKING:


### PR DESCRIPTION
- We don't need to cover static type checking with tests.