### PR TITLE
Make Node a subclass of Endpoint

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -393,7 +393,7 @@ def test_node_inclusion():
     """Emulate a node being added."""
     # when a node node is added, it has minimal info first
     node = node_pkg.Node(
-        None, {"nodeId": 52, "status": 1, "ready": False, "values": []}
+        None, {"nodeId": 52, "status": 1, "ready": False, "values": [], "endpoints": []}
     )
     assert node.node_id == 52
     assert node.status == 1

--- a/zwave_js_server/model/driver.py
+++ b/zwave_js_server/model/driver.py
@@ -1,5 +1,5 @@
 """Provide a model for the Z-Wave JS Driver."""
-from typing import Any, Dict, Optional, TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
 
 from zwave_js_server.model.log_config import LogConfig, LogConfigDataType
 from zwave_js_server.model.log_message import LogMessage, LogMessageDataType

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -4,13 +4,12 @@ Model for a Zwave Node's endpoints.
 https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=endpoint-properties
 """
 
-from typing import Dict, List, TYPE_CHECKING, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Dict, Optional, TypedDict, Union
 
-from .command_class import CommandClassInfoDataType
-from .device_class import DeviceClass, DeviceClassDataType
-from .device_config import DeviceConfigDataType
 from ..event import EventBase
-from .value import ConfigurationValue, Value, ValueDataType
+from .device_class import DeviceClass, DeviceClassDataType
+from .node import NodeDataType
+from .value import ConfigurationValue, Value
 
 if TYPE_CHECKING:
     from ..client import Client
@@ -26,41 +25,6 @@ class EndpointDataType(TypedDict, total=False):
     installerIcon: int
     userIcon: int
 
-    # Node data
-    name: str
-    location: str
-    status: int  # 0-4  # required for Nodes
-    zwavePlusVersion: int
-    zwavePlusNodeType: int
-    zwavePlusRoleType: int
-    isListening: bool
-    isFrequentListening: Union[bool, str]
-    isRouting: bool
-    maxDataRate: int
-    supportedDataRates: List[int]
-    isSecure: bool
-    supportsBeaming: bool
-    supportsSecurity: bool
-    protocolVersion: int
-    firmwareVersion: str
-    manufacturerId: int
-    productId: int
-    productType: int
-    deviceConfig: DeviceConfigDataType
-    deviceDatabaseUrl: str
-    keepAwake: bool
-    ready: bool
-    label: str
-    endpoints: List["EndpointDataType"]  # type: ignore
-    endpointCountIsDynamic: bool
-    endpointsHaveIdenticalCapabilities: bool
-    individualEndpointCount: int
-    aggregatedEndpointCount: int
-    interviewAttempts: int
-    interviewStage: Optional[Union[int, str]]
-    commandClasses: List[CommandClassInfoDataType]
-    values: List[ValueDataType]
-
 
 class Endpoint(EventBase):
     """Model for a Zwave Node's endpoint."""
@@ -68,7 +32,7 @@ class Endpoint(EventBase):
     def __init__(
         self,
         client: "Client",
-        data: EndpointDataType,
+        data: Union[EndpointDataType, NodeDataType],
         values: Dict[str, Union[ConfigurationValue, Value]] = None,
     ) -> None:
         """Initialize."""

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -4,9 +4,13 @@ Model for a Zwave Node's endpoints.
 https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=endpoint-properties
 """
 
-from typing import Optional, TypedDict
+from typing import Optional, TYPE_CHECKING, TypedDict
+from zwave_js_server.event import EventBase
 
 from .device_class import DeviceClass, DeviceClassDataType
+
+if TYPE_CHECKING:
+    from ..client import Client
 
 
 class EndpointDataType(TypedDict, total=False):
@@ -19,11 +23,13 @@ class EndpointDataType(TypedDict, total=False):
     userIcon: int
 
 
-class Endpoint:
+class Endpoint(EventBase):
     """Model for a Zwave Node's endpoint."""
 
-    def __init__(self, data: EndpointDataType) -> None:
+    def __init__(self, client: "Client", data: EndpointDataType) -> None:
         """Initialize."""
+        super().__init__()
+        self.client = client
         self.data = data
 
     @property

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -4,14 +4,13 @@ Model for a Zwave Node's endpoints.
 https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=endpoint-properties
 """
 
-from typing import List, TYPE_CHECKING, Optional, TypedDict, Union
-from zwave_js_server.model.value import ValueDataType
-from zwave_js_server.model.command_class import CommandClassInfoDataType
-from zwave_js_server.model.device_config import DeviceConfigDataType
+from typing import Dict, List, TYPE_CHECKING, Optional, TypedDict, Union
 
-from zwave_js_server.event import EventBase
-
+from .command_class import CommandClassInfoDataType
 from .device_class import DeviceClass, DeviceClassDataType
+from .device_config import DeviceConfigDataType
+from ..event import EventBase
+from .value import ConfigurationValue, Value, ValueDataType
 
 if TYPE_CHECKING:
     from ..client import Client
@@ -66,11 +65,18 @@ class EndpointDataType(TypedDict, total=False):
 class Endpoint(EventBase):
     """Model for a Zwave Node's endpoint."""
 
