### PR TITLE
Add utility functions to send multicast commands

### DIFF
--- a/test/util/test_multicast.py
+++ b/test/util/test_multicast.py
@@ -19,7 +19,12 @@ async def test_endpoint_get_cc_version_multicast(
         {"version": 1},
     )
 
-    assert await async_multicast_endpoint_get_cc_version(client, 1, CommandClass.ALARM, [node1, node2]) == 1
+    assert (
+        await async_multicast_endpoint_get_cc_version(
+            client, 1, CommandClass.ALARM, [node1, node2]
+        )
+        == 1
+    )
 
     assert ack_commands[0] == {
         "command": "multicast_group.get_cc_version",
@@ -30,16 +35,17 @@ async def test_endpoint_get_cc_version_multicast(
     }
 
 
-async def test_endpoint_get_cc_version_broadcast(
-    client, uuid4, mock_command
-):
+async def test_endpoint_get_cc_version_broadcast(client, uuid4, mock_command):
     """Test broadcast_node.get_cc_version command."""
     ack_commands = mock_command(
         {"command": "broadcast_node.get_cc_version"},
         {"version": 1},
     )
 
-    assert await async_multicast_endpoint_get_cc_version(client, 1, CommandClass.ALARM) == 1
+    assert (
+        await async_multicast_endpoint_get_cc_version(client, 1, CommandClass.ALARM)
+        == 1
+    )
 
     assert ack_commands[0] == {
         "command": "broadcast_node.get_cc_version",
@@ -88,7 +94,9 @@ async def test_set_value(client, uuid4, mock_command):
         {"success": True},
     )
 
-    assert await async_multicast_set_value(client, 1, {"commandClass": 1, "property": 1})
+    assert await async_multicast_set_value(
+        client, 1, {"commandClass": 1, "property": 1}
+    )
 
     assert ack_commands[0] == {
         "command": "broadcast_node.set_value",

--- a/test/util/test_multicast.py
+++ b/test/util/test_multicast.py
@@ -1,0 +1,98 @@
+"""Test node utility functions."""
+from zwave_js_server.const import CommandClass
+from zwave_js_server.util.multicast import (
+    async_multicast_endpoint_get_cc_version,
+    async_multicast_endpoint_supports_cc,
+    async_multicast_get_endpoint_count,
+    async_multicast_set_value,
+)
+
+
+async def test_endpoint_get_cc_version_multicast(
+    climate_radio_thermostat_ct100_plus, inovelli_switch, client, uuid4, mock_command
+):
+    """Test multicast_group.get_cc_version command."""
+    node1 = climate_radio_thermostat_ct100_plus
+    node2 = inovelli_switch
+    ack_commands = mock_command(
+        {"command": "multicast_group.get_cc_version"},
+        {"version": 1},
+    )
+
+    assert await async_multicast_endpoint_get_cc_version(client, 1, CommandClass.ALARM, [node1, node2]) == 1
+
+    assert ack_commands[0] == {
+        "command": "multicast_group.get_cc_version",
+        "index": 1,
+        "commandClass": 113,
+        "nodeIDs": [node1.node_id, node2.node_id],
+        "messageId": uuid4,
+    }
+
+
+async def test_endpoint_get_cc_version_broadcast(
+    client, uuid4, mock_command
+):
+    """Test broadcast_node.get_cc_version command."""
+    ack_commands = mock_command(
+        {"command": "broadcast_node.get_cc_version"},
+        {"version": 1},
+    )
+
+    assert await async_multicast_endpoint_get_cc_version(client, 1, CommandClass.ALARM) == 1
+
+    assert ack_commands[0] == {
+        "command": "broadcast_node.get_cc_version",
+        "index": 1,
+        "commandClass": 113,
+        "messageId": uuid4,
+    }
+
+
+async def test_endpoint_supports_cc(client, uuid4, mock_command):
+    """Test broadcast_node.supports_cc command."""
+    ack_commands = mock_command(
+        {"command": "broadcast_node.supports_cc"},
+        {"supported": True},
+    )
+
+    assert await async_multicast_endpoint_supports_cc(client, 1, CommandClass.ALARM)
+
+    assert ack_commands[0] == {
+        "command": "broadcast_node.supports_cc",
+        "index": 1,
+        "commandClass": 113,
+        "messageId": uuid4,
+    }
+
+
+async def test_get_endpoint_count(client, uuid4, mock_command):
+    """Test broadcast_node.get_endpoint_count command."""
+    ack_commands = mock_command(
+        {"command": "broadcast_node.get_endpoint_count"},
+        {"count": 1},
+    )
+
+    assert await async_multicast_get_endpoint_count(client) == 1
+
+    assert ack_commands[0] == {
+        "command": "broadcast_node.get_endpoint_count",
+        "messageId": uuid4,
+    }
+
+
+async def test_set_value(client, uuid4, mock_command):
+    """Test broadcast_node.set_value command."""
+    ack_commands = mock_command(
+        {"command": "broadcast_node.set_value"},
+        {"success": True},
+    )
+
+    assert await async_multicast_set_value(client, 1, {"commandClass": 1, "property": 1})
+
+    assert ack_commands[0] == {
+        "command": "broadcast_node.set_value",
+        "value": 1,
+        "valueId": {"commandClass": 1, "property": 1},
+        "messageId": uuid4,
+    }

--- a/test/util/test_multicast.py
+++ b/test/util/test_multicast.py
@@ -55,7 +55,7 @@ async def test_endpoint_get_cc_version_broadcast(client, uuid4, mock_command):
     }
 
 
-async def test_endpoint_supports_cc(client, uuid4, mock_command):
+async def test_endpoint_supports_cc_broadcast(client, uuid4, mock_command):
     """Test broadcast_node.supports_cc command."""
     ack_commands = mock_command(
         {"command": "broadcast_node.supports_cc"},
@@ -72,7 +72,31 @@ async def test_endpoint_supports_cc(client, uuid4, mock_command):
     }
 
 
-async def test_get_endpoint_count(client, uuid4, mock_command):
+async def test_endpoint_supports_cc_multicast(
+    climate_radio_thermostat_ct100_plus, inovelli_switch, client, uuid4, mock_command
+):
+    """Test multicast_group.supports_cc command."""
+    node1 = climate_radio_thermostat_ct100_plus
+    node2 = inovelli_switch
+    ack_commands = mock_command(
+        {"command": "multicast_group.supports_cc"},
+        {"supported": True},
+    )
+
+    assert await async_multicast_endpoint_supports_cc(
+        client, 1, CommandClass.ALARM, [node1, node2]
+    )
+
+    assert ack_commands[0] == {
+        "command": "multicast_group.supports_cc",
+        "index": 1,
+        "commandClass": 113,
+        "nodeIDs": [node1.node_id, node2.node_id],
+        "messageId": uuid4,
+    }
+
+
+async def test_get_endpoint_count_broadcast(client, uuid4, mock_command):
     """Test broadcast_node.get_endpoint_count command."""
     ack_commands = mock_command(
         {"command": "broadcast_node.get_endpoint_count"},
@@ -87,7 +111,27 @@ async def test_get_endpoint_count(client, uuid4, mock_command):
     }
 
 
-async def test_set_value(client, uuid4, mock_command):
+async def test_get_endpoint_count_multicast(
+    climate_radio_thermostat_ct100_plus, inovelli_switch, client, uuid4, mock_command
+):
+    """Test multicast_group.get_endpoint_count command."""
+    node1 = climate_radio_thermostat_ct100_plus
+    node2 = inovelli_switch
+    ack_commands = mock_command(
+        {"command": "multicast_group.get_endpoint_count"},
+        {"count": 1},
+    )
+
+    assert await async_multicast_get_endpoint_count(client, [node1, node2]) == 1
+
+    assert ack_commands[0] == {
+        "command": "multicast_group.get_endpoint_count",
+        "nodeIDs": [node1.node_id, node2.node_id],
+        "messageId": uuid4,
+    }
+
+
+async def test_set_value_broadcast(client, uuid4, mock_command):
     """Test broadcast_node.set_value command."""
     ack_commands = mock_command(
         {"command": "broadcast_node.set_value"},
@@ -100,6 +144,30 @@ async def test_set_value(client, uuid4, mock_command):
 
     assert ack_commands[0] == {
         "command": "broadcast_node.set_value",
+        "value": 1,
+        "valueId": {"commandClass": 1, "property": 1},
+        "messageId": uuid4,
+    }
+
+
+async def test_set_value_multicast(
+    climate_radio_thermostat_ct100_plus, inovelli_switch, client, uuid4, mock_command
+):
+    """Test multicast_group.set_value command."""
+    node1 = climate_radio_thermostat_ct100_plus
+    node2 = inovelli_switch
+    ack_commands = mock_command(
+        {"command": "multicast_group.set_value"},
+        {"success": True},
+    )
+
+    assert await async_multicast_set_value(
+        client, 1, {"commandClass": 1, "property": 1}, [node1, node2]
+    )
+
+    assert ack_commands[0] == {
+        "command": "multicast_group.set_value",
+        "nodeIDs": [node1.node_id, node2.node_id],
         "value": 1,
         "valueId": {"commandClass": 1, "property": 1},
         "messageId": uuid4,

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -1,10 +1,10 @@
 """Support for multicast commands."""
 
 from typing import Any, List, Optional, Union, cast
-from zwave_js_server.model.value import Value, ValueDataType
 
 from ..client import Client
 from ..const import CommandClass
+from ..model.value import Value, ValueDataType
 
 
 async def _async_send_command(

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -17,7 +17,11 @@ async def _async_send_command(
 ) -> dict:
     """Send a multicast command."""
     if nodes:
-        cmd = {"command": f"multicast_group.{command}", "nodeIDs": [node.node_id for node in nodes], **kwargs}
+        cmd = {
+            "command": f"multicast_group.{command}",
+            "nodeIDs": [node.node_id for node in nodes],
+            **kwargs,
+        }
     else:
         cmd = {"command": f"broadcast_node.{command}", **kwargs}
 

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -76,7 +76,7 @@ async def async_multicast_endpoint_get_cc_version(
     endpoint: int,
     command_class: CommandClass,
     node_ids: Optional[List[int]] = None,
-) -> bool:
+) -> int:
     """Send a get_cc_version command to a multicast endpoint."""
     result = await _async_send_command(
         client,
@@ -86,4 +86,4 @@ async def async_multicast_endpoint_get_cc_version(
         commandClass=command_class,
         require_schema=5,
     )
-    return cast(bool, result["version"])
+    return cast(int, result["version"])

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -1,6 +1,7 @@
 """Support for multicast commands."""
 
 from typing import Any, List, Optional, Union, cast
+from zwave_js_server.model.node import Node
 
 from ..client import Client
 from ..const import CommandClass
@@ -10,13 +11,13 @@ from ..model.value import Value, ValueDataType
 async def _async_send_command(
     client: Client,
     command: str,
-    node_ids: Optional[List[int]] = None,
+    nodes: Optional[List[Node]] = None,
     require_schema: Optional[int] = None,
     **kwargs: Any,
 ) -> dict:
     """Send a multicast command."""
-    if node_ids:
-        cmd = {"command": f"multicast_group.{command}", "node_ids": node_ids, **kwargs}
+    if nodes:
+        cmd = {"command": f"multicast_group.{command}", "nodeIDs": [node.node_id for node in nodes], **kwargs}
     else:
         cmd = {"command": f"broadcast_node.{command}", **kwargs}
 
@@ -27,7 +28,7 @@ async def async_multicast_set_value(
     client: Client,
     new_value: Any,
     val: Union[Value, ValueDataType],
-    node_ids: Optional[List[int]] = None,
+    nodes: Optional[List[Node]] = None,
 ) -> bool:
     """Send a multicast set_value command."""
     value_id = val.data if isinstance(val, Value) else val
@@ -35,7 +36,7 @@ async def async_multicast_set_value(
     result = await _async_send_command(
         client,
         "set_value",
-        node_ids,
+        nodes,
         valueId=value_id,
         value=new_value,
         require_schema=5,
@@ -44,11 +45,11 @@ async def async_multicast_set_value(
 
 
 async def async_multicast_get_endpoint_count(
-    client: Client, node_ids: Optional[List[int]] = None
+    client: Client, nodes: Optional[List[Node]] = None
 ) -> int:
     """Send a multicast get_endpoint_count command."""
     result = await _async_send_command(
-        client, "get_endpoint_count", node_ids, require_schema=5
+        client, "get_endpoint_count", nodes, require_schema=5
     )
     return cast(int, result["count"])
 
@@ -57,13 +58,13 @@ async def async_multicast_endpoint_supports_cc(
     client: Client,
     endpoint: int,
     command_class: CommandClass,
-    node_ids: Optional[List[int]] = None,
+    nodes: Optional[List[Node]] = None,
 ) -> bool:
     """Send a supports_cc command to a multicast endpoint."""
     result = await _async_send_command(
         client,
         "supports_cc",
-        node_ids,
+        nodes,
         index=endpoint,
         commandClass=command_class,
         require_schema=5,
@@ -75,13 +76,13 @@ async def async_multicast_endpoint_get_cc_version(
     client: Client,
     endpoint: int,
     command_class: CommandClass,
-    node_ids: Optional[List[int]] = None,
+    nodes: Optional[List[Node]] = None,
 ) -> int:
     """Send a get_cc_version command to a multicast endpoint."""
     result = await _async_send_command(
         client,
         "get_cc_version",
-        node_ids,
+        nodes,
         index=endpoint,
         commandClass=command_class,
         require_schema=5,

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -1,0 +1,89 @@
+"""Support for multicast commands."""
+
+from typing import Any, List, Optional, Union, cast
+from zwave_js_server.model.value import Value, ValueDataType
+
+from ..client import Client
+from ..const import CommandClass
+
+
+async def _async_send_command(
+    client: Client,
+    command: str,
+    node_ids: Optional[List[int]] = None,
+    require_schema: Optional[int] = None,
+    **kwargs: Any,
+) -> dict:
+    """Send a multicast command."""
+    if node_ids:
+        cmd = {"command": f"multicast_group.{command}", "node_ids": node_ids, **kwargs}
+    else:
+        cmd = {"command": f"broadcast_node.{command}", **kwargs}
+
+    return await client.async_send_command(cmd, require_schema)
+
+
+async def async_multicast_set_value(
+    client: Client,
+    new_value: Any,
+    val: Union[Value, ValueDataType],
+    node_ids: Optional[List[int]] = None,
+) -> bool:
+    """Send a multicast set_value command."""
+    value_id = val.data if isinstance(val, Value) else val
+
+    result = await _async_send_command(
+        client,
+        "set_value",
+        node_ids,
+        valueId=value_id,
+        value=new_value,
+        require_schema=5,
+    )
+    return cast(bool, result["success"])
+
+
+async def async_multicast_get_endpoint_count(
+    client: Client, node_ids: Optional[List[int]] = None
+) -> int:
+    """Send a multicast get_endpoint_count command."""
+    result = await _async_send_command(
+        client, "get_endpoint_count", node_ids, require_schema=5
+    )
+    return cast(int, result["count"])
+
+
+async def async_multicast_endpoint_supports_cc(
+    client: Client,
+    endpoint: int,
+    command_class: CommandClass,
+    node_ids: Optional[List[int]] = None,
+) -> bool:
+    """Send a supports_cc command to a multicast endpoint."""
+    result = await _async_send_command(
+        client,
+        "supports_cc",
+        node_ids,
+        index=endpoint,
+        commandClass=command_class,
+        require_schema=5,
+    )
+    return cast(bool, result["supported"])
+
+
+async def async_multicast_endpoint_get_cc_version(
+    client: Client,
+    endpoint: int,
+    command_class: CommandClass,
+    node_ids: Optional[List[int]] = None,
+) -> bool:
+    """Send a get_cc_version command to a multicast endpoint."""
+    result = await _async_send_command(
+        client,
+        "get_cc_version",
+        node_ids,
+        index=endpoint,
+        commandClass=command_class,
+        require_schema=5,
+    )
+    return cast(bool, result["version"])


### PR DESCRIPTION
These multicast commands don't really fit into our existing model, so I thought they made more sense as utility commands. We can either send a broadcast to all nodes or a multicast to a subset of nodes, and that is controlled by whether the node_id's are provided or not.