### PR TITLE
Meter CC constant updates

### DIFF
--- a/zwave_js_server/const/command_class/meter.py
+++ b/zwave_js_server/const/command_class/meter.py
@@ -94,3 +94,9 @@ GAS_METER_TYPES: Set[MeterScaleType] = {
     GasScale.CUBIC_FEET,
     GasScale.PULSE_COUNT,
 }
+WATER_METER_TYPES: Set[MeterScaleType] = {
+    WaterScale.CUBIC_METER,
+    WaterScale.CUBIC_FEET,
+    WaterScale.US_GALLON,
+    WaterScale.PULSE_COUNT,
+}


### PR DESCRIPTION
- Rename meter CC electric scale enum for pulse to pulse count as this is more consistent with the spec
- Move pulse count from POWER_METER_TYPES to ENERGY_TOTAL_INCREASING_METER_TYPES
- Added `GAS_METER_TYPES` and `WATER_METER_TYPES` (there is no device class for water yet but there is for gas)