### PR TITLE
Selectively create ConfigurationValues when necessary

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1,5 +1,6 @@
 """Test the node model."""
 import json
+from zwave_js_server.model.value import ConfigurationValue
 
 import pytest
 
@@ -305,6 +306,45 @@ async def test_node_status_events(multisensor_6):
     event = Event(type="sleep")
     node.handle_sleep(event)
     assert node.status == NodeStatus.ASLEEP
+
+
+async def test_value_added_events(multisensor_6):
+    """Test Node value added events."""
+    node = multisensor_6
+    event = Event(
+        type="value added",
+        data={
+            "source": "node",
+            "event": "value added",
+            "nodeId": 52,
+            "args": {
+                "commandClassName": "Configuration",
+                "commandClass": 112,
+                "endpoint": 0,
+                "property": 2,
+                "propertyName": "Stay Awake in Battery Mode",
+                "metadata": {
+                    "type": "number",
+                    "readable": True,
+                    "writeable": True,
+                    "valueSize": 1,
+                    "min": 0,
+                    "max": 1,
+                    "default": 0,
+                    "format": 0,
+                    "allowManualEntry": False,
+                    "states": {"0": "Disable", "1": "Enable"},
+                    "label": "Stay Awake in Battery Mode",
+                    "description": "Stay awake for 10 minutes at power on",
+                    "isFromConfig": True,
+                },
+                "value": 0,
+            },
+        },
+    )
+    node.handle_value_added(event)
+    assert isinstance(event.data["value"], ConfigurationValue)
+    assert isinstance(node.values["52-112-0-2"], ConfigurationValue)
 
 
 async def test_value_notification(wallmote_central_scene: Node):

--- a/zwave_js_server/model/association.py
+++ b/zwave_js_server/model/association.py
@@ -1,6 +1,6 @@
 """Provide a model for the association."""
-from typing import Dict, List, Optional
 from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 
 
 @dataclass

--- a/zwave_js_server/model/command_class.py
+++ b/zwave_js_server/model/command_class.py
@@ -5,6 +5,7 @@ https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=commandclasses
 """
 
 from typing import TypedDict
+
 from ..const import CommandClass
 
 

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -2,10 +2,7 @@
 from typing import TYPE_CHECKING, Dict, List, Optional, TypedDict, cast
 
 from ..event import Event, EventBase
-from .association import (
-    AssociationGroup,
-    Association,
-)
+from .association import Association, AssociationGroup
 from .node import Node
 
 if TYPE_CHECKING:

--- a/zwave_js_server/model/driver.py
+++ b/zwave_js_server/model/driver.py
@@ -1,5 +1,6 @@
 """Provide a model for the Z-Wave JS Driver."""
 from typing import TYPE_CHECKING
+
 from zwave_js_server.model.log_config import LogConfig
 
 from ..event import Event, EventBase

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -393,8 +393,8 @@ class Node(EventBase):
             # We should never reach this code
             raise FailedCommand("Command failed", "failed_command")
         return [
-            _init_value(self, cast(ValueDataType, valueId))
-            for valueId in data["valueIds"]
+            _init_value(self, cast(ValueDataType, value_id))
+            for value_id in data["valueIds"]
         ]
 
     async def async_get_value_metadata(self, val: Union[Value, str]) -> ValueMetadata:

--- a/zwave_js_server/model/notification.py
+++ b/zwave_js_server/model/notification.py
@@ -4,7 +4,8 @@ Model for a Zwave Node's Notification Event.
 https://zwave-js.github.io/node-zwave-js/#/api/node?id=quotnotificationquot
 """
 
-from typing import Literal, TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, TypedDict, Union
+
 from zwave_js_server.util.helpers import parse_buffer
 
 if TYPE_CHECKING:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -1,7 +1,7 @@
 """Provide a model for the Z-Wave JS value."""
 from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union
 
-from ..const import VALUE_UNKNOWN, ConfigurationValueType
+from ..const import VALUE_UNKNOWN, CommandClass, ConfigurationValueType
 from ..event import Event
 from ..util.helpers import parse_buffer
 
@@ -40,6 +40,15 @@ class ValueDataType(TypedDict, total=False):
     prevValue: Any
     metadata: MetaDataType
     ccVersion: int
+
+
+def _init_value(
+    node: "Node", val: ValueDataType
+) -> Union["Value", "ConfigurationValue"]:
+    """Intialize a Value object from ValueDataType."""
+    if val["commandClass"] == CommandClass.CONFIGURATION:
+        return ConfigurationValue(node, val)
+    return Value(node, val)
 
 
 def _get_value_id_from_dict(node: "Node", val: ValueDataType) -> str:


### PR DESCRIPTION
Occasionally, users have been getting `AttributeErrors` when setting configuration values in Home Assistant. This is because in some cases, we were always creating `Values` instead of selectively `ConfigurationValues`, like when a value was added or node becomes ready. I've introduced a helper function that we use in more places to always create `ConfigurationValues` when appropriate.

I also ran `isort`, hence the number of files changed