### PR TITLE
Bump library to 0.26.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.26.0"
+VERSION = "0.26.1"
 
 
 setup(


### PR DESCRIPTION
Once https://github.com/home-assistant-libs/zwave-js-server-python/pull/230 is merged we will need to release a new version of the library so we can bump it in HA