### PR TITLE
Add controller/node statistics to model

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -106,16 +106,17 @@ def test_from_state():
     assert ctrl.suc_node_id == 1
     assert ctrl.supports_timers is False
     assert ctrl.is_heal_network_active is False
+    stats = ctrl.statistics
     assert (
-        ctrl.statistics.can
-        == ctrl.statistics.messages_dropped_rx
-        == ctrl.statistics.messages_dropped_tx
-        == ctrl.statistics.messages_rx
-        == ctrl.statistics.messages_tx
-        == ctrl.statistics.nak
-        == ctrl.statistics.timeout_ack
-        == ctrl.statistics.timeout_callback
-        == ctrl.statistics.timeout_response
+        stats.can
+        == stats.messages_dropped_rx
+        == stats.messages_dropped_tx
+        == stats.messages_rx
+        == stats.messages_tx
+        == stats.nak
+        == stats.timeout_ack
+        == stats.timeout_callback
+        == stats.timeout_response
         == 0
     )
 
@@ -550,7 +551,7 @@ async def test_statistics_updated(controller):
     controller.receive_event(event)
     # Event should be modified with the ControllerStatistics object
     assert "statistics_updated" in event.data
-    assert isinstance(
-        event.data["statistics_updated"], controller_pkg.ControllerStatistics
-    )
+    event_stats = event.data["statistics_updated"]
+    assert isinstance(event_stats, controller_pkg.ControllerStatistics)
     assert controller.statistics.nak == 1
+    assert controller.statistics == event_stats

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -841,3 +841,30 @@ async def test_value_added_new_value(climate_radio_thermostat_ct100_plus):
     )
     node.receive_event(event)
     assert f"{node.node_id}-128-1-isMedium" in node.values
+
+
+async def test_statistics_updated(wallmote_central_scene: Node):
+    """Test that statistics get updated on events."""
+    node = wallmote_central_scene
+    assert node.statistics.commands_rx == 0
+    event = Event(
+        "statistics updated",
+        {
+            "source": "node",
+            "event": "statistics updated",
+            "statistics": {
+                "commandsTX": 1,
+                "commandsRX": 1,
+                "commandsDroppedTX": 1,
+                "commandsDroppedRX": 1,
+                "timeoutResponse": 1,
+            },
+        },
+    )
+    node.receive_event(event)
+    # Event should be modified with the NodeStatistics object
+    assert "statistics_updated" in event.data
+    event_stats = event.data["statistics_updated"]
+    assert isinstance(event_stats, NodeStatistics)
+    assert node.statistics.timeout_response == 1
+    assert node.statistics == event_stats

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -14,7 +14,7 @@ from zwave_js_server.event import Event
 from zwave_js_server.exceptions import UnwriteableValue
 from zwave_js_server.model import node as node_pkg
 from zwave_js_server.model.firmware import FirmwareUpdateStatus
-from zwave_js_server.model.node import Node, NodeStatus
+from zwave_js_server.model.node import Node, NodeStatistics, NodeStatus
 from zwave_js_server.model.value import ConfigurationValue
 
 from .. import load_fixture
@@ -69,6 +69,15 @@ def test_from_state():
     assert device_class.basic.key == 2
     assert device_class.generic.key == 2
     assert device_class.specific.key == 1
+    stats = node.statistics
+    assert (
+        stats.commands_dropped_rx
+        == stats.commands_dropped_tx
+        == stats.commands_rx
+        == stats.commands_tx
+        == stats.timeout_response
+        == 0
+    )
 
 
 async def test_device_config(wallmote_central_scene):

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -62,7 +62,11 @@ class ControllerStatistics:
 
     @property
     def messages_dropped_tx(self) -> int:
-        """Return number of outgoing messages that were dropped."""
+        """
+        Return number of outgoing messages that were dropped.
+
+        These messages could not be sent.
+        """
         return self.data["messagesDroppedTX"]
 
     @property

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -398,3 +398,6 @@ class Controller(EventBase):
         """Process a heal network done event."""
         # pylint: disable=unused-argument
         self.data["isHealNetworkActive"] = False
+
+    def handle_statistics_updated(self, event: Event) -> None:
+        """Process a statistics updated event."""

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -24,7 +24,7 @@ class ControllerStatisticsDataType(TypedDict):
 
 
 class ControllerStatistics:
