### PR TITLE
Wait for result when fetching lock usercodes

### DIFF
--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -98,7 +98,9 @@ async def get_usercode_from_node(
     This call will populate the ValueDB and trigger value update events from the
     driver.
     """
-    resp = await node.async_invoke_cc_api(CommandClass.USER_CODE, "get", code_slot)
+    resp = await node.async_invoke_cc_api(
+        CommandClass.USER_CODE, "get", code_slot, wait_for_result=True
+    )
     return {
         ATTR_IN_USE: resp["userIdStatus"] == CodeSlotStatus.ENABLED,
         ATTR_USERCODE: resp["userCode"],


### PR DESCRIPTION
Noticed this the other day but forgot to submit a PR. We should always wait for a result from the lock in this util function because we expect the data to be there as part of the return