### PR TITLE
Bump lib to 0.27.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.27.0"
+VERSION = "0.27.1"
 
 
 setup(


### PR DESCRIPTION
We need to do this after merging https://github.com/home-assistant-libs/zwave-js-server-python/pull/247 because that fixes a bug with notification CC values