### PR TITLE
Add support for new multicast commands and multicast setValue options

### DIFF
--- a/test/util/test_multicast.py
+++ b/test/util/test_multicast.py
@@ -185,9 +185,12 @@ async def test_invoke_cc_api_broadcast(client, uuid4, mock_command):
         {"response": 1},
     )
 
-    assert await async_multicast_endpoint_invoke_cc_api(
-        client, 1, 1, "test", ["test_args", "test_args2"]
-    ) == 1
+    assert (
+        await async_multicast_endpoint_invoke_cc_api(
+            client, 1, 1, "test", ["test_args", "test_args2"]
+        )
+        == 1
+    )
 
     assert ack_commands[0] == {
         "command": "broadcast_node.invoke_cc_api",
@@ -210,9 +213,12 @@ async def test_invoke_cc_api_multicast(
         {"response": 1},
     )
 
-    assert await async_multicast_endpoint_invoke_cc_api(
-        client, 1,  1, "test", ["test_args", "test_args2"], [node1, node2]
-    ) == 1
+    assert (
+        await async_multicast_endpoint_invoke_cc_api(
+            client, 1, 1, "test", ["test_args", "test_args2"], [node1, node2]
+        )
+        == 1
+    )
 
     assert ack_commands[0] == {
         "command": "multicast_group.invoke_cc_api",
@@ -232,9 +238,7 @@ async def test_supports_cc_api_broadcast(client, uuid4, mock_command):
         {"supported": True},
     )
 
-    assert await async_multicast_endpoint_supports_cc_api(
-        client, 1, 1
-    )
+    assert await async_multicast_endpoint_supports_cc_api(client, 1, 1)
 
     assert ack_commands[0] == {
         "command": "broadcast_node.supports_cc_api",
@@ -255,9 +259,7 @@ async def test_supports_cc_api_multicast(
         {"supported": True},
     )
 
-    assert await async_multicast_endpoint_supports_cc_api(
-        client, 1, 1, [node1, node2]
-    )
+    assert await async_multicast_endpoint_supports_cc_api(client, 1, 1, [node1, node2])
 
     assert ack_commands[0] == {
         "command": "multicast_group.supports_cc_api",

--- a/test/util/test_multicast.py
+++ b/test/util/test_multicast.py
@@ -1,8 +1,8 @@
 """Test node utility functions."""
 import pytest
 
-from zwave_js_server.exceptions import NotFoundError
 from zwave_js_server.const import CommandClass
+from zwave_js_server.exceptions import NotFoundError
 from zwave_js_server.util.multicast import (
     async_multicast_endpoint_get_cc_version,
     async_multicast_endpoint_invoke_cc_api,

--- a/test/util/test_multicast.py
+++ b/test/util/test_multicast.py
@@ -136,7 +136,7 @@ async def test_get_endpoint_count_multicast(
     }
 
 
-async def test_set_value_broadcast(client, uuid4, mock_command):
+async def test_set_value_broadcast(client, driver, uuid4, mock_command):
     """Test broadcast_node.set_value command."""
     ack_commands = mock_command(
         {"command": "broadcast_node.set_value"},

--- a/test/util/test_multicast.py
+++ b/test/util/test_multicast.py
@@ -2,7 +2,9 @@
 from zwave_js_server.const import CommandClass
 from zwave_js_server.util.multicast import (
     async_multicast_endpoint_get_cc_version,
+    async_multicast_endpoint_invoke_cc_api,
     async_multicast_endpoint_supports_cc,
+    async_multicast_endpoint_supports_cc_api,
     async_multicast_get_endpoint_count,
     async_multicast_set_value,
 )
@@ -146,6 +148,7 @@ async def test_set_value_broadcast(client, uuid4, mock_command):
         "command": "broadcast_node.set_value",
         "value": 1,
         "valueId": {"commandClass": 1, "property": 1},
+        "options": None,
         "messageId": uuid4,
     }
 
@@ -170,5 +173,96 @@ async def test_set_value_multicast(
         "nodeIDs": [node1.node_id, node2.node_id],
         "value": 1,
         "valueId": {"commandClass": 1, "property": 1},
+        "options": None,
+        "messageId": uuid4,
+    }
+
+
+async def test_invoke_cc_api_broadcast(client, uuid4, mock_command):
+    """Test broadcast_node.invoke_cc_api command."""
+    ack_commands = mock_command(
+        {"command": "broadcast_node.invoke_cc_api"},
+        {"response": 1},
+    )
+
+    assert await async_multicast_endpoint_invoke_cc_api(
+        client, 1, 1, "test", ["test_args", "test_args2"]
+    ) == 1
+
+    assert ack_commands[0] == {
+        "command": "broadcast_node.invoke_cc_api",
+        "index": 1,
+        "commandClass": 1,
+        "methodName": "test",
+        "args": ["test_args", "test_args2"],
+        "messageId": uuid4,
+    }
+
+
+async def test_invoke_cc_api_multicast(
+    climate_radio_thermostat_ct100_plus, inovelli_switch, client, uuid4, mock_command
+):
+    """Test multicast_group.invoke_cc_api command."""
+    node1 = climate_radio_thermostat_ct100_plus
+    node2 = inovelli_switch
+    ack_commands = mock_command(
+        {"command": "multicast_group.invoke_cc_api"},
+        {"response": 1},
+    )
+
+    assert await async_multicast_endpoint_invoke_cc_api(
+        client, 1,  1, "test", ["test_args", "test_args2"], [node1, node2]
+    ) == 1
+
+    assert ack_commands[0] == {
+        "command": "multicast_group.invoke_cc_api",
+        "nodeIDs": [node1.node_id, node2.node_id],
+        "index": 1,
+        "commandClass": 1,
+        "methodName": "test",
+        "args": ["test_args", "test_args2"],
+        "messageId": uuid4,
+    }
+
+
+async def test_supports_cc_api_broadcast(client, uuid4, mock_command):
+    """Test broadcast_node.supports_cc_api command."""
+    ack_commands = mock_command(
+        {"command": "broadcast_node.supports_cc_api"},
+        {"supported": True},
+    )
+
+    assert await async_multicast_endpoint_supports_cc_api(
+        client, 1, 1
+    )
+
+    assert ack_commands[0] == {
+        "command": "broadcast_node.supports_cc_api",
+        "index": 1,
+        "commandClass": 1,
+        "messageId": uuid4,
+    }
+
+
+async def test_supports_cc_api_multicast(
+    climate_radio_thermostat_ct100_plus, inovelli_switch, client, uuid4, mock_command
+):
+    """Test multicast_group.supports_cc_api command."""
+    node1 = climate_radio_thermostat_ct100_plus
+    node2 = inovelli_switch
+    ack_commands = mock_command(
+        {"command": "multicast_group.supports_cc_api"},
+        {"supported": True},
+    )
+
+    assert await async_multicast_endpoint_supports_cc_api(
+        client, 1, 1, [node1, node2]
+    )
+
+    assert ack_commands[0] == {
+        "command": "multicast_group.supports_cc_api",
+        "nodeIDs": [node1.node_id, node2.node_id],
+        "index": 1,
+        "commandClass": 1,
         "messageId": uuid4,
     }

--- a/test/util/test_multicast.py
+++ b/test/util/test_multicast.py
@@ -1,5 +1,6 @@
 """Test node utility functions."""
 import pytest
+
 from zwave_js_server.exceptions import NotFoundError
 from zwave_js_server.const import CommandClass
 from zwave_js_server.util.multicast import (

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -399,7 +399,7 @@ class Node(Endpoint):
         self,
         val: Union[Value, str],
         new_value: Any,
-        options: dict = None,
+        options: Optional[dict] = None,
         wait_for_result: Optional[bool] = None,
     ) -> Optional[bool]:
         """Send setValue command to Node for given value (or value_id)."""

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -37,7 +37,7 @@ async def async_multicast_set_value(
     options: Optional[dict] = None,
 ) -> bool:
     """Send a multicast set_value command."""
-    for node in nodes or []:
+    for node in nodes or client.driver.controller.nodes:
         value_id = _get_value_id_from_dict(node, value_data)
         if value_id not in node.values:
             raise NotFoundError(f"Node {node} doesn't have value {value_id}")

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -37,8 +37,9 @@ async def async_multicast_set_value(
     options: Optional[dict] = None,
 ) -> bool:
     """Send a multicast set_value command."""
+    assert client.driver
     # Iterate through nodes specified or all nodes if not specified
-    for node in nodes or client.driver.controller.nodes:
+    for node in nodes or client.driver.controller.nodes.values():
         value_id = _get_value_id_from_dict(node, value_data)
         # Check that the value exists on the node
         if value_id not in node.values:

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -37,10 +37,13 @@ async def async_multicast_set_value(
     options: Optional[dict] = None,
 ) -> bool:
     """Send a multicast set_value command."""
+    # Iterate through nodes specified or all nodes if not specified
     for node in nodes or client.driver.controller.nodes:
         value_id = _get_value_id_from_dict(node, value_data)
+        # Check that the value exists on the node
         if value_id not in node.values:
             raise NotFoundError(f"Node {node} doesn't have value {value_id}")
+        # Check that the option is valid for the value
         if options:
             for option in options:
                 if option not in node.values[value_id].metadata.value_change_options:

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -41,7 +41,7 @@ async def async_multicast_set_value(
         value_id = _get_value_id_from_dict(node, value_data)
         if value_id not in node.values:
             raise NotFoundError(f"Node {node} doesn't have value {value_id}")
-        if options and nodes:
+        if options:
             for option in options:
                 if option not in node.values[value_id].metadata.value_change_options:
                     raise NotFoundError(

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -44,12 +44,11 @@ async def async_multicast_set_value(
         if value_id not in node.values:
             raise NotFoundError(f"Node {node} doesn't have value {value_id}")
         # Check that the option is valid for the value
-        if options:
-            for option in options:
-                if option not in node.values[value_id].metadata.value_change_options:
-                    raise NotFoundError(
-                        f"Node {node} value {value_id} doesn't support option {option}"
-                    )
+        for option in options or {}:
+            if option not in node.values[value_id].metadata.value_change_options:
+                raise NotFoundError(
+                    f"Node {node} value {value_id} doesn't support option {option}"
+                )
 
     result = await _async_send_command(
         client,

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -34,6 +34,7 @@ async def async_multicast_set_value(
     new_value: Any,
     val: Union[Value, ValueDataType],
     nodes: Optional[List[Node]] = None,
+    options: dict = None,
 ) -> bool:
     """Send a multicast set_value command."""
     value_id = val.data if isinstance(val, Value) else val
@@ -44,6 +45,7 @@ async def async_multicast_set_value(
         nodes,
         valueId=value_id,
         value=new_value,
+        options=options,
         require_schema=5,
     )
     return cast(bool, result["success"])
@@ -93,3 +95,43 @@ async def async_multicast_endpoint_get_cc_version(
         require_schema=5,
     )
     return cast(int, result["version"])
+
+
+async def async_multicast_endpoint_invoke_cc_api(
+    client: Client,
+    endpoint: int,
+    command_class: CommandClass,
+    method_name: str,
+    args: Optional[List[Any]] = None,
+    nodes: Optional[List[Node]] = None,
+) -> Any:
+    """Send a invoke_cc_api command to a multicast endpoint."""
+    result = await _async_send_command(
+        client,
+        "invoke_cc_api",
+        nodes,
+        index=endpoint,
+        commandClass=command_class,
+        methodName=method_name,
+        args=args,
+        require_schema=5,
+    )
+    return result["response"]
+
+
+async def async_multicast_endpoint_supports_cc_api(
+    client: Client,
+    endpoint: int,
+    command_class: CommandClass,
+    nodes: Optional[List[Node]] = None,
+) -> bool:
+    """Send a supports_cc_api command to a multicast endpoint."""
+    result = await _async_send_command(
+        client,
+        "supports_cc_api",
+        nodes,
+        index=endpoint,
+        commandClass=command_class,
+        require_schema=5,
+    )
+    return cast(bool, result["supported"])

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -34,7 +34,7 @@ async def async_multicast_set_value(
     new_value: Any,
     val: Union[Value, ValueDataType],
     nodes: Optional[List[Node]] = None,
-    options: dict = None,
+    options: Optional[dict] = None,
 ) -> bool:
     """Send a multicast set_value command."""
     value_id = val.data if isinstance(val, Value) else val


### PR DESCRIPTION
Corresponding PR: https://github.com/zwave-js/zwave-js-server/pull/312

I also added a new guard to `async_multicast_set_value` to raise better errors when the caller does the wrong thing. This could be considered a breaking change because I removed `Value` as a type for the input, but it didn't really make sense since `Value` is node specific and multicast calls are being applied to multiple nodes. This is not breaking for HA at least