### PR TITLE
Add missed commit for driver.async_enable_statistics

### DIFF
--- a/test/model/test_driver.py
+++ b/test/model/test_driver.py
@@ -119,18 +119,18 @@ async def test_statistics(driver, uuid4, mock_command):
     ack_commands = mock_command(
         {
             "command": "driver.enable_statistics",
-            "applicationName": "test",
-            "applicationVersion": "test",
+            "applicationName": "test_name",
+            "applicationVersion": "test_version",
         },
         {"success": True},
     )
-    await driver.async_enable_statistics("test", "test")
+    await driver.async_enable_statistics("test_name", "test_version")
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "driver.enable_statistics",
-        "applicationName": "test",
-        "applicationVersion": "test",
+        "applicationName": "test_name",
+        "applicationVersion": "test_version",
         "messageId": uuid4,
     }
 

--- a/test/model/test_driver.py
+++ b/test/model/test_driver.py
@@ -117,14 +117,20 @@ async def test_statistics(driver, uuid4, mock_command):
     """Test statistics commands."""
     # Test that enable_statistics command is sent
     ack_commands = mock_command(
-        {"command": "driver.enable_statistics"},
+        {
+            "command": "driver.enable_statistics",
+            "applicationName": "test",
+            "applicationVersion": "test",
+        },
         {"success": True},
     )
-    await driver.async_enable_statistics()
+    await driver.async_enable_statistics("test", "test")
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "driver.enable_statistics",
+        "applicationName": "test",
+        "applicationVersion": "test",
         "messageId": uuid4,
     }
 

--- a/zwave_js_server/model/driver.py
+++ b/zwave_js_server/model/driver.py
@@ -65,9 +65,16 @@ class Driver(EventBase):
         result = await self._async_send_command("get_log_config", require_schema=4)
         return LogConfig.from_dict(result["config"])
 
-    async def async_enable_statistics(self) -> None:
+    async def async_enable_statistics(
+        self, application_name: str, application_version: str
+    ) -> None:
         """Send command to enable data collection."""
-        await self._async_send_command("enable_statistics", require_schema=4)
+        await self._async_send_command(
+            "enable_statistics",
+            applicationName=application_name,
+            applicationVersion=application_version,
+            require_schema=4,
+        )
 
     async def async_disable_statistics(self) -> None:
         """Send command to stop listening to log events."""


### PR DESCRIPTION
`driver.enable_statistics` takes two inputs that were missed in the last PR