### PR TITLE
Support server side compression

### DIFF
--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -102,6 +102,7 @@ class Client:
             self._client = await self.aiohttp_session.ws_connect(
                 self.ws_server_url,
                 heartbeat=55,
+                compress=15,
             )
         except (
             client_exceptions.WSServerHandshakeError,

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -13,7 +13,7 @@ async def dump_msgs(
     timeout: Optional[float] = None,
 ) -> List[dict]:
     """Dump server state."""
-    client = await session.ws_connect(url)
+    client = await session.ws_connect(url, compress=15)
     msgs = []
 
     version = await client.receive_json()


### PR DESCRIPTION
With https://github.com/zwave-js/zwave-js-server/pull/403 we will compress the network state dump as long as both the server and client support it. I tested this on my network and the state dump went from ~119 kb to 11kb. This suggests that we may still need to increase the message size at some point for extremely large networks, but we shouldn't have to increase it so significantly as we attempted to do before (from 4 MB to 64 MB)