### PR TITLE
Improve handling of heal network events

### DIFF
--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -87,6 +87,16 @@ class LogLevel(str, Enum):
     SILLY = "silly"
 
 
+class HealNodeStatus(str, Enum):
+    """Enum for heal node statuses."""
+
+    # https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/controller/Controller.ts#L154
+    PENDING = "pending"
+    DONE = "done"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
 class CommandClass(IntEnum):
     """Enum with all known CommandClasses."""
 

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -1,5 +1,6 @@
 """Provide a model for the Z-Wave JS controller."""
 from typing import TYPE_CHECKING, Dict, List, Optional, TypedDict, cast
+from zwave_js_server.const import HealNodeStatus
 
 from ..event import Event, EventBase
 from .association import Association, AssociationGroup
@@ -373,8 +374,23 @@ class Controller(EventBase):
         """Process a node removed event."""
         event.data["node"] = self.nodes.pop(event.data["node"]["nodeId"])
 
+    def _convert_heal_node_status(
+        self, heal_node_status: Dict[int, str]
+    ) -> Dict[Node, HealNodeStatus]:
+        """Convert a heal node status from the server into something more friendly."""
+        return {
+            self.nodes[node_id]: HealNodeStatus(status)
+            for node_id, status in heal_node_status.items()
+        }
+
     def handle_heal_network_progress(self, event: Event) -> None:
         """Process a heal network progress event."""
+        event.data["heal_network_progress"] = self._convert_heal_node_status(
+            event.data["progress"]
+        )
 
     def handle_heal_network_done(self, event: Event) -> None:
         """Process a heal network done event."""
+        event.data["heal_network_done"] = self._convert_heal_node_status(
+            event.data["result"]
+        )

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -1,7 +1,7 @@
 """Provide a model for the Z-Wave JS controller."""
 from typing import TYPE_CHECKING, Dict, List, Optional, TypedDict, cast
-from zwave_js_server.const import HealNodeStatus
 
+from ..const import HealNodeStatus
 from ..event import Event, EventBase
 from .association import Association, AssociationGroup
 from .node import Node


### PR DESCRIPTION
In this PR we parse the event data and return a corresponding dictionary that includes `Node`s mapped to a `HealNodeStatus` enum.

Note that there is an upstream bug that needs to be resolved so that we can properly see the payload data (right now we get an empty dictionary): https://github.com/zwave-js/zwave-js-server/pull/233. This PR can be merged ahead of that getting merged because it will still work with the current payload