-    def __init__(self, client: "Client", data: EndpointDataType) -> None:
+    def __init__(
+        self,
+        client: "Client",
+        data: EndpointDataType,
+        values: Dict[str, Union[ConfigurationValue, Value]] = None,
+    ) -> None:
         """Initialize."""
         super().__init__()
         self.client = client
         self.data = data
+        if values is not None:
+            self.values = values
 
     @property
     def node_id(self) -> int:

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -20,11 +20,14 @@ if TYPE_CHECKING:
 class EndpointDataType(TypedDict, total=False):
     """Represent an endpoint data dict type."""
 
+    # Endpoint data
     nodeId: int  # required
     index: int  # required
     deviceClass: DeviceClassDataType  # required
     installerIcon: int
     userIcon: int
+
+    # Node data
     name: str
     location: str
     status: int  # 0-4  # required for Nodes

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -4,7 +4,10 @@ Model for a Zwave Node's endpoints.
 https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=endpoint-properties
 """
 
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import List, TYPE_CHECKING, Optional, TypedDict, Union
+from zwave_js_server.model.value import ValueDataType
+from zwave_js_server.model.command_class import CommandClassInfoDataType
+from zwave_js_server.model.device_config import DeviceConfigDataType
 
 from zwave_js_server.event import EventBase
 
@@ -22,6 +25,39 @@ class EndpointDataType(TypedDict, total=False):
     deviceClass: DeviceClassDataType  # required
     installerIcon: int
     userIcon: int
+    name: str
+    location: str
+    status: int  # 0-4  # required for Nodes
+    zwavePlusVersion: int
+    zwavePlusNodeType: int
+    zwavePlusRoleType: int
+    isListening: bool
+    isFrequentListening: Union[bool, str]
+    isRouting: bool
+    maxDataRate: int
+    supportedDataRates: List[int]
+    isSecure: bool
+    supportsBeaming: bool
+    supportsSecurity: bool
+    protocolVersion: int
+    firmwareVersion: str
+    manufacturerId: int
+    productId: int
+    productType: int
+    deviceConfig: DeviceConfigDataType
+    deviceDatabaseUrl: str
+    keepAwake: bool
+    ready: bool
+    label: str
+    endpoints: List["EndpointDataType"]  # type: ignore
+    endpointCountIsDynamic: bool
+    endpointsHaveIdenticalCapabilities: bool
+    individualEndpointCount: int
+    aggregatedEndpointCount: int
+    interviewAttempts: int
+    interviewStage: Optional[Union[int, str]]
+    commandClasses: List[CommandClassInfoDataType]
+    values: List[ValueDataType]
 
 
 class Endpoint(EventBase):

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Dict, Optional, TypedDict, Union
 
 from ..event import EventBase
 from .device_class import DeviceClass, DeviceClassDataType
-from .node import NodeDataType
 from .value import ConfigurationValue, Value
 
 if TYPE_CHECKING:
@@ -31,7 +30,7 @@ class Endpoint(EventBase):
     def __init__(
         self,
         client: "Client",
-        data: Union[EndpointDataType, NodeDataType],
+        data: EndpointDataType,
         values: Dict[str, Union[ConfigurationValue, Value]] = None,
     ) -> None:
         """Initialize."""

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 class EndpointDataType(TypedDict, total=False):
     """Represent an endpoint data dict type."""
 
-    # Endpoint data
     nodeId: int  # required
     index: int  # required
     deviceClass: DeviceClassDataType  # required

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -4,7 +4,8 @@ Model for a Zwave Node's endpoints.
 https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=endpoint-properties
 """
 
-from typing import Optional, TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Optional, TypedDict
+
 from zwave_js_server.event import EventBase
 
 from .device_class import DeviceClass, DeviceClassDataType

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -1,13 +1,12 @@
 """Provide a model for the Z-Wave JS node."""
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 from ..const import INTERVIEW_FAILED, CommandClass
 from ..event import Event
 from ..exceptions import FailedCommand, UnparseableValue, UnwriteableValue
