### PR TITLE
Do not update value data with latest value notification data

### DIFF
--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -527,7 +527,7 @@ class Node(EventBase):
         # in the event, otherwise use the event data
         event_data = event.data["args"]
         if value := self.values.get(_get_value_id_from_dict(self, event_data)):
-            value_notification = ValueNotification(self, value.data)
+            value_notification = ValueNotification(self, dict(value.data))
             value_notification.update(event_data)
         else:
             value_notification = ValueNotification(self, event_data)

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -527,7 +527,9 @@ class Node(EventBase):
         # in the event, otherwise use the event data
         event_data = event.data["args"]
         if value := self.values.get(_get_value_id_from_dict(self, event_data)):
-            value_notification = ValueNotification(self, dict(value.data))
+            value_notification = ValueNotification(
+                self, cast(ValueDataType, dict(value.data))
+            )
             value_notification.update(event_data)
         else:
             value_notification = ValueNotification(self, event_data)


### PR DESCRIPTION
I was looking into https://github.com/zwave-js/zwave-js-server/issues/211

What seems to happen is that we pass the value data into the value notification and then merge the value notification info into it. However, since we don't make a copy of the value data, we're also updating the data of the value itself. 

I don't think that this was intended and is most likely the cause of above issue.