### PR TITLE
Rename energy meter type set

### DIFF
--- a/zwave_js_server/const.py
+++ b/zwave_js_server/const.py
@@ -662,7 +662,7 @@ METER_TYPE_TO_SCALE_ENUM_MAP: Dict[MeterType, Type[MeterScaleType]] = {
     MeterType.COOLING: CoolingScale,
 }
 
-ENERGY_METER_TYPES: Set[MeterScaleType] = {
+ENERGY_TOTAL_INCREASING_METER_TYPES: Set[MeterScaleType] = {
     ElectricScale.KILOWATT_HOUR,
     ElectricScale.KILOVOLT_AMPERE_HOUR,
     ElectricScale.KILOVOLT_AMPERE_REACTIVE_HOUR,


### PR DESCRIPTION
For consistency we will rename the sets to indicate their state class