-from .command_class import CommandClassInfo, CommandClassInfoDataType
-from .device_class import DeviceClassDataType
-from .device_config import DeviceConfig, DeviceConfigDataType
+from .command_class import CommandClassInfo
+from .device_config import DeviceConfig
 from .endpoint import Endpoint, EndpointDataType
 from .firmware import (
     FirmwareUpdateFinished,
@@ -49,53 +48,10 @@ class NodeStatus(IntEnum):
     ALIVE = 4
 
 
-class NodeDataType(TypedDict, total=False):
-    """Represent a node data dict type."""
-
-    nodeId: int  # required
-    name: str
-    location: str
-    status: int  # 0-4  # required
-    deviceClass: DeviceClassDataType
-    zwavePlusVersion: int
-    zwavePlusNodeType: int
-    zwavePlusRoleType: int
-    isListening: bool
-    isFrequentListening: Union[bool, str]
-    isRouting: bool
-    maxDataRate: int
-    supportedDataRates: List[int]
-    isSecure: bool
-    supportsBeaming: bool
-    supportsSecurity: bool
-    protocolVersion: int
-    firmwareVersion: str
-    manufacturerId: int
-    productId: int
-    productType: int
-    deviceConfig: DeviceConfigDataType
-    deviceDatabaseUrl: str
-    keepAwake: bool
-    index: int
-    installerIcon: int
-    userIcon: int
-    ready: bool
-    label: str
-    endpoints: List[EndpointDataType]
-    endpointCountIsDynamic: bool
-    endpointsHaveIdenticalCapabilities: bool
-    individualEndpointCount: int
-    aggregatedEndpointCount: int
-    interviewAttempts: int
-    interviewStage: Optional[Union[int, str]]
-    commandClasses: List[CommandClassInfoDataType]
-    values: List[ValueDataType]
-
-
 class Node(Endpoint):
     """Represent a Z-Wave JS node."""
 
-    def __init__(self, client: "Client", data: NodeDataType) -> None:
+    def __init__(self, client: "Client", data: EndpointDataType) -> None:
         """Initialize the node."""
         super().__init__(client, data)
         self._device_config = DeviceConfig(self.data.get("deviceConfig", {}))

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 from ..const import INTERVIEW_FAILED, CommandClass
 from ..event import Event
 from ..exceptions import FailedCommand, UnparseableValue, UnwriteableValue
-from .command_class import CommandClassInfo
-from .device_config import DeviceConfig
+from .command_class import CommandClassInfo, CommandClassInfoDataType
+from .device_config import DeviceConfig, DeviceConfigDataType
 from .endpoint import Endpoint, EndpointDataType
 from .firmware import (
     FirmwareUpdateFinished,
@@ -48,12 +48,51 @@ class NodeStatus(IntEnum):
     ALIVE = 4
 
 
+class NodeDataType(EndpointDataType):
+    """Represent a node data dict type."""
+
+    name: str
+    location: str
+    status: int  # 0-4  # required
+    zwavePlusVersion: int
+    zwavePlusNodeType: int
+    zwavePlusRoleType: int
+    isListening: bool
+    isFrequentListening: Union[bool, str]
+    isRouting: bool
+    maxDataRate: int
+    supportedDataRates: List[int]
+    isSecure: bool
+    supportsBeaming: bool
+    supportsSecurity: bool
+    protocolVersion: int
+    firmwareVersion: str
+    manufacturerId: int
+    productId: int
+    productType: int
+    deviceConfig: DeviceConfigDataType
+    deviceDatabaseUrl: str
+    keepAwake: bool
+    ready: bool
+    label: str
+    endpoints: List[EndpointDataType]
+    endpointCountIsDynamic: bool
+    endpointsHaveIdenticalCapabilities: bool
+    individualEndpointCount: int
+    aggregatedEndpointCount: int
+    interviewAttempts: int
+    interviewStage: Optional[Union[int, str]]
+    commandClasses: List[CommandClassInfoDataType]
+    values: List[ValueDataType]
+
+
 class Node(Endpoint):
     """Represent a Z-Wave JS node."""
 
-    def __init__(self, client: "Client", data: EndpointDataType) -> None:
+    def __init__(self, client: "Client", data: NodeDataType) -> None:
         """Initialize the node."""
         super().__init__(client, data)
+        self.data = data
         self._device_config = DeviceConfig(self.data.get("deviceConfig", {}))
         self.values: Dict[str, Union[Value, ConfigurationValue]] = {}
         for val in data["values"]:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -2,7 +2,7 @@
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
 
-from ..const import CommandClass, INTERVIEW_FAILED
+from ..const import INTERVIEW_FAILED, CommandClass
 from ..event import Event
 from ..exceptions import FailedCommand, UnparseableValue, UnwriteableValue
 from .command_class import CommandClassInfo, CommandClassInfoDataType

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -92,7 +92,7 @@ class Node(Endpoint):
     def __init__(self, client: "Client", data: NodeDataType) -> None:
         """Initialize the node."""
         super().__init__(client, data)
-        self.data = data
+        self.data: NodeDataType = data
         self._device_config = DeviceConfig(self.data.get("deviceConfig", {}))
         self.values: Dict[str, Union[Value, ConfigurationValue]] = {}
         for val in data["values"]:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -64,6 +64,20 @@ class Node(Endpoint):
                 # If we can't parse the value, don't store it
                 pass
 
+        self.endpoints: List[Endpoint] = []
+        for endpoint in self.data["endpoints"]:
+            self.endpoints.append(
+                Endpoint(
+                    self.client,
+                    endpoint,
+                    {
+                        value_id: value
+                        for value_id, value in self.values.items()
+                        if self.index == value.endpoint
+                    },
+                )
+            )
+
     def __repr__(self) -> str:
         """Return the representation."""
         return f"{type(self).__name__}(node_id={self.node_id})"
@@ -194,11 +208,6 @@ class Node(Endpoint):
     def device_database_url(self) -> Optional[str]:
         """Return the device database URL."""
         return self.data.get("deviceDatabaseUrl")
-
-    @property
-    def endpoints(self) -> List[Endpoint]:
-        """Return the endpoints."""
-        return [Endpoint(self.client, endpoint) for endpoint in self.data["endpoints"]]
 
     @property
     def endpoint_count_is_dynamic(self) -> Optional[bool]:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -3,10 +3,10 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
 
 from ..const import CommandClass, INTERVIEW_FAILED
-from ..event import Event, EventBase
+from ..event import Event
 from ..exceptions import FailedCommand, UnparseableValue, UnwriteableValue
 from .command_class import CommandClassInfo, CommandClassInfoDataType
-from .device_class import DeviceClass, DeviceClassDataType
+from .device_class import DeviceClassDataType
 from .device_config import DeviceConfig, DeviceConfigDataType
 from .endpoint import Endpoint, EndpointDataType
 from .firmware import (
@@ -92,14 +92,12 @@ class NodeDataType(TypedDict, total=False):
     values: List[ValueDataType]
 
 
-class Node(EventBase):
+class Node(Endpoint):
     """Represent a Z-Wave JS node."""
 
     def __init__(self, client: "Client", data: NodeDataType) -> None:
         """Initialize the node."""
-        super().__init__()
-        self.client = client
-        self.data = data
+        super().__init__(client, data)
         self._device_config = DeviceConfig(self.data.get("deviceConfig", {}))
         self.values: Dict[str, Union[Value, ConfigurationValue]] = {}
         for val in data["values"]:
@@ -127,26 +125,6 @@ class Node(EventBase):
         )
 
     @property
-    def node_id(self) -> int:
-        """Return the node_id."""
-        return self.data["nodeId"]
-
-    @property
-    def index(self) -> Optional[int]:
-        """Return the index."""
-        return self.data.get("index")
-
-    @property
-    def installer_icon(self) -> Optional[int]:
-        """Return the installer_icon."""
-        return self.data.get("installerIcon")
-
-    @property
-    def user_icon(self) -> Optional[int]:
-        """Return the user_icon."""
-        return self.data.get("userIcon")
-
-    @property
     def status(self) -> NodeStatus:
         """Return the status."""
         return NodeStatus(self.data["status"])
@@ -155,11 +133,6 @@ class Node(EventBase):
     def ready(self) -> Optional[bool]:
         """Return the ready."""
         return self.data.get("ready")
-
-    @property
-    def device_class(self) -> DeviceClass:
-        """Return the device_class."""
-        return DeviceClass(self.data["deviceClass"])
 
     @property
     def is_listening(self) -> Optional[bool]:
@@ -269,7 +242,7 @@ class Node(EventBase):
     @property
     def endpoints(self) -> List[Endpoint]:
         """Return the endpoints."""
-        return [Endpoint(endpoint) for endpoint in self.data["endpoints"]]
+        return [Endpoint(self.client, endpoint) for endpoint in self.data["endpoints"]]
 
     @property
     def endpoint_count_is_dynamic(self) -> Optional[bool]:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -1,5 +1,5 @@
 """Provide a model for the Z-Wave JS value."""
-from typing import List, TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union
 
 from ..const import VALUE_UNKNOWN, CommandClass, ConfigurationValueType
 from ..event import Event

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -1,6 +1,7 @@
 """Support for multicast commands."""
 
 from typing import Any, List, Optional, Union, cast
+
 from zwave_js_server.model.node import Node
 
 from ..client import Client


### PR DESCRIPTION
The way this is implemented feels a bit circular, so not sure if this will work, but in zwave-js, the `ZwaveNode` type is a subclass of `Endpoint`. Given that we want to model zwave-js, this change improves the model.

I also added values on each endpoint for the values that are relevant.

Part of the reason why I did this is to add support for https://github.com/zwave-js/zwave-js-server/pull/282