-    """Represent a controller statitics update."""
+    """Represent a controller statistics update."""
 
     def __init__(self, data: Optional[ControllerStatisticsDataType] = None) -> None:
         """Initialize controller statistics."""

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -126,11 +126,11 @@ class Controller(EventBase):
         super().__init__()
         self.client = client
         self.data: ControllerDataType = state["controller"]
+        self.statistics = ControllerStatistics(self)
         self.nodes: Dict[int, Node] = {}
         for node_state in state["nodes"]:
             node = Node(client, node_state)
             self.nodes[node.node_id] = node
-        self.statistics = ControllerStatistics(self)
 
     def __repr__(self) -> str:
         """Return the representation."""

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -484,6 +484,5 @@ class Controller(EventBase):
 
     def handle_statistics_updated(self, event: Event) -> None:
         """Process a statistics updated event."""
-        self.statistics = event.data["statistics_updated"] = ControllerStatistics(
-            self, event.data["statistics"]
-        )
+        self.statistics.data.update(event.data["statistics"])
+        event.data["statistics_updated"] = self.statistics

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -47,7 +47,7 @@ class NodeStatisticsDataType(TypedDict):
 
 
 class NodeStatistics:
-    """Represent a node statitics update."""
+    """Represent a node statistics update."""
 
     def __init__(self, data: Optional[NodeStatisticsDataType] = None) -> None:
         """Initialize node statistics."""

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -36,6 +36,68 @@ if TYPE_CHECKING:
     from ..client import Client
 
 
+class NodeStatisticsDataType(TypedDict):
+    """Represent a node statistics data dict type."""
+
+    commandsTX: int
+    commandsRX: int
+    commandsDroppedTX: int
+    commandsDroppedRX: int
+    timeoutResponse: int
+
+
+class NodeStatistics:
+    """Represent a node statitics update."""
+
+    def __init__(
+        self,
+        node: "Node",
+        data: Optional[NodeStatisticsDataType] = None,
+    ) -> None:
+        """Initialize node statistics."""
+        self.node = node
+        self.data = data or NodeStatisticsDataType(
+            commandsDroppedRX=0,
+            commandsDroppedTX=0,
+            commandsRX=0,
+            commandsTX=0,
+            timeoutResponse=0,
+        )
+
+    @property
+    def commands_tx(self) -> int:
+        """Return number of commands successfully sent to node."""
+        return self.data["commandsTX"]
+
+    @property
+    def commands_rx(self) -> int:
+        """
+        Return number of commands received from node.
+
+        Includes responses to sent commands.
+        """
+        return self.data["commandsRX"]
+
+    @property
+    def commands_dropped_rx(self) -> int:
+        """Return number of commands from node that were dropped by host."""
+        return self.data["commandsDroppedRX"]
+
+    @property
+    def commands_dropped_tx(self) -> int:
+        """
+        Return number of outgoing commands that were dropped.
+
+        These commands could not be sent.
+        """
+        return self.data["commandsDroppedTX"]
+
+    @property
+    def timeout_response(self) -> int:
+        """Return number of Get-type cmds where node's response didn't come in time."""
+        return self.data["timeoutResponse"]
+
+
 class NodeStatus(IntEnum):
     """Enum with all Node status values.
 
@@ -101,6 +163,7 @@ class Node(EventBase):
         self.client = client
         self.data = data
         self._device_config = DeviceConfig(self.data.get("deviceConfig", {}))
+        self.statistics = NodeStatistics(self)
         self.values: Dict[str, Union[Value, ConfigurationValue]] = {}
         for val in data["values"]:
             value_id = _get_value_id_from_dict(self, val)
@@ -579,3 +642,8 @@ class Node(EventBase):
         event.data["firmware_update_finished"] = FirmwareUpdateFinished(
             self, cast(FirmwareUpdateFinishedDataType, event.data)
         )
+
+    def handle_statistics_updated(self, event: Event) -> None:
+        """Process a statistics updated event."""
+        self.statistics.data.update(event.data["statistics"])
+        event.data["statistics_updated"] = self.statistics


### PR DESCRIPTION
See https://github.com/zwave-js/zwave-js-server/pull/296 

We will now be receiving an initial state of statistics for the node and controller and will receive regular updates to those statistics from the `statistics updated` event