### PR TITLE
Return command status when setting a config parameter

### DIFF
--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -52,7 +52,9 @@ async def test_configuration_parameter_values(
         {"success": True},
     )
 
-    await async_set_config_parameter(node_2, 190, 8, 255)
+    zwave_value, cmd_status = await async_set_config_parameter(node_2, 190, 8, 255)
+    assert isinstance(zwave_value, ConfigurationValue)
+    assert cmd_status == CommandStatus.ACCEPTED
 
     value = node_2.values["31-112-0-8-255"]
     assert len(ack_commands_2) == 1
@@ -64,7 +66,9 @@ async def test_configuration_parameter_values(
         "messageId": uuid4,
     }
 
-    await async_set_config_parameter(node_2, "Blue", 8, 255)
+    zwave_value, cmd_status = await async_set_config_parameter(node_2, "Blue", 8, 255)
+    assert isinstance(zwave_value, ConfigurationValue)
+    assert cmd_status == CommandStatus.ACCEPTED
 
     value = node_2.values["31-112-0-8-255"]
     assert len(ack_commands_2) == 2
@@ -97,9 +101,11 @@ async def test_configuration_parameter_values(
         await async_set_config_parameter(node, 1, 1, property_key=1)
 
     # Test setting a configuration parameter by state label and property name
-    await async_set_config_parameter(
+    zwave_value, cmd_status = await async_set_config_parameter(
         node, "2.0\u00b0 F", "Temperature Reporting Threshold"
     )
+    assert isinstance(zwave_value, ConfigurationValue)
+    assert cmd_status == CommandStatus.ACCEPTED
 
     value = node.values["13-112-0-1"]
     assert len(ack_commands) == 3
@@ -119,7 +125,8 @@ async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_com
         {"command": "node.set_value", "nodeId": node.node_id},
         {"success": True},
     )
-    await async_bulk_set_partial_config_parameters(node, 101, 241)
+    cmd_status = await async_bulk_set_partial_config_parameters(node, 101, 241)
+    assert cmd_status == CommandStatus.QUEUED
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "node.set_value",
@@ -132,9 +139,10 @@ async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_com
         "messageId": uuid4,
     }
 
