### PR TITLE
Add new endpoint commands

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -255,7 +255,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 6,
+        "maxSchemaVersion": 7,
     }
 
 
@@ -380,7 +380,8 @@ def mock_command_fixture(ws_client, client, uuid4):
 @pytest.fixture(name="driver")
 def driver_fixture(client, controller_state, log_config):
     """Return a driver instance with a supporting client."""
-    return Driver(client, controller_state, log_config)
+    client.driver = Driver(client, controller_state, log_config)
+    return client.driver
 
 
 @pytest.fixture(name="multisensor_6")

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -940,4 +940,3 @@ async def test_statistics_updated(wallmote_central_scene: Node):
     assert isinstance(event_stats, NodeStatistics)
     assert node.statistics.timeout_response == 1
     assert node.statistics == event_stats
-

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1,5 +1,6 @@
 """Test the node model."""
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -897,7 +898,9 @@ async def test_supports_cc_api(multisensor_6, uuid4, mock_command):
         "messageId": uuid4,
     }
 
-    # Test that command fails if driver has been cleared
-    node.client.driver = None
+    # Test that command fails when client is disconnected
+    with patch("asyncio.Event.wait", return_value=True):
+        await node.client.disconnect()
+
     with pytest.raises(FailedCommand):
         await node.async_supports_cc_api(CommandClass.USER_CODE)

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -12,7 +12,7 @@ from zwave_js_server.const import (
     ProtocolVersion,
 )
 from zwave_js_server.event import Event
-from zwave_js_server.exceptions import UnwriteableValue
+from zwave_js_server.exceptions import FailedCommand, UnwriteableValue
 from zwave_js_server.model import node as node_pkg
 from zwave_js_server.model.firmware import FirmwareUpdateStatus
 from zwave_js_server.model.node import Node
@@ -896,3 +896,8 @@ async def test_supports_cc_api(multisensor_6, uuid4, mock_command):
         "commandClass": 99,
         "messageId": uuid4,
     }
+
+    # Test that command fails if driver has been cleared
+    node.client.driver = None
+    with pytest.raises(FailedCommand):
+        await node.async_supports_cc_api(CommandClass.USER_CODE)

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -13,8 +13,9 @@ from zwave_js_server.const import (
 from zwave_js_server.event import Event
 from zwave_js_server.exceptions import UnwriteableValue
 from zwave_js_server.model import node as node_pkg
+from zwave_js_server.const import NodeStatus
 from zwave_js_server.model.firmware import FirmwareUpdateStatus
-from zwave_js_server.model.node import Node, NodeStatus
+from zwave_js_server.model.node import Node
 from zwave_js_server.model.value import ConfigurationValue
 
 from .. import load_fixture
@@ -832,3 +833,66 @@ async def test_value_added_new_value(climate_radio_thermostat_ct100_plus):
     )
     node.receive_event(event)
     assert f"{node.node_id}-128-1-isMedium" in node.values
