### PR TITLE
Add support for node.begin_firmware_update

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -173,8 +173,8 @@ async def firmware_ws_client_fixture(
     This fixture only allows a single message to be received.
     """
     ws_client = AsyncMock(spec_set=ClientWebSocketResponse, closed=False)
-    ws_client.receive_json.side_effect = (version_data, set_api_schema_data, {})
-    for data in (version_data, set_api_schema_data, {}):
+    ws_client.receive_json.side_effect = (version_data, set_api_schema_data)
+    for data in (version_data, set_api_schema_data):
         messages.append(create_ws_message(data))
 
     async def receive():
@@ -193,7 +193,6 @@ async def firmware_ws_client_fixture(
         """Close the client."""
         if msg["command"] in (
             "set_api_schema",
-            "node.begin_firmware_update"
         ):
             return
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -83,16 +83,6 @@ def client_session_fixture(ws_client):
     return client_session
 
 
-@pytest.fixture(name="firmware_client_session")
-def firmware_client_session_fixture(firmware_ws_client):
-    """Mock an aiohttp client session."""
-    firmware_client_session = AsyncMock(spec_set=ClientSession)
-    firmware_client_session.ws_connect.side_effect = AsyncMock(
-        return_value=firmware_ws_client
-    )
-    return firmware_client_session
-
-
 @pytest.fixture(name="inovelli_switch_state", scope="session")
 def inovelli_switch_state_fixture():
     """Load the bad string meta data node state fixture data."""
@@ -148,48 +138,6 @@ async def ws_client_fixture(
     async def close_client(msg):
         """Close the client."""
         if msg["command"] in ("set_api_schema", "start_listening"):
-            return
-
-        await asyncio.sleep(0)
-        ws_client.closed = True
-
-    ws_client.send_json.side_effect = close_client
-
-    async def reset_close():
-        """Reset the websocket client close method."""
-        ws_client.closed = True
-
-    ws_client.close.side_effect = reset_close
-
-    return ws_client
-
-
-@pytest.fixture(name="firmware_ws_client")
-async def firmware_ws_client_fixture(loop, version_data, messages, set_api_schema_data):
-    """Mock a websocket client.
-
-    This fixture only allows a single message to be received.
-    """
-    ws_client = AsyncMock(spec_set=ClientWebSocketResponse, closed=False)
-    ws_client.receive_json.side_effect = (version_data, set_api_schema_data)
-    for data in (version_data, set_api_schema_data):
-        messages.append(create_ws_message(data))
-
-    async def receive():
-        """Return a websocket message."""
-        await asyncio.sleep(0)
-
-        message = messages.popleft()
-        if not messages:
-            ws_client.closed = True
-
-        return message
-
-    ws_client.receive.side_effect = receive
-
-    async def close_client(msg):
-        """Close the client."""
-        if msg["command"] in ("set_api_schema"):
             return
 
         await asyncio.sleep(0)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -165,9 +165,7 @@ async def ws_client_fixture(
 
 
 @pytest.fixture(name="firmware_ws_client")
-async def firmware_ws_client_fixture(
-    loop, version_data, ws_message, messages, set_api_schema_data
-):
+async def firmware_ws_client_fixture(loop, version_data, messages, set_api_schema_data):
     """Mock a websocket client.
 
     This fixture only allows a single message to be received.
@@ -191,9 +189,7 @@ async def firmware_ws_client_fixture(
 
     async def close_client(msg):
         """Close the client."""
-        if msg["command"] in (
-            "set_api_schema",
-        ):
+        if msg["command"] in ("set_api_schema"):
             return
 
         await asyncio.sleep(0)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -193,8 +193,7 @@ async def firmware_ws_client_fixture(
         """Close the client."""
         if msg["command"] in (
             "set_api_schema",
-            "node.begin_firmware_update_guess_format",
-            "node.begin_firmware_update_known_format",
+            "node.begin_firmware_update"
         ):
             return
 
@@ -239,7 +238,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 4,
+        "maxSchemaVersion": 5,
     }
 
 

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -213,6 +213,48 @@ async def test_refresh_info(multisensor_6, uuid4, mock_command):
     }
 
 
+async def test_begin_firmware_update_guess_format(multisensor_6, uuid4, mock_command):
+    """Test begin_firmware_update_guess_format."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "node.begin_firmware_update_guess_format", "nodeId": node.node_id},
+        {"result": "something"},
+    )
+    assert await node.async_begin_firmware_update_guess_format("test", bytes(10)) == {
+        "result": "something"
+    }
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.begin_firmware_update_guess_format",
+        "nodeId": node.node_id,
+        "messageId": uuid4,
+        "firmwareFilename": "test",
+        "firmwareFile": {"type": "Buffer", "data": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
+    }
+
+
+async def test_begin_firmware_update_known_format(multisensor_6, uuid4, mock_command):
+    """Test begin_firmware_update_known_format."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "node.begin_firmware_update_known_format", "nodeId": node.node_id},
+        {"result": "something"},
+    )
+    assert await node.async_begin_firmware_update_known_format("test", bytes(10)) == {
+        "result": "something"
+    }
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.begin_firmware_update_known_format",
+        "nodeId": node.node_id,
+        "messageId": uuid4,
+        "firmwareFileFormat": "test",
+        "firmwareFile": {"type": "Buffer", "data": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
+    }
+
+
 async def test_value_added_event(multisensor_6):
     """Test Node value removed event."""
     node = multisensor_6

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -213,48 +213,6 @@ async def test_refresh_info(multisensor_6, uuid4, mock_command):
     }
 
 