-    await async_bulk_set_partial_config_parameters(
+    cmd_status = await async_bulk_set_partial_config_parameters(
         node, 101, {128: 1, 64: 1, 32: 1, 16: 1, 1: 1}
     )
+    assert cmd_status == CommandStatus.QUEUED
     assert len(ack_commands) == 2
     assert ack_commands[1] == {
         "command": "node.set_value",
@@ -148,9 +156,10 @@ async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_com
     }
 
     # Only set some values so we use cached values for the rest
-    await async_bulk_set_partial_config_parameters(
+    cmd_status = await async_bulk_set_partial_config_parameters(
         node, 101, {64: 1, 32: 1, 16: 1, 1: 1}
     )
+    assert cmd_status == CommandStatus.QUEUED
     assert len(ack_commands) == 3
     assert ack_commands[2] == {
         "command": "node.set_value",

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -10,6 +10,14 @@ MAX_SERVER_SCHEMA_VERSION = 3
 VALUE_UNKNOWN = "unknown"
 
 
+class CommandStatus(str, Enum):
+    """Status of a command sent to zwave-js-server."""
+
+    ACCEPTED = "accepted"
+    QUEUED = "queued"
+    FAILED = "failed"
+
+
 class EntryControlEventType(IntEnum):
     """Entry control event types."""
 

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -15,7 +15,6 @@ class CommandStatus(str, Enum):
 
     ACCEPTED = "accepted"
     QUEUED = "queued"
-    FAILED = "failed"
 
 
 class EntryControlEventType(IntEnum):

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -1,8 +1,8 @@
 """Utility functions for Z-Wave JS nodes."""
 import json
-from typing import Dict, Optional, Union, cast
+from typing import Dict, Optional, Tuple, Union, cast
 
-from ..const import CommandClass, ConfigurationValueType
+from ..const import CommandClass, CommandStatus, ConfigurationValueType
 from ..exceptions import InvalidNewValue, NotFoundError, SetValueFailed, ValueTypeError
 from ..model.node import Node
 from ..model.value import ConfigurationValue, get_value_id
@@ -88,7 +88,7 @@ async def async_bulk_set_partial_config_parameters(
     node: Node,
     property_: int,
     new_value: Union[int, Dict[int, Union[int, str]]],
-) -> None:
+) -> CommandStatus:
     """Bulk set partial configuration values on this node."""
     config_values = node.get_configuration_values()
     property_values = [
@@ -153,7 +153,7 @@ async def async_bulk_set_partial_config_parameters(
             remaining_value = remaining_value % multiplication_factor
             _validate_and_transform_new_value(zwave_value, partial_value)
 
-    response = await node.async_send_command(
+    cmd_response = await node.async_send_command(
         "set_value",
         valueId={
             "commandClass": CommandClass.CONFIGURATION.value,
@@ -161,12 +161,16 @@ async def async_bulk_set_partial_config_parameters(
         },
         value=new_value,
     )
-    if response and not cast(bool, response["success"]):
+    if cmd_response and not cast(bool, cmd_response["success"]):
         raise SetValueFailed(
             "Unable to set value, refer to "
             "https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue for "
             "possible reasons"
         )
+
+    # If we received a response that is not false, the command was successful, otherwise
+    # we've queued it
+    return CommandStatus.ACCEPTED if cmd_response else CommandStatus.QUEUED
 
 
 async def async_set_config_parameter(
@@ -174,7 +178,7 @@ async def async_set_config_parameter(
     new_value: Union[int, str],
     property_or_property_name: Union[int, str],
     property_key: Optional[Union[int, str]] = None,
-) -> ConfigurationValue:
+) -> Tuple[ConfigurationValue, CommandStatus]:
     """
     Set a value for a config parameter on this node.
 
@@ -216,11 +220,14 @@ async def async_set_config_parameter(
     new_value = _validate_and_transform_new_value(zwave_value, new_value)
 
     # Finally attempt to set the value and return the Value object if successful
-    if await node.async_set_value(zwave_value, new_value) is False:
+    cmd_response = await node.async_set_value(zwave_value, new_value)
+    if cmd_response is False:
         raise SetValueFailed(
             "Unable to set value, refer to "
             "https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue for "
             "possible reasons"
         )
 
-    return zwave_value
+    status = CommandStatus.ACCEPTED if cmd_response else CommandStatus.QUEUED
+
+    return zwave_value, status

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -161,16 +161,20 @@ async def async_bulk_set_partial_config_parameters(
         },
         value=new_value,
     )
-    if cmd_response and not cast(bool, cmd_response["success"]):
+
+    # If we didn't wait for a response, we assume the command has been queued
+    if cmd_response is None:
+        return CommandStatus.QUEUED
+
+    if not cast(bool, cmd_response["success"]):
         raise SetValueFailed(
             "Unable to set value, refer to "
             "https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue for "
             "possible reasons"
         )
 
-    # If we received a response that is not false, the command was successful, otherwise
-    # we've queued it
-    return CommandStatus.ACCEPTED if cmd_response else CommandStatus.QUEUED
+    # If we received a response that is not false, the command was successful
+    return CommandStatus.ACCEPTED
 
 
 async def async_set_config_parameter(

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -224,14 +224,14 @@ async def async_set_config_parameter(
     new_value = _validate_and_transform_new_value(zwave_value, new_value)
 
     # Finally attempt to set the value and return the Value object if successful
-    cmd_response = await node.async_set_value(zwave_value, new_value)
-    if cmd_response is False:
+    success = await node.async_set_value(zwave_value, new_value)
+    if success is False:
         raise SetValueFailed(
             "Unable to set value, refer to "
             "https://zwave-js.github.io/node-zwave-js/#/api/node?id=setvalue for "
             "possible reasons"
         )
 
-    status = CommandStatus.ACCEPTED if cmd_response else CommandStatus.QUEUED
+    status = CommandStatus.ACCEPTED if success else CommandStatus.QUEUED
 
     return zwave_value, status


### PR DESCRIPTION
@cgarwood  has requested that we have a way to know whether the command failed, was accepted, or was queued when setting a config parameter. This PR adds a status to the return which can be used in HA to get the status.

This should follow #176 so we can apply this to both utility functions