### PR TITLE
Support schema 8 changes to zwave-js-server

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -255,7 +255,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 7,
+        "maxSchemaVersion": 8,
     }
 
 

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -129,12 +129,31 @@ async def test_begin_inclusion(controller, uuid4, mock_command):
         {"command": "controller.begin_inclusion"},
         {"success": True},
     )
-    assert await controller.async_begin_inclusion(InclusionStrategy.DEFAULT)
+    assert await controller.async_begin_inclusion(InclusionStrategy.SECURITY_S0)
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.begin_inclusion",
-        "options": {"inclusionStrategy": InclusionStrategy.DEFAULT.value},
+        "options": {"inclusionStrategy": InclusionStrategy.SECURITY_S0},
+        "messageId": uuid4,
+    }
+
+
+async def test_begin_inclusion_default(controller, uuid4, mock_command):
+    """Test begin inclusion."""
+    ack_commands = mock_command(
+        {"command": "controller.begin_inclusion"},
+        {"success": True},
+    )
+    assert await controller.async_begin_inclusion_default()
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.begin_inclusion",
+        "options": {
+            "inclusionStrategy": InclusionStrategy.DEFAULT,
+            "forceSecurity": None,
+        },
         "messageId": uuid4,
     }
 

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -614,7 +614,7 @@ async def test_grant_security_classes(controller, uuid4, mock_command) -> None:
         "inclusionGrant": inclusion_grant_dict,
     }
 
-    """Test grant security classes event."""
+    # Test grant security classes event
     event = Event(
         "grant security classes",
         {

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -11,6 +11,7 @@ from zwave_js_server.const import (
     EntryControlEventType,
     NodeStatus,
     ProtocolVersion,
+    SecurityClass,
 )
 from zwave_js_server.event import Event
 from zwave_js_server.exceptions import FailedCommand, NotFoundError, UnwriteableValue
@@ -952,3 +953,40 @@ async def test_statistics_updated(wallmote_central_scene: Node):
     assert isinstance(event_stats, NodeStatistics)
     assert node.statistics.timeout_response == 1
     assert node.statistics == event_stats
+
+
+async def test_has_security_class(multisensor_6: Node, uuid4, mock_command):
+    """Test node.has_security_class command."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "node.has_security_class", "nodeId": node.node_id},
+        {"hasSecurityClass": True},
+    )
+    assert await node.async_has_security_class(SecurityClass.S2_AUTHENTICATED)
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.has_security_class",
+        "nodeId": node.node_id,
+        "securityClass": SecurityClass.S2_AUTHENTICATED.value,
+        "messageId": uuid4,
+    }
+
+
+async def test_get_highest_security_class(multisensor_6: Node, uuid4, mock_command):
+    """Test node.get_highest_security_class command."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "node.get_highest_security_class", "nodeId": node.node_id},
+        {"highestSecurityClass": SecurityClass.S2_AUTHENTICATED.value},
+    )
+    assert (
+        await node.async_get_highest_security_class() == SecurityClass.S2_AUTHENTICATED
+    )
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.get_highest_security_class",
+        "nodeId": node.node_id,
+        "messageId": uuid4,
+    }

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -64,7 +64,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 7}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 8}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -3,9 +3,9 @@ from enum import Enum, IntEnum
 from typing import Dict, List
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 7
+MIN_SERVER_SCHEMA_VERSION = 8
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 7
+MAX_SERVER_SCHEMA_VERSION = 8
 
 VALUE_UNKNOWN = "unknown"
 