+
+
+async def test_invoke_cc_api(multisensor_6, uuid4, mock_command):
+    """Test endpoint.invoke_cc_api commands."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "endpoint.invoke_cc_api", "nodeId": node.node_id, "endpoint": 0},
+        {"response": "ok"},
+    )
+
+    assert (
+        await node.async_invoke_cc_api(CommandClass.USER_CODE, "set", 1, 1, "1234")
+        is None
+    )
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "endpoint.invoke_cc_api",
+        "nodeId": node.node_id,
+        "endpoint": 0,
+        "commandClass": 99,
+        "methodName": "set",
+        "args": [1, 1, "1234"],
+        "messageId": uuid4,
+    }
+
+    assert (
+        await node.async_invoke_cc_api(
+            CommandClass.USER_CODE, "set", 2, 2, "1234", wait_for_result=True
+        )
+        == "ok"
+    )
+
+    assert len(ack_commands) == 2
+    assert ack_commands[1] == {
+        "command": "endpoint.invoke_cc_api",
+        "nodeId": node.node_id,
+        "endpoint": 0,
+        "commandClass": 99,
+        "methodName": "set",
+        "args": [2, 2, "1234"],
+        "messageId": uuid4,
+    }
+
+
+async def test_supports_cc_api(multisensor_6, uuid4, mock_command):
+    """Test endpoint.supports_cc_api commands."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "endpoint.supports_cc_api", "nodeId": node.node_id, "endpoint": 0},
+        {"supported": True},
+    )
+
+    assert await node.async_supports_cc_api(CommandClass.USER_CODE)
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "endpoint.supports_cc_api",
+        "nodeId": node.node_id,
+        "endpoint": 0,
+        "commandClass": 99,
+        "messageId": uuid4,
+    }

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -4,16 +4,16 @@ import json
 import pytest
 
 from zwave_js_server.const import (
+    INTERVIEW_FAILED,
     CommandClass,
     EntryControlDataType,
     EntryControlEventType,
-    INTERVIEW_FAILED,
+    NodeStatus,
     ProtocolVersion,
 )
 from zwave_js_server.event import Event
 from zwave_js_server.exceptions import UnwriteableValue
 from zwave_js_server.model import node as node_pkg
-from zwave_js_server.const import NodeStatus
 from zwave_js_server.model.firmware import FirmwareUpdateStatus
 from zwave_js_server.model.node import Node
 from zwave_js_server.model.value import ConfigurationValue

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -899,7 +899,7 @@ async def test_supports_cc_api(multisensor_6, uuid4, mock_command):
     }
 
     # Test that command fails when client is disconnected
-    with patch("asyncio.Event.wait", return_value=True):
+    with patch("zwave_js_server.client.asyncio.Event.wait", return_value=True):
         await node.client.disconnect()
 
     with pytest.raises(FailedCommand):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -64,7 +64,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 6}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 7}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -224,6 +224,7 @@ class Client:
 
             for future in self._result_futures.values():
                 future.cancel()
+            self._result_futures.clear()
 
             if not self._client.closed:
                 await self._client.close()
@@ -248,6 +249,9 @@ class Client:
         self._shutdown_complete_event = asyncio.Event()
         await self._client.close()
         await self._shutdown_complete_event.wait()
+
+        self._shutdown_complete_event = None
+        self.driver = None
 
     async def _receive_json_or_raise(self) -> dict:
         """Receive json or raise."""

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -3,7 +3,7 @@ from enum import Enum, IntEnum
 from typing import Dict, List
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 6
+MIN_SERVER_SCHEMA_VERSION = 7
 # max server schema version we can handle (and our code is compatible with)
 MAX_SERVER_SCHEMA_VERSION = 7
 

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 6
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 6
+MAX_SERVER_SCHEMA_VERSION = 7
 
 VALUE_UNKNOWN = "unknown"
 
@@ -411,3 +411,16 @@ class ToneID(IntEnum):
     # https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts#L71
     OFF = 0
     DEFAULT = 255
+
+
+class NodeStatus(IntEnum):
+    """Enum with all Node status values.
+
+    https://zwave-js.github.io/node-zwave-js/#/api/node?id=status
+    """
+
+    UNKNOWN = 0
+    ASLEEP = 1
+    AWAKE = 2
+    DEAD = 3
+    ALIVE = 4

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -113,8 +113,7 @@ class Endpoint(EventBase):
         wait_for_result: bool = None,
     ) -> Any:
         """Call endpoint.invoke_cc_api command."""
