### PR TITLE
Add guards for Node.async_set_value

### DIFF
--- a/test/fixtures/multisensor_6_state.json
+++ b/test/fixtures/multisensor_6_state.json
@@ -94,7 +94,8 @@
         "writeable": true,
         "min": 0,
         "max": 99,
-        "label": "Target value"
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"]
       }
     },
     {

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -13,7 +13,7 @@ from zwave_js_server.const import (
     ProtocolVersion,
 )
 from zwave_js_server.event import Event
-from zwave_js_server.exceptions import FailedCommand, UnwriteableValue
+from zwave_js_server.exceptions import FailedCommand, NotFoundError, UnwriteableValue
 from zwave_js_server.model import node as node_pkg
 from zwave_js_server.model.firmware import FirmwareUpdateStatus
 from zwave_js_server.model.node import Node, NodeStatistics
@@ -194,7 +194,6 @@ async def test_set_value(multisensor_6, uuid4, mock_command):
     }
 
     # Set value with options
-
     assert await node.async_set_value(value_id, 42, {"transitionDuration": 1}) is None
 
     assert len(ack_commands) == 2
@@ -206,6 +205,14 @@ async def test_set_value(multisensor_6, uuid4, mock_command):
         "options": {"transitionDuration": 1},
         "messageId": uuid4,
     }
+
+    # Set value with illegal option
+    with pytest.raises(NotFoundError):
+        await node.async_set_value(value_id, 42, {"fake_option": 1})
+
+    # Use invalid value
+    with pytest.raises(NotFoundError):
+        await node.async_set_value(f"{value_id}_fake_value", 42)
 
 
 async def test_poll_value(multisensor_6, uuid4, mock_command):

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -425,7 +425,7 @@ class Node(Endpoint):
             option = next(
                 (
                     option
-                    for option in options.keys()
+                    for option in options
                     if option not in val.metadata.value_change_options
                 ),
                 None,

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -3,7 +3,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union, c
 
 from ..const import INTERVIEW_FAILED, CommandClass, NodeStatus
 from ..event import Event
-from ..exceptions import FailedCommand, UnparseableValue, UnwriteableValue
+from ..exceptions import (
+    FailedCommand,
+    NotFoundError,
+    UnparseableValue,
+    UnwriteableValue,
+)
 from .command_class import CommandClassInfo, CommandClassInfoDataType
 from .device_config import DeviceConfig, DeviceConfigDataType
 from .endpoint import Endpoint, EndpointDataType
@@ -405,6 +410,8 @@ class Node(Endpoint):
         """Send setValue command to Node for given value (or value_id)."""
         # a value may be specified as value_id or the value itself
         if not isinstance(val, Value):
+            if val not in self.values:
+                raise NotFoundError(f"Value {val} not found on node {self}")
             val = self.values[val]
 
         if val.metadata.writeable is False:
@@ -415,6 +422,18 @@ class Node(Endpoint):
             "value": new_value,
         }
         if options:
+            option = next(
+                (
+                    option
+                    for option in options.keys()
+                    if option not in val.metadata.value_change_options
+                ),
+                None,
+            )
+            if option is not None:
+                raise NotFoundError(
+                    f"Option {option} not found on value {val} on node {self}"
+                )
             cmd_args["options"] = options
 
         # the value object needs to be send to the server


### PR DESCRIPTION
We can raise more informative exceptions when the value_id provided doesn't exist or the value doesn't have the appropriate options