### PR TITLE
Add enums for sensor and meter types to match device class

### DIFF
--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -1,6 +1,6 @@
 """Constants for the Z-Wave JS python library."""
 from enum import Enum, IntEnum
-from typing import Dict, List
+from typing import Dict, List, Union
 
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 7
@@ -653,7 +653,9 @@ class HeatingScale(IntEnum):
 
 CoolingScale = HeatingScale
 
-METER_TYPE_TO_SCALE_ENUM_MAP: Dict[MeterType, IntEnum] = {
+ScaleEnum = Union[ElectricScale, GasScale, WaterScale, HeatingScale, CoolingScale]
+
+METER_TYPE_TO_SCALE_ENUM_MAP: Dict[MeterType, ScaleEnum] = {
     MeterType.ELECTRIC: ElectricScale,
     MeterType.GAS: GasScale,
     MeterType.WATER: WaterScale,

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -445,13 +445,230 @@ class ToneID(IntEnum):
 
 
 class NodeStatus(IntEnum):
-    """Enum with all Node status values.
+    """Enum with all Node status values."""
 
-    https://zwave-js.github.io/node-zwave-js/#/api/node?id=status
-    """
-
+    # https://zwave-js.github.io/node-zwave-js/#/api/node?id=status
     UNKNOWN = 0
     ASLEEP = 1
     AWAKE = 2
     DEAD = 3
     ALIVE = 4
+
+
+CC_SPECIFIC_SENSOR_TYPE = "sensorType"
+
+
+class MultilevelSensorType(IntEnum):
+    """Enum with all known multilevel sensor types."""
+
+    # https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/sensorTypes.json
+    AIR_TEMPERATURE = 1
+    GENERAL_PURPOSE = 2
+    ILLUMINANCE = 3
+    POWER = 4
+    HUMIDITY = 5
+    VELOCITY = 6
+    DIRECTION = 7
+    ATMOSPHERIC_PRESSURE = 8
+    BAROMETRIC_PRESSURE = 9
+    SOLAR_RADIATION = 10
+    DEW_POINT = 11
+    RAIN_RATE = 12
+    TIDE_LEVEL = 13
+    WEIGHT = 14
+    VOLTAGE = 15
+    CURRENT = 16
+    CARBON_DIOXIDE_LEVEL = 17
+    AIR_FLOW = 18
+    TANK_CAPACITY = 19
+    DISTANCE = 20
+    ANGLE_POSITION = 21
+    ROTATION = 22
+    WATER_TEMPERATURE = 23
+    SOIL_TEMPERATURE = 24
+    SEISMIC_INTENSITY = 25
+    SEISMIC_MAGNITUDE = 26
+    ULTRAVIOLET = 27
+    ELECTRICAL_RESISTIVITY = 28
+    ELECTRICAL_CONDUCTIVITY = 29
+    LOUDNESS = 30
+    MOISTURE = 31
+    FREQUENCY = 32
+    TIME = 33
+    TARGET_TEMPERATURE = 34
+    PARTICULATE_MATTER_25 = 35
+    FORMALDEHYDE_LEVEL = 36
+    RADON_CONCENTRATION = 37
+    METHANE_DENSITY = 38
+    VOLATILE_ORGANIC_COMPOUND_LEVEL = 39
+    CARBON_MONOXIDE_LEVEL = 40
+    SOIL_HUMIDITY = 41
+    SOIL_REACTIVITY = 42
+    SOIL_SALINITY = 43
+    HEART_RATE = 44
+    BLOOD_PRESSURE = 45
+    MUSCLE_MASS = 46
+    FAT_MASS = 47
+    BONE_MASS = 48
+    TOTAL_BODY_WATER = 49
+    BASIS_METABOLIC_RATE = 50
+    BODY_MASS_INDEX = 51
+    ACCELERATION_X_AXIS = 52
+    ACCELERATION_Y_AXIS = 53
+    ACCELERATION_Z_AXIS = 54
+    SMOKE_DENSITY = 55
+    WATER_FLOW = 56
+    WATER_PRESSURE = 57
+    RF_SIGNAL_STRENGTH = 58
+    PARTICULATE_MATTER_10 = 59
+    RESPIRATORY_RATE = 60
+    RELATIVE_MODULATION_LEVEL = 61
+    BOILER_WATER_TEMPERATURE = 62
+    DOMESTIC_HOT_WATER_TEMPERATURE = 63
+    OUTSIDE_TEMPERATURE = 64
+    EXHAUST_TEMPERATURE = 65
+    WATER_CHLORINE_LEVEL = 66
+    WATER_ACIDITY = 67
+    WATER_OXIDATION_REDUCTION_POTENTIAL = 68
+    HEART_RATE_LF_HF_RATIO = 69
+    MOTION_DIRECTION = 70
+    APPLIED_FORCE_ON_THE_SENSOR = 71
+    RETURN_AIR_TEMPERATURE = 72
+    SUPPLY_AIR_TEMPERATURE = 73
+    CONDENSER_COIL_TEMPERATURE = 74
+    EVAPORATOR_COIL_TEMPERATURE = 75
+    LIQUID_LINE_TEMPERATURE = 76
+    DISCHARGE_LINE_TEMPERATURE = 77
+    SUCTION_PRESSURE = 78
+    DISCHARGE_PRESSURE = 79
+    DEFROST_TEMPERATURE = 80
+    OZONE = 81
+    SULFUR_DIOXIDE = 82
+    NITROGEN_DIOXIDE = 83
+    AMMONIA = 84
+    LEAD = 85
+    PARTICULATE_MATTER_1 = 86
+
+
+BATTERY_SENSORS = {}
+CO_SENSORS = {MultilevelSensorType.CARBON_MONOXIDE_LEVEL}
+CO2_SENSORS = {MultilevelSensorType.CARBON_DIOXIDE_LEVEL}
+CURRENT_SENSORS = {MultilevelSensorType.CURRENT}
+ENERGY_SENSORS = {MultilevelSensorType.BASIS_METABOLIC_RATE}
+HUMIDITY_SENSORS = {MultilevelSensorType.HUMIDITY}
+ILLUMINANCE_SENSORS = {MultilevelSensorType.ILLUMINANCE}
+MONETARY_SENSORS = {}
+POWER_SENSORS = {MultilevelSensorType.POWER}
+POWER_FACTOR_SENSORS = {}
+PRESSURE_SENSORS = {
+    MultilevelSensorType.BLOOD_PRESSURE,
+    MultilevelSensorType.WATER_PRESSURE,
+    MultilevelSensorType.SUCTION_PRESSURE,
+    MultilevelSensorType.DISCHARGE_PRESSURE,
+    MultilevelSensorType.BAROMETRIC_PRESSURE,
+    MultilevelSensorType.ATMOSPHERIC_PRESSURE,
+}
+SIGNAL_STRENGTH_SENSORS = {MultilevelSensorType.RF_SIGNAL_STRENGTH}
+TEMPERATURE_SENSORS = {
+    MultilevelSensorType.AIR_TEMPERATURE,
+    MultilevelSensorType.DEW_POINT,
+    MultilevelSensorType.WATER_TEMPERATURE,
+    MultilevelSensorType.SOIL_TEMPERATURE,
+    MultilevelSensorType.TARGET_TEMPERATURE,
+    MultilevelSensorType.BOILER_WATER_TEMPERATURE,
+    MultilevelSensorType.DOMESTIC_HOT_WATER_TEMPERATURE,
+    MultilevelSensorType.OUTSIDE_TEMPERATURE,
+    MultilevelSensorType.EXHAUST_TEMPERATURE,
+    MultilevelSensorType.RETURN_AIR_TEMPERATURE,
+    MultilevelSensorType.SUPPLY_AIR_TEMPERATURE,
+    MultilevelSensorType.CONDENSER_COIL_TEMPERATURE,
+    MultilevelSensorType.EVAPORATOR_COIL_TEMPERATURE,
+    MultilevelSensorType.LIQUID_LINE_TEMPERATURE,
+    MultilevelSensorType.DISCHARGE_LINE_TEMPERATURE,
+    MultilevelSensorType.DEFROST_TEMPERATURE,
+}
+TIMESTAMP_SENSORS = {MultilevelSensorType.TIME}
+VOLTAGE_SENSORS = {
+    MultilevelSensorType.VOLTAGE,
+    MultilevelSensorType.WATER_OXIDATION_REDUCTION_POTENTIAL,
+}
+
+CC_SPECIFIC_METER_TYPE = "meterType"
+CC_SPECIFIC_RATE_TYPE = "rateType"
+CC_SPECIFIC_SCALE = "scale"
+
+
+# Meter enums
+# https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/meters.json
+class MeterType(IntEnum):
+    """Enum with all known meter types."""
+
+    ELECTRIC = 1
+    GAS = 2
+    WATER = 3
+    HEATING = 4
+    COOLING = 5
+
+
+class ElectricScale(IntEnum):
+    """Enum with all known electric meter scale values."""
+
+    KILOWATT_HOUR = 0
+    KILOVOLT_AMPERE_HOUR = 1
+    WATT = 2
+    PULSE = 3
+    VOLT = 4
+    AMPERE = 5
+    POWER_FACTOR = 6
+    KILOVOLT_AMPERE_REACTIVE = 7
+    KILOVOLT_AMPERE_REACTIVE_HOUR = 8
+
+
+class GasScale(IntEnum):
+    """Enum with all known gas meter scale values."""
+
+    CUBIC_METER = 0
+    CUBIC_FEET = 1
+    PULSE_COUNT = 3
+
+
+class WaterScale(IntEnum):
+    """Enum with all known water meter scale values."""
+
+    CUBIC_METER = 0
+    CUBIC_FEET = 1
+    US_GALLON = 2
+    PULSE_COUNT = 3
+
+
+class HeatingScale(IntEnum):
+    """Enum with all known heating meter scale values."""
+
+    KILOWATT_HOUR = 0
+
+
+CoolingScale = HeatingScale
+
+METER_TYPE_TO_SCALE_MAP = {
+    MeterType.ELECTRIC: ElectricScale,
+    MeterType.GAS: GasScale,
+    MeterType.WATER: WaterScale,
+    MeterType.HEATING: HeatingScale,
+    MeterType.COOLING: CoolingScale,
+}
+
+ENERGY_METERS = {
+    ElectricScale.KILOWATT_HOUR,
+    ElectricScale.KILOVOLT_AMPERE_HOUR,
+    ElectricScale.KILOVOLT_AMPERE_REACTIVE_HOUR,
+    HeatingScale.KILOWATT_HOUR,
+    CoolingScale.KILOWATT_HOUR,
+}
+POWER_METERS = {
+    ElectricScale.WATT,
+    ElectricScale.PULSE,
+    ElectricScale.KILOVOLT_AMPERE_REACTIVE,
+}
+POWER_FACTOR_METERS = {ElectricScale.POWER_FACTOR}
+VOLTAGE_METERS = {ElectricScale.VOLT}
+CURRENT_METERS = {ElectricScale.AMPERE}

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -1,6 +1,6 @@
 """Constants for the Z-Wave JS python library."""
 from enum import Enum, IntEnum
-from typing import Dict, List, Union
+from typing import Dict, List
 
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 7

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -653,8 +653,6 @@ class HeatingScale(IntEnum):
 
 CoolingScale = HeatingScale
 
-ScaleEnum = Union[ElectricScale, GasScale, WaterScale, HeatingScale, CoolingScale]
-
 METER_TYPE_TO_SCALE_ENUM_MAP = {
     MeterType.ELECTRIC: ElectricScale,
     MeterType.GAS: GasScale,

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -1,6 +1,6 @@
 """Constants for the Z-Wave JS python library."""
 from enum import Enum, IntEnum
-from typing import Dict, List, Set
+from typing import Dict, List
 
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 7
@@ -430,11 +430,6 @@ TARGET_COLOR_PROPERTY = "targetColor"
 TARGET_STATE_PROPERTY = "targetState"
 TARGET_VALUE_PROPERTY = "targetValue"
 
-# optional attributes when calling the Meter CC reset API.
-# https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/MeterCC.ts#L873-L881
-RESET_METER_TARGET_VALUE_PROPERTY = TARGET_VALUE_PROPERTY
-RESET_METER_TYPE_PROPERTY = "type"
-
 
 class ToneID(IntEnum):
     """Enum with all known Sound Switch CC tone IDs."""
@@ -455,6 +450,10 @@ class NodeStatus(IntEnum):
     ALIVE = 4
 
 
+CC_SPECIFIC_SCALE = "scale"
+
+
+# Multilevel Sensor constants
 CC_SPECIFIC_SENSOR_TYPE = "sensorType"
 
 
@@ -550,16 +549,13 @@ class MultilevelSensorType(IntEnum):
     PARTICULATE_MATTER_1 = 86
 
 
-BATTERY_SENSORS: Set[MultilevelSensorType] = {}
 CO_SENSORS = {MultilevelSensorType.CARBON_MONOXIDE_LEVEL}
 CO2_SENSORS = {MultilevelSensorType.CARBON_DIOXIDE_LEVEL}
 CURRENT_SENSORS = {MultilevelSensorType.CURRENT}
 ENERGY_SENSORS = {MultilevelSensorType.BASIS_METABOLIC_RATE}
 HUMIDITY_SENSORS = {MultilevelSensorType.HUMIDITY}
 ILLUMINANCE_SENSORS = {MultilevelSensorType.ILLUMINANCE}
-MONETARY_SENSORS: Set[MultilevelSensorType] = {}
 POWER_SENSORS = {MultilevelSensorType.POWER}
-POWER_FACTOR_SENSORS: Set[MultilevelSensorType] = {}
 PRESSURE_SENSORS = {
     MultilevelSensorType.BLOOD_PRESSURE,
     MultilevelSensorType.WATER_PRESSURE,
@@ -593,12 +589,18 @@ VOLTAGE_SENSORS = {
     MultilevelSensorType.WATER_OXIDATION_REDUCTION_POTENTIAL,
 }
 
+
+# Meter CC constants
+
 CC_SPECIFIC_METER_TYPE = "meterType"
 CC_SPECIFIC_RATE_TYPE = "rateType"
-CC_SPECIFIC_SCALE = "scale"
+
+# optional attributes when calling the Meter CC reset API.
+# https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/MeterCC.ts#L873-L881
+RESET_METER_OPTION_TARGET_VALUE = TARGET_VALUE_PROPERTY
+RESET_METER_OPTION_TYPE = "type"
 
 
-# Meter enums
 # https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/meters.json
 class MeterType(IntEnum):
     """Enum with all known meter types."""
@@ -649,7 +651,7 @@ class HeatingScale(IntEnum):
 
 CoolingScale = HeatingScale
 
-METER_TYPE_TO_SCALE_MAP = {
+METER_TYPE_TO_SCALE_ENUM_MAP: Dict[MeterType, IntEnum] = {
     MeterType.ELECTRIC: ElectricScale,
     MeterType.GAS: GasScale,
     MeterType.WATER: WaterScale,
@@ -657,18 +659,18 @@ METER_TYPE_TO_SCALE_MAP = {
     MeterType.COOLING: CoolingScale,
 }
 
-ENERGY_METERS = {
+ENERGY_METER_TYPES = {
     ElectricScale.KILOWATT_HOUR,
     ElectricScale.KILOVOLT_AMPERE_HOUR,
     ElectricScale.KILOVOLT_AMPERE_REACTIVE_HOUR,
     HeatingScale.KILOWATT_HOUR,
     CoolingScale.KILOWATT_HOUR,
 }
-POWER_METERS = {
+POWER_METER_TYPES = {
     ElectricScale.WATT,
     ElectricScale.PULSE,
     ElectricScale.KILOVOLT_AMPERE_REACTIVE,
 }
-POWER_FACTOR_METERS = {ElectricScale.POWER_FACTOR}
-VOLTAGE_METERS = {ElectricScale.VOLT}
-CURRENT_METERS = {ElectricScale.AMPERE}
+POWER_FACTOR_METER_TYPES = {ElectricScale.POWER_FACTOR}
+VOLTAGE_METER_TYPES = {ElectricScale.VOLT}
+CURRENT_METER_TYPES = {ElectricScale.AMPERE}

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -1,6 +1,6 @@
 """Constants for the Z-Wave JS python library."""
 from enum import Enum, IntEnum
-from typing import Dict, List
+from typing import Dict, List, Set
 
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 7
@@ -550,16 +550,16 @@ class MultilevelSensorType(IntEnum):
     PARTICULATE_MATTER_1 = 86
 
 
-BATTERY_SENSORS = {}
+BATTERY_SENSORS: Set[MultilevelSensorType] = {}
 CO_SENSORS = {MultilevelSensorType.CARBON_MONOXIDE_LEVEL}
 CO2_SENSORS = {MultilevelSensorType.CARBON_DIOXIDE_LEVEL}
 CURRENT_SENSORS = {MultilevelSensorType.CURRENT}
 ENERGY_SENSORS = {MultilevelSensorType.BASIS_METABOLIC_RATE}
 HUMIDITY_SENSORS = {MultilevelSensorType.HUMIDITY}
 ILLUMINANCE_SENSORS = {MultilevelSensorType.ILLUMINANCE}
-MONETARY_SENSORS = {}
+MONETARY_SENSORS: Set[MultilevelSensorType] = {}
 POWER_SENSORS = {MultilevelSensorType.POWER}
-POWER_FACTOR_SENSORS = {}
+POWER_FACTOR_SENSORS: Set[MultilevelSensorType] = {}
 PRESSURE_SENSORS = {
     MultilevelSensorType.BLOOD_PRESSURE,
     MultilevelSensorType.WATER_PRESSURE,

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -595,6 +595,8 @@ VOLTAGE_SENSORS = {
 CC_SPECIFIC_METER_TYPE = "meterType"
 CC_SPECIFIC_RATE_TYPE = "rateType"
 
+RESET_METER_CC_API = "reset"
+
 # optional attributes when calling the Meter CC reset API.
 # https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/MeterCC.ts#L873-L881
 RESET_METER_OPTION_TARGET_VALUE = TARGET_VALUE_PROPERTY

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -655,7 +655,7 @@ CoolingScale = HeatingScale
 
 ScaleEnum = Union[ElectricScale, GasScale, WaterScale, HeatingScale, CoolingScale]
 
-METER_TYPE_TO_SCALE_ENUM_MAP: Dict[MeterType, ScaleEnum] = {
+METER_TYPE_TO_SCALE_ENUM_MAP = {
     MeterType.ELECTRIC: ElectricScale,
     MeterType.GAS: GasScale,
     MeterType.WATER: WaterScale,


### PR DESCRIPTION
We can use the `ZwaveValue.metadata.cc_specific` map to map Multilevel Sensor and Meter CC values to a type/scale, and use that to derive the right device class/EntityDescription. I think this is a better method than using units.

Let me know if the following sensor types to device class mappings make sense. You can use https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/sensorTypes.json as the reference to look at units.
- `MultilevelSensorType.BASIS_METABOLIC_RATE` as an energy device class
- `MultilevelSensorType.TIME` as a timestamp device class
- `MultilevelSensorType.WATER_OXIDATION_REDUCTION_POTENTIAL` as a voltage device class