### PR TITLE
Bump zwave-js-server-python to 0.31.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.31.1"
+VERSION = "0.31.2"
 
 
 setup(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -261,7 +261,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 9,
+        "maxSchemaVersion": 10,
     }
 
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -64,7 +64,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 9}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 10}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -2,9 +2,9 @@
 from enum import Enum, IntEnum
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 9
+MIN_SERVER_SCHEMA_VERSION = 10
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 9
+MAX_SERVER_SCHEMA_VERSION = 10
 
 VALUE_UNKNOWN = "unknown"
 


### PR DESCRIPTION
After https://github.com/home-assistant-libs/zwave-js-server-python/pull/303