### PR TITLE
Update node's `device_info` property during a `ready` event

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -399,10 +399,14 @@ def test_node_inclusion():
     assert node.status == 1
     assert not node.ready
     assert len(node.values) == 0
+    assert node.device_config.manufacturer is None
+
     # the ready event contains a full (and complete) dump of the node, including values
     state = json.loads(load_fixture("multisensor_6_state.json"))
     event = Event("ready", {"nodeState": state})
     node.receive_event(event)
+
+    assert node.device_config.manufacturer == "AEON Labs"
     assert len(node.values) > 0
 
 

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -504,6 +504,9 @@ class Node(EventBase):
         """Process a node ready event."""
         # the event contains a full dump of the node
         self.data.update(event.data["nodeState"])
+        # update device config
+        if new_device_config := self.data.get("deviceConfig"):
+            self._device_config = DeviceConfig(new_device_config)
         # update/add values
         for value_state in event.data["nodeState"]["values"]:
             value_id = _get_value_id_from_dict(self, value_state)


### PR DESCRIPTION
When a node handles a `ready` event from the server, it doesn't update its internal device_info cache. This means access to the `node.device_info` property by clients later on have stale data. This change updates the event handler to reset the internal device_config attribute based on the new event data.

I noticed this when adding a node to HA, the manufacturing and product info were all missing, and the name was `Node XX` (default when product info is missing). Upon inspection, the integration was passing null data (derived from the Node object) to the device registry. I assume this was a regression from a previous change.