-        result = await Endpoint._async_send_command(
-            self,
+        result = await self._async_send_command(
             "invoke_cc_api",
             commandClass=command_class.value,
             methodName=method_name,
@@ -128,8 +127,7 @@ class Endpoint(EventBase):
 
     async def async_supports_cc_api(self, command_class: CommandClass) -> bool:
         """Call endpoint.supports_cc_api command."""
-        result = await Endpoint._async_send_command(
-            self,
+        result = await self._async_send_command(
             "supports_cc_api",
             commandClass=command_class.value,
             require_schema=7,

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -82,7 +82,9 @@ class Endpoint(EventBase):
         or not based on the node status.
         """
         if self.client.driver is None:
-            raise FailedCommand("Command failed", "failed_command", "The client is not connected")
+            raise FailedCommand(
+                "Command failed", "failed_command", "The client is not connected"
+            )
         node = self.client.driver.controller.nodes[self.node_id]
         kwargs = {}
         message = {

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -80,6 +80,7 @@ class Endpoint(EventBase):
         If wait_for_result is not None, it will take precedence, otherwise we will decide to wait
         or not based on the node status.
         """
+        assert self.client.driver
         node = self.client.driver.controller.nodes[self.node_id]
         kwargs = {}
         message = {
@@ -130,4 +131,6 @@ class Endpoint(EventBase):
             require_schema=7,
             wait_for_result=True,
         )
+        # We can assert this because we are forcing the client to await the response
+        assert result
         return cast(bool, result["supported"])

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -7,6 +7,7 @@ https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=endpoint-properties
 from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union, cast
 
 from ..const import NodeStatus
+from ..exceptions import FailedCommand
 from ..event import EventBase
 from .command_class import CommandClass
 from .device_class import DeviceClass, DeviceClassDataType
@@ -80,7 +81,8 @@ class Endpoint(EventBase):
         If wait_for_result is not None, it will take precedence, otherwise we will decide to wait
         or not based on the node status.
         """
-        assert self.client.driver
+        if self.client.driver is None:
+            raise FailedCommand("Command failed", "failed_command", "The client is not connected")
         node = self.client.driver.controller.nodes[self.node_id]
         kwargs = {}
         message = {
@@ -131,6 +133,7 @@ class Endpoint(EventBase):
             require_schema=7,
             wait_for_result=True,
         )
-        # We can assert this because we are forcing the client to await the response
-        assert result
+        if result is None:
+            # We should never reach this code
+            raise FailedCommand("Command failed", "failed_command")
         return cast(bool, result["supported"])

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -4,12 +4,12 @@ Model for a Zwave Node's endpoints.
 https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=endpoint-properties
 """
 
-from typing import Any, TYPE_CHECKING, Dict, Optional, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union, cast
 
 from ..const import NodeStatus
+from ..event import EventBase
 from .command_class import CommandClass
 from .device_class import DeviceClass, DeviceClassDataType
-from ..event import EventBase
 from .value import ConfigurationValue, Value
 
 if TYPE_CHECKING:

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -135,7 +135,5 @@ class Endpoint(EventBase):
             require_schema=7,
             wait_for_result=True,
         )
-        if result is None:
-            # We should never reach this code
-            raise FailedCommand("Command failed", "failed_command")
+        assert result
         return cast(bool, result["supported"])

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -7,8 +7,8 @@ https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=endpoint-properties
 from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict, Union, cast
 
 from ..const import NodeStatus
-from ..exceptions import FailedCommand
 from ..event import EventBase
+from ..exceptions import FailedCommand
 from .command_class import CommandClass
 from .device_class import DeviceClass, DeviceClassDataType
 from .value import ConfigurationValue, Value

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -4,10 +4,12 @@ Model for a Zwave Node's endpoints.
 https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=endpoint-properties
 """
 
-from typing import TYPE_CHECKING, Dict, Optional, TypedDict, Union
+from typing import Any, TYPE_CHECKING, Dict, Optional, TypedDict, Union, cast
 
-from ..event import EventBase
+from ..const import NodeStatus
+from .command_class import CommandClass
 from .device_class import DeviceClass, DeviceClassDataType
+from ..event import EventBase
 from .value import ConfigurationValue, Value
 
 if TYPE_CHECKING:
@@ -64,3 +66,68 @@ class Endpoint(EventBase):
     def user_icon(self) -> Optional[int]:
         """Return user icon property."""
         return self.data.get("userIcon")
+
+    async def _async_send_command(
+        self,
+        cmd: str,
+        require_schema: Optional[int] = None,
+        wait_for_result: Optional[bool] = None,
+        **cmd_kwargs: Any,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Send an endpoint command. For internal use only.
+
+        If wait_for_result is not None, it will take precedence, otherwise we will decide to wait
+        or not based on the node status.
+        """
+        node = self.client.driver.controller.nodes[self.node_id]
+        kwargs = {}
+        message = {
+            "command": f"endpoint.{cmd}",
+            "nodeId": self.node_id,
+            "endpoint": self.index,
+            **cmd_kwargs,
+        }
+        if require_schema is not None:
+            kwargs["require_schema"] = require_schema
+
+        if wait_for_result or (
+            wait_for_result is None and node.status != NodeStatus.ASLEEP
+        ):
+            result = await self.client.async_send_command(message, **kwargs)
+            return result
+
+        await self.client.async_send_command_no_wait(message, **kwargs)
+        return None
+
+    async def async_invoke_cc_api(
+        self,
+        command_class: CommandClass,
+        method_name: str,
+        *args: Any,
+        wait_for_result: bool = None,
+    ) -> Any:
+        """Call endpoint.invoke_cc_api command."""
+        result = await Endpoint._async_send_command(
+            self,
+            "invoke_cc_api",
+            commandClass=command_class.value,
+            methodName=method_name,
+            args=list(args),
+            require_schema=7,
+            wait_for_result=wait_for_result,
+        )
+        if result is None:
+            return None
+        return result["response"]
+
+    async def async_supports_cc_api(self, command_class: CommandClass) -> bool:
+        """Call endpoint.supports_cc_api command."""
+        result = await Endpoint._async_send_command(
+            self,
+            "supports_cc_api",
+            commandClass=command_class.value,
+            require_schema=7,
+            wait_for_result=True,
+        )
+        return cast(bool, result["supported"])

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -1,5 +1,5 @@
 """Provide a model for the Z-Wave JS node."""
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, cast
 
 from ..const import INTERVIEW_FAILED, CommandClass, NodeStatus
 from ..event import Event

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -1,8 +1,7 @@
 """Provide a model for the Z-Wave JS node."""
-from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
-from ..const import INTERVIEW_FAILED, CommandClass
+from ..const import CommandClass, NodeStatus, INTERVIEW_FAILED
 from ..event import Event
 from ..exceptions import FailedCommand, UnparseableValue, UnwriteableValue
 from .command_class import CommandClassInfo, CommandClassInfoDataType
@@ -33,19 +32,6 @@ from .value import (
 
 if TYPE_CHECKING:
     from ..client import Client
-
-
-class NodeStatus(IntEnum):
-    """Enum with all Node status values.
-
-    https://zwave-js.github.io/node-zwave-js/#/api/node?id=status
-    """
-
-    UNKNOWN = 0
-    ASLEEP = 1
-    AWAKE = 2
-    DEAD = 3
-    ALIVE = 4
 
 
 class NodeDataType(EndpointDataType):

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -1,7 +1,7 @@
 """Provide a model for the Z-Wave JS node."""
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
-from ..const import CommandClass, NodeStatus, INTERVIEW_FAILED
+from ..const import INTERVIEW_FAILED, CommandClass, NodeStatus
 from ..event import Event
 from ..exceptions import FailedCommand, UnparseableValue, UnwriteableValue
 from .command_class import CommandClassInfo, CommandClassInfoDataType


### PR DESCRIPTION
Adds `endpoint.invoke_cc_api` and `endpoint.supports_cc_api` (Upstream PR: https://github.com/zwave-js/zwave-js-server/pull/282)

As part of this change I had to move `NodeStatus` to `const` so that it could be referenced in `zwave_js_server.model.endpoint`