### PR TITLE
Change the order of messages sent to the server on connection

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -128,10 +128,10 @@ async def ws_client_fixture(
     ws_client.receive_json.side_effect = (
         version_data,
         set_api_schema_data,
-        result,
         get_log_config_data,
+        result,
     )
-    for data in (version_data, set_api_schema_data, result, get_log_config_data):
+    for data in (version_data, set_api_schema_data, get_log_config_data, result):
         messages.append(create_ws_message(data))
 
     async def receive():

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -32,22 +32,29 @@ def event_fixture():
 
 
 async def test_dump(
-    client_session, result, url, version_data, set_api_schema_data, ws_client
+    client_session,
+    result,
+    url,
+    version_data,
+    get_log_config_data,
+    set_api_schema_data,
+    ws_client,
 ):
     """Test the dump function."""
     messages = await dump_msgs(url, client_session)
 
-    assert ws_client.receive_json.call_count == 3
-    assert ws_client.send_json.call_count == 2
+    assert ws_client.receive_json.call_count == 4
+    assert ws_client.send_json.call_count == 3
     assert ws_client.send_json.call_args == call(
         {"command": "start_listening", "messageId": "listen-id"}
     )
     assert ws_client.close.call_count == 1
     assert messages
-    assert len(messages) == 3
+    assert len(messages) == 4
     assert messages[0] == version_data
     assert messages[1] == set_api_schema_data
-    assert messages[2] == result
+    assert messages[2] == get_log_config_data
+    assert messages[3] == result
 
 
 async def test_dump_timeout(
@@ -65,7 +72,7 @@ async def test_dump_timeout(
     messages = await dump_msgs(url, client_session, 0.05)
 
     assert ws_client.receive_json.call_count == 5
-    assert ws_client.send_json.call_count == 2
+    assert ws_client.send_json.call_count == 3
     assert ws_client.send_json.call_args == call(
         {"command": "start_listening", "messageId": "listen-id"}
     )

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -2,6 +2,7 @@
 import asyncio
 from unittest.mock import AsyncMock, call
 
+from aiohttp.client import ClientSession
 import pytest
 
 from zwave_js_server.dump import dump_msgs
@@ -31,23 +32,33 @@ def event_fixture():
     }
 
 
+@pytest.fixture(name="no_get_log_config_client_session")
+def no_get_log_config_client_session_fixture(no_get_log_config_ws_client):
+    """Mock an aiohttp client session without calling get_log_config."""
+    no_get_log_config_client_session = AsyncMock(spec_set=ClientSession)
+    no_get_log_config_client_session.ws_connect.side_effect = AsyncMock(
+        return_value=no_get_log_config_ws_client
+    )
+    return no_get_log_config_client_session
+
+
 async def test_dump(
-    dump_client_session,
+    no_get_log_config_client_session,
     result,
     url,
     version_data,
     set_api_schema_data,
-    dump_ws_client,
+    no_get_log_config_ws_client,
 ):
     """Test the dump function."""
-    messages = await dump_msgs(url, dump_client_session)
+    messages = await dump_msgs(url, no_get_log_config_client_session)
 
-    assert dump_ws_client.receive_json.call_count == 3
-    assert dump_ws_client.send_json.call_count == 2
-    assert dump_ws_client.send_json.call_args == call(
+    assert no_get_log_config_ws_client.receive_json.call_count == 3
+    assert no_get_log_config_ws_client.send_json.call_count == 2
+    assert no_get_log_config_ws_client.send_json.call_args == call(
         {"command": "start_listening", "messageId": "listen-id"}
     )
-    assert dump_ws_client.close.call_count == 1
+    assert no_get_log_config_ws_client.close.call_count == 1
     assert messages
     assert len(messages) == 3
     assert messages[0] == version_data
@@ -56,13 +67,13 @@ async def test_dump(
 
 
 async def test_dump_timeout(
-    dump_client_session,
+    no_get_log_config_client_session,
     result,
     url,
     event,
     version_data,
     set_api_schema_data,
-    dump_ws_client,
+    no_get_log_config_ws_client,
 ):
     """Test the dump function with timeout."""
     to_receive = asyncio.Queue()
@@ -72,15 +83,15 @@ async def test_dump_timeout(
     async def receive_json():
         return await to_receive.get()
 
-    dump_ws_client.receive_json = AsyncMock(side_effect=receive_json)
-    messages = await dump_msgs(url, dump_client_session, 0.05)
+    no_get_log_config_ws_client.receive_json = AsyncMock(side_effect=receive_json)
+    messages = await dump_msgs(url, no_get_log_config_client_session, 0.05)
 
-    assert dump_ws_client.receive_json.call_count == 5
-    assert dump_ws_client.send_json.call_count == 2
-    assert dump_ws_client.send_json.call_args == call(
+    assert no_get_log_config_ws_client.receive_json.call_count == 5
+    assert no_get_log_config_ws_client.send_json.call_count == 2
+    assert no_get_log_config_ws_client.send_json.call_args == call(
         {"command": "start_listening", "messageId": "listen-id"}
     )
-    assert dump_ws_client.close.call_count == 1
+    assert no_get_log_config_ws_client.close.call_count == 1
     assert messages
     assert len(messages) == 4
     assert messages[0] == version_data

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -52,10 +52,13 @@ def test_dump_state(client_session, url, ws_client, result, capsys):
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
         "'minSchemaVersion': 0, 'maxSchemaVersion': 5}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
+        "{'type': 'result', 'success': True, 'result': {'config': {'enabled': True, "
+        "'level': 'info', 'logToFile': False, 'filename': '', 'forceConsole': "
+        "False}}, 'messageId': 'get-initial-log-config'}\n"
         "test_result\n"
     )
 
-    assert ws_client.receive_json.call_count == 3
+    assert ws_client.receive_json.call_count == 4
     assert ws_client.close.call_count == 1
 
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -37,8 +37,7 @@ def test_server_version(client_session, url, ws_client, result, capsys):
     assert ws_client.close.call_count == 1
 
 
-@pytest.mark.parametrize("result", ["test_result"])
-def test_dump_state(client_session, url, ws_client, result, capsys):
+def test_dump_state(dump_client_session, url, dump_ws_client, capsys):
     """Test dump state."""
     with patch.object(
         sys, "argv", ["zwave_js_server", url, "--dump-state"]
@@ -52,14 +51,11 @@ def test_dump_state(client_session, url, ws_client, result, capsys):
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
         "'minSchemaVersion': 0, 'maxSchemaVersion': 5}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
-        "{'type': 'result', 'success': True, 'result': {'config': {'enabled': True, "
-        "'level': 'info', 'logToFile': False, 'filename': '', 'forceConsole': "
-        "False}}, 'messageId': 'get-initial-log-config'}\n"
         "test_result\n"
     )
 
-    assert ws_client.receive_json.call_count == 4
-    assert ws_client.close.call_count == 1
+    assert dump_ws_client.receive_json.call_count == 3
+    assert dump_ws_client.close.call_count == 1
 
 
 def test_connect(client_session, url, ws_client):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -19,7 +19,19 @@ def client_session_fixture(ws_client):
         yield session
 
 
-def test_server_version(client_session, url, ws_client, result, capsys):
+@pytest.fixture(name="no_get_log_config_client_session")
+def no_get_log_config_client_session_fixture(no_get_log_config_ws_client):
+    """Mock the aiohttp client session that doesn't call get_log_config."""
+    with patch("aiohttp.ClientSession") as session:
+        session.return_value.__aenter__.return_value.ws_connect.side_effect = AsyncMock(
+            return_value=no_get_log_config_ws_client
+        )
+        yield session
+
+
+def test_server_version(
+    no_get_log_config_client_session, url, no_get_log_config_ws_client, result, capsys
+):
     """Test print server version."""
     with patch.object(
         sys, "argv", ["zwave_js_server", url, "--server-version"]
@@ -33,12 +45,14 @@ def test_server_version(client_session, url, ws_client, result, capsys):
         "Server: test_server_version\n"
         "Home ID: test_home_id\n"
     )
-    assert ws_client.receive_json.call_count == 1
-    assert ws_client.close.call_count == 1
+    assert no_get_log_config_ws_client.receive_json.call_count == 1
+    assert no_get_log_config_ws_client.close.call_count == 1
 
 
 @pytest.mark.parametrize("result", ["test_result"])
-def test_dump_state(dump_client_session, url, dump_ws_client, result, capsys):
+def test_dump_state(
+    no_get_log_config_client_session, url, no_get_log_config_ws_client, result, capsys
+):
     """Test dump state."""
     with patch.object(
         sys, "argv", ["zwave_js_server", url, "--dump-state"]
@@ -55,8 +69,8 @@ def test_dump_state(dump_client_session, url, dump_ws_client, result, capsys):
         "test_result\n"
     )
 
-    assert dump_ws_client.receive_json.call_count == 3
-    assert dump_ws_client.close.call_count == 1
+    assert no_get_log_config_ws_client.receive_json.call_count == 3
+    assert no_get_log_config_ws_client.close.call_count == 1
 
 
 def test_connect(client_session, url, ws_client):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -37,7 +37,8 @@ def test_server_version(client_session, url, ws_client, result, capsys):
     assert ws_client.close.call_count == 1
 
 
-def test_dump_state(dump_client_session, url, dump_ws_client, capsys):
+@pytest.mark.parametrize("result", ["test_result"])
+def test_dump_state(dump_client_session, url, dump_ws_client, result, capsys):
     """Test dump state."""
     with patch.object(
         sys, "argv", ["zwave_js_server", url, "--dump-state"]

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -169,18 +169,6 @@ class Client:
         try:
             await self.set_api_schema()
 
-            # send start_listening command to the server
-            # we will receive a full state dump and from now on get events
-            await self._send_json_message(
-                {"command": "start_listening", "messageId": "listen-id"}
-            )
-
-            state_msg = await self._receive_json_or_raise()
-
-            if not state_msg["success"]:
-                await self._client.close()
-                raise FailedCommand(state_msg["messageId"], state_msg["errorCode"])
-
             await self._send_json_message(
                 {
                     "command": "driver.get_log_config",
@@ -194,6 +182,18 @@ class Client:
             if not log_msg["success"]:
                 await self._client.close()
                 raise FailedCommand(log_msg["messageId"], log_msg["errorCode"])
+
+            # send start_listening command to the server
+            # we will receive a full state dump and from now on get events
+            await self._send_json_message(
+                {"command": "start_listening", "messageId": "listen-id"}
+            )
+
+            state_msg = await self._receive_json_or_raise()
+
+            if not state_msg["success"]:
+                await self._client.close()
+                raise FailedCommand(state_msg["messageId"], state_msg["errorCode"])
 
             self.driver = cast(
                 Driver,

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -25,10 +25,6 @@ async def dump_msgs(
             "messageId": "api-schema-id",
             "schemaVersion": MAX_SERVER_SCHEMA_VERSION,
         },
-        {
-            "command": "driver.get_log_config",
-            "messageId": "get-initial-log-config",
-        },
         {"command": "start_listening", "messageId": "listen-id"},
     ):
         await client.send_json(to_send)

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -25,6 +25,10 @@ async def dump_msgs(
             "messageId": "api-schema-id",
             "schemaVersion": MAX_SERVER_SCHEMA_VERSION,
         },
+        {
+            "command": "driver.get_log_config",
+            "messageId": "get-initial-log-config",
+        },
         {"command": "start_listening", "messageId": "listen-id"},
     ):
         await client.send_json(to_send)


### PR DESCRIPTION
Currently, on connection, we send `start_listening` before `driver.get_log_config`. Per https://github.com/home-assistant/core/issues/51334 and https://github.com/home-assistant/core/issues/51384 this can result in events getting sent to the client before the `driver.get_log_config` message response is received which breaks the order of operations in `Client.listen()`. So we will simply switch the order of messages sent so that `start_listening` is the last message to be sent.

~~As part of this change, I also added the `driver.get_log_config` message to the dump. Admittedly I did this because it was easier to adjust the fixtures when the `dump_msgs` function sent the same messages in the same order as `Client.listen()`, but I also don't see any harm in adding it. With that being said, I can adjust this if needed (we'd basically have to duplicate the `ws_client` and `client_session` fixtures specifically for the dump function).~~

Fixes https://github.com/home-assistant/core/issues/51384 and fixes https://github.com/home-assistant/core/issues/51334