### PR TITLE
Fix KeyError: 'isHealNetworkActive'

### DIFF
--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -145,9 +145,9 @@ class Controller(EventBase):
         return self.data.get("supportsTimers")
 
     @property
-    def is_heal_network_active(self) -> bool:
+    def is_heal_network_active(self) -> Optional[bool]:
         """Return is_heal_network_active."""
-        return self.data["isHealNetworkActive"]
+        return self.data.get("isHealNetworkActive")
 
     async def async_begin_inclusion(
         self, include_non_secure: Optional[bool] = None


### PR DESCRIPTION
Accessing the controller `is_heal_network_active` property results in a KeyError for node-zwave-js versions prior to 7.6.0.