### PR TITLE
Bugfix and code cleanup

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -266,7 +266,17 @@ async def test_stop_healing_network(controller, uuid4, mock_command):
         {"success": True},
     )
 
-    controller.heal_network_progress = {1: "pending"}
+    event = Event(
+        "heal network progress",
+        {
+            "source": "controller",
+            "event": "heal network progress",
+            "progress": {52: "pending"},
+        },
+    )
+    controller.receive_event(event)
+
+    assert controller.heal_network_progress == {52: "pending"}
     assert await controller.async_stop_healing_network()
 
     assert len(ack_commands) == 1


### PR DESCRIPTION
I decided to move the `Controller.heal_network_progress` to a private attribute so it could only be modified by the controller, and that turned out to be a good thing because it uncovered the fact that we don't reset `isHealNetworkActive` when the command to stop healing the network is issued and is successful