-async def test_begin_firmware_update_guess_format(multisensor_6, uuid4, mock_command):
-    """Test begin_firmware_update_guess_format."""
-    node = multisensor_6
-    ack_commands = mock_command(
-        {"command": "node.begin_firmware_update_guess_format", "nodeId": node.node_id},
-        {"result": "something"},
-    )
-    assert await node.async_begin_firmware_update_guess_format("test", bytes(10)) == {
-        "result": "something"
-    }
-
-    assert len(ack_commands) == 1
-    assert ack_commands[0] == {
-        "command": "node.begin_firmware_update_guess_format",
-        "nodeId": node.node_id,
-        "messageId": uuid4,
-        "firmwareFilename": "test",
-        "firmwareFile": {"type": "Buffer", "data": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    }
-
-
-async def test_begin_firmware_update_known_format(multisensor_6, uuid4, mock_command):
-    """Test begin_firmware_update_known_format."""
-    node = multisensor_6
-    ack_commands = mock_command(
-        {"command": "node.begin_firmware_update_known_format", "nodeId": node.node_id},
-        {"result": "something"},
-    )
-    assert await node.async_begin_firmware_update_known_format("test", bytes(10)) == {
-        "result": "something"
-    }
-
-    assert len(ack_commands) == 1
-    assert ack_commands[0] == {
-        "command": "node.begin_firmware_update_known_format",
-        "nodeId": node.node_id,
-        "messageId": uuid4,
-        "firmwareFileFormat": "test",
-        "firmwareFile": {"type": "Buffer", "data": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]},
-    }
-
-
 async def test_value_added_event(multisensor_6):
     """Test Node value removed event."""
     node = multisensor_6

--- a/test/test_firmware.py
+++ b/test/test_firmware.py
@@ -1,4 +1,5 @@
 """Test the firmware update helper."""