@@ -676,3 +676,25 @@ POWER_METER_TYPES = {
 POWER_FACTOR_METER_TYPES = {ElectricScale.POWER_FACTOR}
 VOLTAGE_METER_TYPES = {ElectricScale.VOLT}
 CURRENT_METER_TYPES = {ElectricScale.AMPERE}
+
+
+class InclusionStrategy(IntEnum):
+    """Enum for all known inclusion strategies."""
+
+    # https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/controller/Inclusion.ts#L9-L46
+    DEFAULT = 0
+    SMART_START = 1
+    INSECURE = 2
+    SECURITY_S0 = 3
+    SECURITY_S2 = 4
+
+
+class SecurityClass(IntEnum):
+    """Enum for all known security classes."""
+
+    # https://github.com/zwave-js/node-zwave-js/blob/master/packages/core/src/security/SecurityClass.ts#L3-L17
+    NONE = -1
+    S2_UNAUTHENTICATED = 0
+    S2_AUTHENTICATED = 1
+    S2_ACCESS_CONTROL = 2
+    S0_LEGACY = 7

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -1,6 +1,6 @@
 """Provide a model for the Z-Wave JS controller."""
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, TypedDict, cast
+from typing import Literal, TYPE_CHECKING, Dict, List, Optional, TypedDict, Union, cast
 
 from ..const import InclusionStrategy, SecurityClass
 from ..event import Event, EventBase
@@ -278,13 +278,35 @@ class Controller(EventBase):
         return self._heal_network_progress
 
     async def async_begin_inclusion(
-        self, inclusion_strategy: InclusionStrategy
+        self,
+        inclusion_strategy: Union[
+            Literal[InclusionStrategy.SECURITY_S0],
+            Literal[InclusionStrategy.SECURITY_S2],
+            Literal[InclusionStrategy.INSECURE],
+        ],
     ) -> bool:
         """Send beginInclusion command to Controller."""
         data = await self.client.async_send_command(
             {
                 "command": "controller.begin_inclusion",
                 "options": {"inclusionStrategy": inclusion_strategy},
+            },
+            require_schema=8,
+        )
+        return cast(bool, data["success"])
+
+    async def async_begin_inclusion_default(
+        self,
+        force_security: Optional[bool] = None,
+    ) -> bool:
+        """Send beginInclusion command to Controller using Default inclusion method."""
+        data = await self.client.async_send_command(
+            {
+                "command": "controller.begin_inclusion",
+                "options": {
+                    "inclusionStrategy": InclusionStrategy.DEFAULT,
+                    "forceSecurity": force_security,
+                },
             },
             require_schema=8,
         )
@@ -318,7 +340,13 @@ class Controller(EventBase):
         )
 
     async def async_replace_failed_node(
-        self, node_id: int, inclusion_strategy: InclusionStrategy
+        self,
+        node_id: int,
+        inclusion_strategy: Union[
+            Literal[InclusionStrategy.SECURITY_S0],
+            Literal[InclusionStrategy.SECURITY_S2],
+            Literal[InclusionStrategy.INSECURE],
+        ],
     ) -> bool:
         """Send replaceFailedNode command to Controller."""
         data = await self.client.async_send_command(

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -33,10 +33,10 @@ class InclusionGrant:
             "clientSideAuth": self.client_side_auth,
         }
 
-    @staticmethod
-    def from_dict(data: InclusionGrantDataType) -> "InclusionGrant":
+    @classmethod
+    def from_dict(cls, data: InclusionGrantDataType) -> "InclusionGrant":
         """Return InclusionGrant from InclusionGrantDataType dict."""
-        return InclusionGrant(
+        return cls(
             [SecurityClass(sec_cls) for sec_cls in data["securityClasses"]],
             data["clientSideAuth"],
         )

--- a/zwave_js_server/model/log_config.py
+++ b/zwave_js_server/model/log_config.py
@@ -38,10 +38,10 @@ class LogConfig:
         }
         return cast(LogConfigDataType, {k: v for k, v in data.items() if v is not None})
 
-    @staticmethod
-    def from_dict(data: LogConfigDataType) -> "LogConfig":
+    @classmethod
+    def from_dict(cls, data: LogConfigDataType) -> "LogConfig":
         """Return LogConfig from LogConfigDataType dict."""
-        return LogConfig(
+        return cls(
             data.get("enabled"),
             LogLevel(data["level"]) if "level" in data else None,
             data.get("logToFile"),

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -528,10 +528,7 @@ class Node(Endpoint):
         data = await self.async_send_command(
             "get_highest_security_class", require_schema=8, wait_for_result=True
         )
-        # We should never get here
-        if not data:
-            return SecurityClass.NONE
-
+        assert data
         return SecurityClass(data["highestSecurityClass"])
 
     def handle_wake_up(self, event: Event) -> None:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -514,15 +514,13 @@ class Node(Endpoint):
 
     async def async_has_security_class(self, security_class: SecurityClass) -> bool:
         """Return whether node has the given security class."""
-        data = (
-            await self.async_send_command(
-                "has_security_class",
-                securityClass=security_class,
-                require_schema=8,
-                wait_for_result=True,
-            )
-            or {}
+        data = await self.async_send_command(
+            "has_security_class",
+            securityClass=security_class,
+            require_schema=8,
+            wait_for_result=True,
         )
+        assert data
         return cast(bool, data["hasSecurityClass"])
 
     async def async_get_highest_security_class(self) -> SecurityClass:


### PR DESCRIPTION
See https://github.com/zwave-js/zwave-js-server/pull/342 for changes

- `controller.begin_inclusion` and `controller.replace_failed_node` have been updated to match upstream changes (we also added a separate method for the default inclusion strategy because it has different inputs. We will do the same for SmartStart once it is supported)
- Two new controller commands have been added to support back and forth exchange for S2 bootstrapping
- Two new controller events that the client can use to communicate back and forth with the driver
- Two new node commands related to security
- A couple of enums and data classes