### PR TITLE
Add support for Z-Wave JS 7.9 changes

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -255,7 +255,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 5,
+        "maxSchemaVersion": 6,
     }
 
 

--- a/test/model/test_driver.py
+++ b/test/model/test_driver.py
@@ -281,3 +281,17 @@ async def test_install_config_update(driver, uuid4, mock_command):
         "command": "driver.install_config_update",
         "messageId": uuid4,
     }
+
+
+async def test_set_preferred_scales(driver, uuid4, mock_command):
+    """Test driver.set_preferred_scales command."""
+    ack_commands = mock_command({"command": "driver.set_preferred_scales"}, {})
+
+    assert not await driver.async_set_preferred_scales({1: 1})
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "driver.set_preferred_scales",
+        "scales": {1: 1},
+        "messageId": uuid4,
+    }

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -182,6 +182,20 @@ async def test_set_value(multisensor_6, uuid4, mock_command):
         "messageId": uuid4,
     }
 
+    # Set value with options
+
+    assert await node.async_set_value(value_id, 42, {"transitionDuration": 1}) is None
+
+    assert len(ack_commands) == 2
+    assert ack_commands[1] == {
+        "command": "node.set_value",
+        "nodeId": node.node_id,
+        "valueId": value.data,
+        "value": 42,
+        "options": {"transitionDuration": 1},
+        "messageId": uuid4,
+    }
+
 
 async def test_poll_value(multisensor_6, uuid4, mock_command):
     """Test poll value."""

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -64,7 +64,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 5}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 6}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -3,9 +3,9 @@ from enum import Enum, IntEnum
 from typing import Dict, List
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 5
+MIN_SERVER_SCHEMA_VERSION = 6
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 5
+MAX_SERVER_SCHEMA_VERSION = 6
 
 VALUE_UNKNOWN = "unknown"
 

--- a/zwave_js_server/model/driver.py
+++ b/zwave_js_server/model/driver.py
@@ -1,5 +1,5 @@
 """Provide a model for the Z-Wave JS Driver."""
-from typing import Any, Optional, TYPE_CHECKING, cast
+from typing import Any, Dict, Optional, TYPE_CHECKING, Union, cast
 
 from zwave_js_server.model.log_config import LogConfig, LogConfigDataType
 from zwave_js_server.model.log_message import LogMessage, LogMessageDataType
@@ -131,3 +131,11 @@ class Driver(EventBase):
             "install_config_update", require_schema=5
         )
         return cast(bool, result["success"])
+
+    async def async_set_preferred_scales(
+        self, scales: Dict[Union[str, int], Union[str, int]]
+    ) -> None:
+        """Send command to set preferred sensor scales."""
+        await self._async_send_command(
+            "set_preferred_scales", scales=scales, require_schema=6
+        )

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -367,6 +367,7 @@ class Node(EventBase):
         self,
         val: Union[Value, str],
         new_value: Any,
+        options: dict = None,
         wait_for_result: Optional[bool] = None,
     ) -> Optional[bool]:
         """Send setValue command to Node for given value (or value_id)."""
@@ -377,12 +378,16 @@ class Node(EventBase):
         if val.metadata.writeable is False:
             raise UnwriteableValue
 
+        cmd_args = {
+            "valueId": val.data,
+            "value": new_value,
+        }
+        if options:
+            cmd_args["options"] = options
+
         # the value object needs to be send to the server
         result = await self.async_send_command(
-            "set_value",
-            valueId=val.data,
-            value=new_value,
-            wait_for_result=wait_for_result,
+            "set_value", **cmd_args, wait_for_result=wait_for_result
         )
 
         if result is None:


### PR DESCRIPTION
In Z-Wave JS 7.9, a new driver command was added to set preferred sensor scales, and `node.setValue` now accepts options.

Corresponding zwave-js-server changes: https://github.com/zwave-js/zwave-js-server/pull/274
zwave-js Changelog: https://github.com/zwave-js/node-zwave-js/releases/tag/v7.9.0