### PR TITLE
Bump minimum server schema version to 5

### DIFF
--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -3,7 +3,7 @@ from enum import Enum, IntEnum
 from typing import Dict, List
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 4
+MIN_SERVER_SCHEMA_VERSION = 5
 # max server schema version we can handle (and our code is compatible with)
 MAX_SERVER_SCHEMA_VERSION = 5
 


### PR DESCRIPTION
- Bumping the server schema version to 5 will require library users to install and use a zwave-js-server with at least version 5 support.