### PR TITLE
Handle value updated and added the same way

### DIFF
--- a/test/fixtures/climate_radio_thermostat_ct100_plus_state.json
+++ b/test/fixtures/climate_radio_thermostat_ct100_plus_state.json
@@ -683,6 +683,19 @@
         "label": "Low battery level"
       },
       "value": false
+    },
+    {
+      "commandClassName": "Battery",
+      "commandClass": 128,
+      "endpoint": 1,
+      "property": "isHigh",
+      "propertyName": "isHigh",
+      "metadata": {
+          "type": "boolean",
+          "readable": true,
+          "writeable": false,
+          "label": "High battery level"
+      }
     }
   ]
 }

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -771,6 +771,9 @@ async def test_firmware_events(wallmote_central_scene: Node):
 async def test_value_added_value_exists(climate_radio_thermostat_ct100_plus):
     """Test value added event when value exists."""
     node: Node = climate_radio_thermostat_ct100_plus
+    value_id = f"{node.node_id}-128-1-isHigh"
+    value = node.values.get(value_id)
+    assert value
     event = Event(
         "value added",
         {
@@ -794,7 +797,8 @@ async def test_value_added_value_exists(climate_radio_thermostat_ct100_plus):
         },
     )
     node.receive_event(event)
-    assert f"{node.node_id}-128-1-isHigh" in node.values
+    assert value_id in node.values
+    assert value is node.values[value_id]
 
 
 async def test_value_added_new_value(climate_radio_thermostat_ct100_plus):

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -798,7 +798,7 @@ async def test_value_added_value_exists(climate_radio_thermostat_ct100_plus):
     )
     node.receive_event(event)
     assert value_id in node.values
-    assert value is node.values[value_id]
+    assert node.values[value_id] is value
 
 
 async def test_value_added_new_value(climate_radio_thermostat_ct100_plus):

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -768,8 +768,8 @@ async def test_firmware_events(wallmote_central_scene: Node):
     assert event.data["firmware_update_finished"].wait_time == 10
 
 
-async def test_value_added(climate_radio_thermostat_ct100_plus):
-    """Test value added event."""
+async def test_value_added_value_exists(climate_radio_thermostat_ct100_plus):
+    """Test value added event when value exists."""
     node: Node = climate_radio_thermostat_ct100_plus
     event = Event(
         "value added",
@@ -795,3 +795,32 @@ async def test_value_added(climate_radio_thermostat_ct100_plus):
     )
     node.receive_event(event)
     assert f"{node.node_id}-128-1-isHigh" in node.values
+
+
+async def test_value_added_new_value(climate_radio_thermostat_ct100_plus):
+    """Test value added event when new value is added."""
+    node: Node = climate_radio_thermostat_ct100_plus
+    event = Event(
+        "value added",
+        {
+            "source": "node",
+            "event": "value added",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Battery",
+                "commandClass": 128,
+                "endpoint": 1,
+                "property": "isMedium",
+                "propertyName": "isMedium",
+                "metadata": {
+                    "type": "boolean",
+                    "readable": True,
+                    "writeable": False,
+                    "label": "Medium battery level",
+                },
+                "value": True,
+            },
+        },
+    )
+    node.receive_event(event)
+    assert f"{node.node_id}-128-1-isMedium" in node.values

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -787,7 +787,7 @@ async def test_value_added(climate_radio_thermostat_ct100_plus):
                     "type": "boolean",
                     "readable": True,
                     "writeable": False,
-                    "label": "Low battery level",
+                    "label": "High battery level",
                 },
                 "value": True,
             },

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -766,3 +766,32 @@ async def test_firmware_events(wallmote_central_scene: Node):
         == FirmwareUpdateStatus.OK_RESTART_PENDING
     )
     assert event.data["firmware_update_finished"].wait_time == 10
+
+
+async def test_value_added(climate_radio_thermostat_ct100_plus):
+    """Test value added event."""
+    node: Node = climate_radio_thermostat_ct100_plus
+    event = Event(
+        "value added",
+        {
+            "source": "node",
+            "event": "value added",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Battery",
+                "commandClass": 128,
+                "endpoint": 1,
+                "property": "isHigh",
+                "propertyName": "isHigh",
+                "metadata": {
+                    "type": "boolean",
+                    "readable": True,
+                    "writeable": False,
+                    "label": "Low battery level",
+                },
+                "value": True,
+            },
+        },
+    )
+    node.receive_event(event)
+    assert f"{node.node_id}-128-1-isHigh" in node.values

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -515,16 +515,14 @@ class Node(EventBase):
 
     def handle_value_added(self, event: Event) -> None:
         """Process a node value added event."""
-        value = _init_value(self, event.data["args"])
-        self.values[value.value_id] = event.data["value"] = value
+        self.handle_value_updated(event)
 
     def handle_value_updated(self, event: Event) -> None:
         """Process a node value updated event."""
         value = self.values.get(_get_value_id_from_dict(self, event.data["args"]))
         if value is None:
-            # received update for unknown value
-            # should not happen but just in case, treat like added value
-            self.handle_value_added(event)
+            value = _init_value(self, event.data["args"])
+            self.values[value.value_id] = event.data["value"] = value
         else:
             value.receive_event(event)
             event.data["value"] = value


### PR DESCRIPTION
See https://github.com/home-assistant/core/issues/52791 and https://discord.com/channels/330944238910963714/800356888827002880/863475611493466152 for context. We've decided from the conversation that value added and value updated events should be handled the same way.

The problem: There are cases where we retrieve a ZwaveValue that doesn't itself have a value, and this specifically seems to happen with the Notification CC. When zwave-js receives the first value for the ZwaveValue after initialization where we've already added the value to our model in the lib, it issues a `value added` event instead of a `value updated` like we would expect. This PR handles that edge case while leaving the `value updated` event effectively as is.

Please merge this before we merge the other PRs so that we can do a patch release for this