+from unittest.mock import call
 
 from zwave_js_server.firmware import (
     begin_firmware_update_guess_format,
@@ -7,54 +8,52 @@ from zwave_js_server.firmware import (
 
 
 async def test_begin_firmware_update_guess_format(
-    url, client_session, set_api_schema_data, multisensor_6, uuid4, mock_command
+    url, firmware_client_session, firmware_ws_client, multisensor_6
 ):
     """Test begin_firmware_update_guess_format."""
     node = multisensor_6
-    mock_command(
-        {"command": "set_api_schema"},
-        set_api_schema_data,
+    assert (
+        await begin_firmware_update_guess_format(
+            url, node, "test", bytes(10), firmware_client_session
+        )
+        == {}
     )
-    ack_commands = mock_command(
-        {"command": "node.begin_firmware_update_guess_format", "nodeId": node.node_id},
-        {"result": "something"},
-    )
-    assert await begin_firmware_update_guess_format(
-        url, node, "test", bytes(10), client_session
-    ) == {"result": "something"}
 
-    assert len(ack_commands) == 1
-    assert ack_commands[0] == {
-        "command": "node.begin_firmware_update_guess_format",
-        "nodeId": node.node_id,
-        "firmwareFilename": "test",
-        "firmwareFile": "AAAAAAAAAAAAAA==",
-        "messageId": uuid4,
-    }
+    assert firmware_ws_client.receive_json.call_count == 3
+    assert firmware_ws_client.send_json.call_count == 2
+    assert firmware_ws_client.send_json.call_args == call(
+        {
+            "command": "node.begin_firmware_update_guess_format",
+            "messageId": "begin-firmware-update-guess-format",
+            "nodeId": node.node_id,
+            "firmwareFile": "AAAAAAAAAAAAAA==",
+            "firmwareFilename": "test",
+        }
+    )
+    assert firmware_ws_client.close.call_count == 1
 
 
 async def test_begin_firmware_update_known_format(
-    url, client_session, set_api_schema_data, multisensor_6, uuid4, mock_command
+    url, firmware_client_session, firmware_ws_client, multisensor_6
 ):
     """Test begin_firmware_update_known_format."""
     node = multisensor_6
-    mock_command(
-        {"command": "set_api_schema"},
-        set_api_schema_data,
+    assert (
+        await begin_firmware_update_known_format(
+            url, node, "test", bytes(10), firmware_client_session
+        )
+        == {}
     )
-    ack_commands = mock_command(
-        {"command": "node.begin_firmware_update_known_format", "nodeId": node.node_id},
-        {"result": "something"},
-    )
-    assert await begin_firmware_update_known_format(
-        url, node, "test", bytes(10), client_session
-    ) == {"result": "something"}
 
-    assert len(ack_commands) == 1
-    assert ack_commands[0] == {
-        "command": "node.begin_firmware_update_known_format",
-        "nodeId": node.node_id,
-        "firmwareFileFormat": "test",
-        "firmwareFile": "AAAAAAAAAAAAAA==",
-        "messageId": uuid4,
-    }
+    assert firmware_ws_client.receive_json.call_count == 3
+    assert firmware_ws_client.send_json.call_count == 2
+    assert firmware_ws_client.send_json.call_args == call(
+        {
+            "command": "node.begin_firmware_update_known_format",
+            "messageId": "begin-firmware-update-known-format",
+            "nodeId": node.node_id,
+            "firmwareFile": "AAAAAAAAAAAAAA==",
+            "firmwareFileFormat": "test",
+        }
+    )
+    assert firmware_ws_client.close.call_count == 1

--- a/test/test_firmware.py
+++ b/test/test_firmware.py
@@ -1,19 +1,16 @@
 """Test the firmware update helper."""
 from unittest.mock import call
 
-from zwave_js_server.firmware import (
-    begin_firmware_update_guess_format,
-    begin_firmware_update_known_format,
-)
+from zwave_js_server.firmware import begin_firmware_update
 
 
 async def test_begin_firmware_update_guess_format(
     url, firmware_client_session, firmware_ws_client, multisensor_6
 ):
-    """Test begin_firmware_update_guess_format."""
+    """Test begin_firmware_update with guessed format."""
     node = multisensor_6
     assert (
-        await begin_firmware_update_guess_format(
+        await begin_firmware_update(
             url, node, "test", bytes(10), firmware_client_session
         )
         == {}
@@ -23,8 +20,8 @@ async def test_begin_firmware_update_guess_format(
     assert firmware_ws_client.send_json.call_count == 2
     assert firmware_ws_client.send_json.call_args == call(
         {
-            "command": "node.begin_firmware_update_guess_format",
-            "messageId": "begin-firmware-update-guess-format",
+            "command": "node.begin_firmware_update",
+            "messageId": "begin-firmware-update",
             "nodeId": node.node_id,
             "firmwareFile": "AAAAAAAAAAAAAA==",
             "firmwareFilename": "test",
@@ -36,11 +33,11 @@ async def test_begin_firmware_update_guess_format(
 async def test_begin_firmware_update_known_format(
     url, firmware_client_session, firmware_ws_client, multisensor_6
 ):
-    """Test begin_firmware_update_known_format."""
+    """Test begin_firmware_update with known format."""
     node = multisensor_6
     assert (
-        await begin_firmware_update_known_format(
-            url, node, "test", bytes(10), firmware_client_session
+        await begin_firmware_update(
+            url, node, "test", bytes(10), firmware_client_session, "test"
         )
         == {}
     )
@@ -49,9 +46,10 @@ async def test_begin_firmware_update_known_format(
     assert firmware_ws_client.send_json.call_count == 2
     assert firmware_ws_client.send_json.call_args == call(
         {
-            "command": "node.begin_firmware_update_known_format",
-            "messageId": "begin-firmware-update-known-format",
+            "command": "node.begin_firmware_update",
+            "messageId": "begin-firmware-update",
             "nodeId": node.node_id,
+            "firmwareFilename": "test",
             "firmwareFile": "AAAAAAAAAAAAAA==",
             "firmwareFileFormat": "test",
         }

--- a/test/test_firmware.py
+++ b/test/test_firmware.py
@@ -1,4 +1,4 @@
-"""Test for firmware functions."""
+"""Test the firmware update helper."""
 
 from zwave_js_server.firmware import (
     begin_firmware_update_guess_format,

--- a/test/test_firmware.py
+++ b/test/test_firmware.py
@@ -1,57 +1,59 @@
 """Test the firmware update helper."""
-from unittest.mock import call
+from unittest.mock import patch
 
 from zwave_js_server.firmware import begin_firmware_update
 
 
-async def test_begin_firmware_update_guess_format(
-    url, firmware_client_session, firmware_ws_client, multisensor_6
-):
+async def test_begin_firmware_update_guess_format(url, client_session, multisensor_6):
     """Test begin_firmware_update with guessed format."""
-    node = multisensor_6
-    assert (
-        await begin_firmware_update(
-            url, node, "test", bytes(10), firmware_client_session
+    with patch("zwave_js_server.firmware.Client.connect") as connect_mock, patch(
+        "zwave_js_server.firmware.Client.set_api_schema"
+    ) as set_api_schema_mock, patch(
+        "zwave_js_server.firmware.Client.async_send_command"
+    ) as cmd_mock, patch(
+        "zwave_js_server.firmware.Client.disconnect"
+    ) as disconnect_mock:
+        node = multisensor_6
+        await begin_firmware_update(url, node, "test", bytes(10), client_session)
+
+        connect_mock.assert_called_once()
+        set_api_schema_mock.assert_called_once()
+        cmd_mock.assert_called_once_with(
+            {
+                "command": "node.begin_firmware_update",
+                "nodeId": node.node_id,
+                "firmwareFilename": "test",
+                "firmwareFile": "AAAAAAAAAAAAAA==",
+            },
+            require_schema=5,
         )
-        == {}
-    )
-
-    assert firmware_ws_client.receive_json.call_count == 3
-    assert firmware_ws_client.send_json.call_count == 2
-    assert firmware_ws_client.send_json.call_args == call(
-        {
-            "command": "node.begin_firmware_update",
-            "messageId": "begin-firmware-update",
-            "nodeId": node.node_id,
-            "firmwareFile": "AAAAAAAAAAAAAA==",
-            "firmwareFilename": "test",
-        }
-    )
-    assert firmware_ws_client.close.call_count == 1
+        disconnect_mock.assert_called_once()
 
 
-async def test_begin_firmware_update_known_format(
-    url, firmware_client_session, firmware_ws_client, multisensor_6
-):
+async def test_begin_firmware_update_known_format(url, client_session, multisensor_6):
     """Test begin_firmware_update with known format."""
-    node = multisensor_6
-    assert (
+    with patch("zwave_js_server.firmware.Client.connect") as connect_mock, patch(
+        "zwave_js_server.firmware.Client.set_api_schema"
+    ) as set_api_schema_mock, patch(
+        "zwave_js_server.firmware.Client.async_send_command"
+    ) as cmd_mock, patch(
+        "zwave_js_server.firmware.Client.disconnect"
+    ) as disconnect_mock:
+        node = multisensor_6
         await begin_firmware_update(
-            url, node, "test", bytes(10), firmware_client_session, "test"
+            url, node, "test", bytes(10), client_session, "test"
         )
-        == {}
-    )
 
-    assert firmware_ws_client.receive_json.call_count == 3
-    assert firmware_ws_client.send_json.call_count == 2
-    assert firmware_ws_client.send_json.call_args == call(
-        {
-            "command": "node.begin_firmware_update",
-            "messageId": "begin-firmware-update",
-            "nodeId": node.node_id,
-            "firmwareFilename": "test",
-            "firmwareFile": "AAAAAAAAAAAAAA==",
-            "firmwareFileFormat": "test",
-        }
-    )
-    assert firmware_ws_client.close.call_count == 1
+        connect_mock.assert_called_once()
+        set_api_schema_mock.assert_called_once()
+        cmd_mock.assert_called_once_with(
+            {
+                "command": "node.begin_firmware_update",
+                "nodeId": node.node_id,
+                "firmwareFilename": "test",
+                "firmwareFile": "AAAAAAAAAAAAAA==",
+                "firmwareFileFormat": "test",
+            },
+            require_schema=5,
+        )
+        disconnect_mock.assert_called_once()

--- a/test/test_firmware.py
+++ b/test/test_firmware.py
@@ -1,0 +1,60 @@
+"""Test for firmware functions."""
+
+from zwave_js_server.firmware import (
+    begin_firmware_update_guess_format,
+    begin_firmware_update_known_format,
+)
+
+
+async def test_begin_firmware_update_guess_format(
+    url, client_session, set_api_schema_data, multisensor_6, uuid4, mock_command
+):
+    """Test begin_firmware_update_guess_format."""
+    node = multisensor_6
+    mock_command(
+        {"command": "set_api_schema"},
+        set_api_schema_data,
+    )
+    ack_commands = mock_command(
+        {"command": "node.begin_firmware_update_guess_format", "nodeId": node.node_id},
+        {"result": "something"},
+    )
+    assert await begin_firmware_update_guess_format(
+        url, node, "test", bytes(10), client_session
+    ) == {"result": "something"}
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.begin_firmware_update_guess_format",
+        "nodeId": node.node_id,
+        "firmwareFilename": "test",
+        "firmwareFile": "AAAAAAAAAAAAAA==",
+        "messageId": uuid4,
+    }
+
+
+async def test_begin_firmware_update_known_format(
+    url, client_session, set_api_schema_data, multisensor_6, uuid4, mock_command
+):
+    """Test begin_firmware_update_known_format."""
+    node = multisensor_6
+    mock_command(
+        {"command": "set_api_schema"},
+        set_api_schema_data,
+    )
+    ack_commands = mock_command(
+        {"command": "node.begin_firmware_update_known_format", "nodeId": node.node_id},
+        {"result": "something"},
+    )
+    assert await begin_firmware_update_known_format(
+        url, node, "test", bytes(10), client_session
+    ) == {"result": "something"}
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.begin_firmware_update_known_format",
+        "nodeId": node.node_id,
+        "firmwareFileFormat": "test",
+        "firmwareFile": "AAAAAAAAAAAAAA==",
+        "messageId": uuid4,
+    }

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -50,7 +50,7 @@ def test_dump_state(client_session, url, ws_client, result, capsys):
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 4}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 5}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -134,7 +134,7 @@ class Client:
             self.schema_version,
         )
 
-    async def set_api_schema(self, version: Optional[int] = None) -> None:
+    async def set_api_schema(self, schema_version: Optional[int] = None) -> None:
         """Set API schema version on server."""
         assert self._client
 
@@ -144,7 +144,7 @@ class Client:
             {
                 "command": "set_api_schema",
                 "messageId": "api-schema-id",
-                "schemaVersion": version or self.schema_version,
+                "schemaVersion": schema_version or self.schema_version,
             }
         )
         set_api_msg = await self._receive_json_or_raise()

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -160,8 +160,6 @@ class Client:
         assert self._client
 
         try:
-            # set preferred schema version on the server
-            # note: we already check for (in)compatible schemas in the connect call
             await self.set_api_schema()
 
             # send start_listening command to the server

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -136,6 +136,8 @@ class Client:
 
     async def set_api_schema(self, version: Optional[int] = None) -> None:
         """Set API schema version on server."""
+        assert self._client
+
         # set preferred schema version on the server
         # note: we already check for (in)compatible schemas in the connect call
         await self._send_json_message(

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -152,7 +152,9 @@ class Client:
             await self._client.close()
             raise FailedCommand(set_api_msg["messageId"], set_api_msg["errorCode"])
 
-    async def listen(self, driver_ready: asyncio.Event) -> None:
+    async def listen(
+        self, driver_ready: asyncio.Event, schema_version: Optional[int] = None
+    ) -> None:
         """Start listening to the websocket."""
         if not self.connected:
             raise InvalidState("Not connected when start listening")
@@ -160,7 +162,7 @@ class Client:
         assert self._client
 
         try:
-            await self.set_api_schema()
+            await self.set_api_schema(schema_version)
 
             # send start_listening command to the server
             # we will receive a full state dump and from now on get events

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 4
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 4
+MAX_SERVER_SCHEMA_VERSION = 5
 
 VALUE_UNKNOWN = "unknown"
 

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -1,0 +1,71 @@
+"""Dump helper."""
+from typing import Any, Dict
+import uuid
+
+import aiohttp
+
+from .const import MAX_SERVER_SCHEMA_VERSION
+from .model.node import Node
+from .util.helpers import convert_bytes_to_base64
+
+
+async def begin_firmware_update_guess_format(
+    url: str, node: Node, filename: str, file: bytes, session: aiohttp.ClientSession
+) -> Dict[str, Any]:
+    """Send beginFirmwareUpdate command to Node (format to be guessed)."""
+    client = await session.ws_connect(url)
+    # Version info
+    await client.receive_json()
+    await client.send_json(
+        {
+            "command": "set_api_schema",
+            "messageId": "api-schema-id",
+            "schemaVersion": MAX_SERVER_SCHEMA_VERSION,
+        }
+    )
+    # set_api_schema response
+    await client.receive_json()
+
+    await client.send_json(
+        {
+            "command": "node.begin_firmware_update_guess_format",
+            "nodeId": node.node_id,
+            "firmwareFilename": filename,
+            "firmwareFile": convert_bytes_to_base64(file),
+            "messageId": uuid.uuid4().hex,
+        }
+    )
+    resp = await client.receive_json()
+    await client.close()
+    return resp
+
+
+async def begin_firmware_update_known_format(
+    url: str, node: Node, file_format: str, file: bytes, session: aiohttp.ClientSession
+) -> Dict[str, Any]:
+    """Send beginFirmwareUpdate command to Node (format is known)."""
+    client = await session.ws_connect(url)
+    # Version info
+    await client.receive_json()
+    await client.send_json(
+        {
+            "command": "set_api_schema",
+            "messageId": "api-schema-id",
+            "schemaVersion": MAX_SERVER_SCHEMA_VERSION,
+        }
+    )
+    # set_api_schema response
+    await client.receive_json()
+
+    await client.send_json(
+        {
+            "command": "node.begin_firmware_update_known_format",
+            "nodeId": node.node_id,
+            "firmwareFileFormat": file_format,
+            "firmwareFile": convert_bytes_to_base64(file),
+            "messageId": uuid.uuid4().hex,
+        }
+    )
+    resp = await client.receive_json()
+    await client.close()
+    return resp

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -1,5 +1,5 @@
 """Firmware update helper."""
-from typing import Any, Dict
+from typing import Any
 
 import aiohttp
 
@@ -10,7 +10,7 @@ from .util.helpers import convert_bytes_to_base64
 
 async def begin_firmware_update_guess_format(
     url: str, node: Node, filename: str, file: bytes, session: aiohttp.ClientSession
-) -> Dict[str, Any]:
+) -> Any:
     """Send beginFirmwareUpdate command to Node (format to be guessed)."""
     client = await session.ws_connect(url)
     # Version info
@@ -41,7 +41,7 @@ async def begin_firmware_update_guess_format(
 
 async def begin_firmware_update_known_format(
     url: str, node: Node, file_format: str, file: bytes, session: aiohttp.ClientSession
-) -> Dict[str, Any]:
+) -> Any:
     """Send beginFirmwareUpdate command to Node (format is known)."""
     client = await session.ws_connect(url)
     # Version info

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -1,6 +1,4 @@
 """Firmware update helper."""
-from typing import Any
-
 import aiohttp
 
 from .client import Client
@@ -15,7 +13,7 @@ async def begin_firmware_update(
     file: bytes,
     session: aiohttp.ClientSession,
     file_format: str = None,
-) -> Any:
+) -> None:
     """Send beginFirmwareUpdate command to Node."""
     client = Client(url, session)
     await client.connect()
@@ -30,6 +28,5 @@ async def begin_firmware_update(
     if file_format is not None:
         cmd["firmwareFileFormat"] = file_format
 
-    resp = await client.async_send_command(cmd, require_schema=5)
+    await client.async_send_command(cmd, require_schema=5)
     await client.disconnect()
-    return resp

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import aiohttp
 
+from .client import Client
 from .const import MAX_SERVER_SCHEMA_VERSION
 from .model.node import Node
 from .util.helpers import convert_bytes_to_base64
@@ -17,30 +18,19 @@ async def begin_firmware_update(
     file_format: str = None,
 ) -> Any:
     """Send beginFirmwareUpdate command to Node."""
-    client = await session.ws_connect(url)
-    # Version info
-    await client.receive_json()
-    await client.send_json(
-        {
-            "command": "set_api_schema",
-            "messageId": "api-schema-id",
-            "schemaVersion": MAX_SERVER_SCHEMA_VERSION,
-        }
-    )
-    # set_api_schema response
-    await client.receive_json()
+    client = Client(url, session)
+    await client.connect()
+    await client.set_api_schema()
 
     cmd = {
         "command": "node.begin_firmware_update",
         "nodeId": node.node_id,
         "firmwareFilename": filename,
         "firmwareFile": convert_bytes_to_base64(file),
-        "messageId": "begin-firmware-update",
     }
     if file_format is not None:
         cmd["firmwareFileFormat"] = file_format
 
-    await client.send_json(cmd)
-    resp = await client.receive_json()
-    await client.close()
+    resp = await client.async_send_command(cmd, require_schema=5)
+    await client.disconnect()
     return resp

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -11,7 +11,7 @@ from .util.helpers import convert_bytes_to_base64
 async def begin_firmware_update_guess_format(
     url: str, node: Node, filename: str, file: bytes, session: aiohttp.ClientSession
 ) -> Any:
-    """Send beginFirmwareUpdate command to Node (format to be guessed)."""
+    """Send beginFirmwareUpdate command to Node (file format to be guessed)."""
     client = await session.ws_connect(url)
     # Version info
     await client.receive_json()
@@ -42,7 +42,7 @@ async def begin_firmware_update_guess_format(
 async def begin_firmware_update_known_format(
     url: str, node: Node, file_format: str, file: bytes, session: aiohttp.ClientSession
 ) -> Any:
-    """Send beginFirmwareUpdate command to Node (format is known)."""
+    """Send beginFirmwareUpdate command to Node (file format is known)."""
     client = await session.ws_connect(url)
     # Version info
     await client.receive_json()

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -1,4 +1,4 @@
-"""Dump helper."""
+"""Firmware update helper."""
 from typing import Any, Dict
 import uuid
 

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -1,6 +1,5 @@
 """Firmware update helper."""
 from typing import Any, Dict
-import uuid
 
 import aiohttp
 
@@ -32,7 +31,7 @@ async def begin_firmware_update_guess_format(
             "nodeId": node.node_id,
             "firmwareFilename": filename,
             "firmwareFile": convert_bytes_to_base64(file),
-            "messageId": uuid.uuid4().hex,
+            "messageId": "begin-firmware-update-guess-format",
         }
     )
     resp = await client.receive_json()
@@ -63,7 +62,7 @@ async def begin_firmware_update_known_format(
             "nodeId": node.node_id,
             "firmwareFileFormat": file_format,
             "firmwareFile": convert_bytes_to_base64(file),
-            "messageId": uuid.uuid4().hex,
+            "messageId": "begin-firmware-update-known-format",
         }
     )
     resp = await client.receive_json()

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -4,7 +4,6 @@ from typing import Any
 import aiohttp
 
 from .client import Client
-from .const import MAX_SERVER_SCHEMA_VERSION
 from .model.node import Node
 from .util.helpers import convert_bytes_to_base64
 

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -2,8 +2,7 @@
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
 
-from zwave_js_server.const import CommandClass, INTERVIEW_FAILED
-
+from ..const import CommandClass, INTERVIEW_FAILED
 from ..event import Event, EventBase
 from ..exceptions import FailedCommand, UnparseableValue, UnwriteableValue
 from .command_class import CommandClassInfo, CommandClassInfoDataType
@@ -22,6 +21,7 @@ from .notification import (
     NotificationNotification,
     NotificationNotificationDataType,
 )
+from ..util.helpers import create_buffer
 from .value import (
     ConfigurationValue,
     MetaDataType,
@@ -445,6 +445,30 @@ class Node(EventBase):
         if not isinstance(val, Value):
             val = self.values[val]
         await self.async_send_command("poll_value", valueId=val.data, require_schema=1)
+
+    async def async_begin_firmware_update_guess_format(
+        self, filename: str, file: bytes
+    ) -> Dict[str, Any]:
+        """Send beginFirmwareUpdate command to Node (format to be guessed)."""
+        return await self.async_send_command(
+            "begin_firmware_update_guess_format",
+            firmwareFilename=filename,
+            firmwareFile=create_buffer(file),
+            require_schema=5,
+            wait_for_result=True,
+        )
+
+    async def async_begin_firmware_update_known_format(
+        self, file_format: str, file: bytes
+    ) -> Dict[str, Any]:
+        """Send beginFirmwareUpdate command to Node (format is known)."""
+        return await self.async_send_command(
+            "begin_firmware_update_known_format",
+            firmwareFileFormat=file_format,
+            firmwareFile=create_buffer(file),
+            require_schema=5,
+            wait_for_result=True,
+        )
 
     def handle_wake_up(self, event: Event) -> None:
         """Process a node wake up event."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -21,7 +21,6 @@ from .notification import (
     NotificationNotification,
     NotificationNotificationDataType,
 )
-from ..util.helpers import create_buffer
 from .value import (
     ConfigurationValue,
     MetaDataType,
@@ -445,30 +444,6 @@ class Node(EventBase):
         if not isinstance(val, Value):
             val = self.values[val]
         await self.async_send_command("poll_value", valueId=val.data, require_schema=1)
-
-    async def async_begin_firmware_update_guess_format(
-        self, filename: str, file: bytes
-    ) -> Optional[Dict[str, Any]]:
-        """Send beginFirmwareUpdate command to Node (format to be guessed)."""
-        return await self.async_send_command(
-            "begin_firmware_update_guess_format",
-            firmwareFilename=filename,
-            firmwareFile=create_buffer(file),
-            require_schema=5,
-            wait_for_result=True,
-        )
-
-    async def async_begin_firmware_update_known_format(
-        self, file_format: str, file: bytes
-    ) -> Optional[Dict[str, Any]]:
-        """Send beginFirmwareUpdate command to Node (format is known)."""
-        return await self.async_send_command(
-            "begin_firmware_update_known_format",
-            firmwareFileFormat=file_format,
-            firmwareFile=create_buffer(file),
-            require_schema=5,
-            wait_for_result=True,
-        )
 
     def handle_wake_up(self, event: Event) -> None:
         """Process a node wake up event."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -448,7 +448,7 @@ class Node(EventBase):
 
     async def async_begin_firmware_update_guess_format(
         self, filename: str, file: bytes
-    ) -> Dict[str, Any]:
+    ) -> Optional[Dict[str, Any]]:
         """Send beginFirmwareUpdate command to Node (format to be guessed)."""
         return await self.async_send_command(
             "begin_firmware_update_guess_format",
@@ -460,7 +460,7 @@ class Node(EventBase):
 
     async def async_begin_firmware_update_known_format(
         self, file_format: str, file: bytes
-    ) -> Dict[str, Any]:
+    ) -> Optional[Dict[str, Any]]:
         """Send beginFirmwareUpdate command to Node (format is known)."""
         return await self.async_send_command(
             "begin_firmware_update_known_format",

--- a/zwave_js_server/util/helpers.py
+++ b/zwave_js_server/util/helpers.py
@@ -1,7 +1,7 @@
 """Generic Utility helper functions."""
 import base64
 import json
-from typing import Any, Dict, List, Literal, Union
+from typing import Any, Dict, Union
 
 from ..exceptions import UnparseableValue
 

--- a/zwave_js_server/util/helpers.py
+++ b/zwave_js_server/util/helpers.py
@@ -1,7 +1,7 @@
 """Generic Utility helper functions."""
 
 import json
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Literal, Union
 
 from ..exceptions import UnparseableValue
 
@@ -10,6 +10,15 @@ def is_json_string(value: Any) -> bool:
     """Check if the provided string looks like json."""
     # NOTE: we do not use json.loads here as it is not strict enough
     return isinstance(value, str) and value.startswith("{") and value.endswith("}")
+
+
+def create_buffer(
+    data: Union[bytes, List[int]]
+) -> Dict[str, Union[Literal["Buffer"], List[int]]]:
+    """Create a Buffer dictionary from input data."""
+    if isinstance(data, bytes):
+        data = list(data)
+    return {"type": "Buffer", "data": data}
 
 
 def parse_buffer(value: Union[Dict[str, Any], str]) -> str:

--- a/zwave_js_server/util/helpers.py
+++ b/zwave_js_server/util/helpers.py
@@ -1,5 +1,5 @@
 """Generic Utility helper functions."""
-
+import base64
 import json
 from typing import Any, Dict, List, Literal, Union
 
@@ -12,13 +12,9 @@ def is_json_string(value: Any) -> bool:
     return isinstance(value, str) and value.startswith("{") and value.endswith("}")
 
 
-def create_buffer(
-    data: Union[bytes, List[int]]
-) -> Dict[str, Union[Literal["Buffer"], List[int]]]:
-    """Create a Buffer dictionary from input data."""
-    if isinstance(data, bytes):
-        data = list(data)
-    return {"type": "Buffer", "data": data}
+def convert_bytes_to_base64(data: bytes) -> str:
+    """Convert bytes data to base64 for serialization."""
+    return base64.b64encode(data).decode("ascii")
 
 
 def parse_buffer(value: Union[Dict[str, Any], str]) -> str:


### PR DESCRIPTION
Added support for one new command:
- `node.begin_firmware_update`

This command allows the caller to begin a firmware update with both a known and unknown file format. We will likely use the unknown file format approach in HA.

~~This will be in draft until https://github.com/zwave-js/zwave-js-server/pull/213 gets merged~~

Because of the size of the files that we will be sending, we will be using a separate websocket connection from the main one to send the request