### PR TITLE
Use `"strategy"` field name in controller inclusion

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -134,7 +134,7 @@ async def test_begin_inclusion(controller, uuid4, mock_command):
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.begin_inclusion",
-        "options": {"inclusionStrategy": InclusionStrategy.SECURITY_S0},
+        "options": {"strategy": InclusionStrategy.SECURITY_S0},
         "messageId": uuid4,
     }
 
@@ -151,7 +151,7 @@ async def test_begin_inclusion_default(controller, uuid4, mock_command):
     assert ack_commands[0] == {
         "command": "controller.begin_inclusion",
         "options": {
-            "inclusionStrategy": InclusionStrategy.DEFAULT,
+            "strategy": InclusionStrategy.DEFAULT,
             "forceSecurity": None,
         },
         "messageId": uuid4,
@@ -243,7 +243,7 @@ async def test_replace_failed_node(controller, uuid4, mock_command):
         "command": "controller.replace_failed_node",
         "messageId": uuid4,
         "nodeId": node_id,
-        "options": {"inclusionStrategy": InclusionStrategy.DEFAULT.value},
+        "options": {"strategy": InclusionStrategy.DEFAULT.value},
     }
 
 

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -289,7 +289,7 @@ class Controller(EventBase):
         data = await self.client.async_send_command(
             {
                 "command": "controller.begin_inclusion",
-                "options": {"inclusionStrategy": inclusion_strategy},
+                "options": {"strategy": inclusion_strategy},
             },
             require_schema=8,
         )
@@ -304,7 +304,7 @@ class Controller(EventBase):
             {
                 "command": "controller.begin_inclusion",
                 "options": {
-                    "inclusionStrategy": InclusionStrategy.DEFAULT,
+                    "strategy": InclusionStrategy.DEFAULT,
                     "forceSecurity": force_security,
                 },
             },
@@ -353,7 +353,7 @@ class Controller(EventBase):
             {
                 "command": "controller.replace_failed_node",
                 "nodeId": node_id,
-                "options": {"inclusionStrategy": inclusion_strategy},
+                "options": {"strategy": inclusion_strategy},
             },
             require_schema=8,
         )


### PR DESCRIPTION
Fixes #288.

I tested this on top of the 0.29.1 tag. The most recent commit does not work with HA 2021.09, so if you are interested in making a patch it would need to be on a different branch.

After this change, I can see node-zwave-js is now emitting the correct "inclusion added" event details. Prior to the change, the event would say `"secure": "true"` even for an insecure inclusion. Now it correctly says `"false"`. This was due to how node-zwave-js handled the undefined `strategy` field.

Before:
```text
2021-09-03 09:09:58 DEBUG (MainThread) [zwave_js_server] Publishing message:
{'command': 'controller.begin_inclusion',
 'messageId': '4a185b3c76c7406e8735cfaa402157e3',
 'options': {'inclusionStrategy': <InclusionStrategy.INSECURE: 2>}}

2021-09-03 09:09:58 DEBUG (MainThread) [zwave_js_server] Received message:
WSMessage(type=<WSMsgType.TEXT: 1>, data='{"type":"event","event":{"source":"controller","event":"inclusion started","secure":true}}', extra='')
```

After:
```text
2021-09-03 09:03:51 DEBUG (MainThread) [zwave_js_server] Publishing message:
{'command': 'controller.begin_inclusion',
 'messageId': '989d53836920418180f6cf673268c851',
 'options': {'strategy': <InclusionStrategy.INSECURE: 2>}}

2021-09-03 09:03:51 DEBUG (MainThread) [zwave_js_server] Received message:
WSMessage(type=<WSMsgType.TEXT: 1>, data='{"type":"event","event":{"source":"controller","event":"inclusion started","secure":false}}', extra='')
```