### PR TITLE
Increase max message size for dumps to support large networks

### DIFF
--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -8,7 +8,11 @@ from typing import Any, Dict, Optional, cast
 
 from aiohttp import ClientSession, ClientWebSocketResponse, WSMsgType, client_exceptions
 
-from .const import MAX_SERVER_SCHEMA_VERSION, MIN_SERVER_SCHEMA_VERSION
+from .const import (
+    MAX_NETWORK_STATE_SIZE,
+    MAX_SERVER_SCHEMA_VERSION,
+    MIN_SERVER_SCHEMA_VERSION,
+)
 from .event import Event
 from .exceptions import (
     CannotConnect,
@@ -102,6 +106,7 @@ class Client:
             self._client = await self.aiohttp_session.ws_connect(
                 self.ws_server_url,
                 heartbeat=55,
+                max_msg_size=MAX_NETWORK_STATE_SIZE,
             )
         except (
             client_exceptions.WSServerHandshakeError,

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -6,6 +6,9 @@ MIN_SERVER_SCHEMA_VERSION = 9
 # max server schema version we can handle (and our code is compatible with)
 MAX_SERVER_SCHEMA_VERSION = 9
 
+# max size of a network state dump that the client can handle
+MAX_DUMP_SIZE = 64 * 1024 * 1024
+
 VALUE_UNKNOWN = "unknown"
 
 INTERVIEW_FAILED = "Failed"

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -7,7 +7,7 @@ MIN_SERVER_SCHEMA_VERSION = 9
 MAX_SERVER_SCHEMA_VERSION = 9
 
 # max size of a network state dump that the client can handle
-MAX_DUMP_SIZE = 64 * 1024 * 1024
+MAX_NETWORK_STATE_SIZE = 64 * 1024 * 1024
 
 VALUE_UNKNOWN = "unknown"
 

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 import aiohttp
 
-from .const import MAX_SERVER_SCHEMA_VERSION
+from .const import MAX_DUMP_SIZE, MAX_SERVER_SCHEMA_VERSION
 
 
 async def dump_msgs(
@@ -13,7 +13,7 @@ async def dump_msgs(
     timeout: Optional[float] = None,
 ) -> List[dict]:
     """Dump server state."""
-    client = await session.ws_connect(url)
+    client = await session.ws_connect(url, max_msg_size=MAX_DUMP_SIZE)
     msgs = []
 
     version = await client.receive_json()

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 import aiohttp
 
-from .const import MAX_DUMP_SIZE, MAX_SERVER_SCHEMA_VERSION
+from .const import MAX_NETWORK_STATE_SIZE, MAX_SERVER_SCHEMA_VERSION
 
 
 async def dump_msgs(
@@ -13,7 +13,7 @@ async def dump_msgs(
     timeout: Optional[float] = None,
 ) -> List[dict]:
     """Dump server state."""
-    client = await session.ws_connect(url, max_msg_size=MAX_DUMP_SIZE)
+    client = await session.ws_connect(url, max_msg_size=MAX_NETWORK_STATE_SIZE)
     msgs = []
 
     version = await client.receive_json()


### PR DESCRIPTION
See https://discord.com/channels/330944238910963714/800356888827002880/893653844813299713 and https://github.com/zwave-js/zwavejs2mqtt/issues/1769 for context. We should push a new release with this change as upstream changes in a recent version of zwave-js caused the value list to increase significantly for some devices

Will there be any issues on the HA side for large dumps? I took a look at the `HomeAssistantView` logic and I don't see any limits being applied.