### PR TITLE
Disable max message size in WS client

### DIFF
--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -103,6 +103,7 @@ class Client:
                 self.ws_server_url,
                 heartbeat=55,
                 compress=15,
+                max_msg_size=0,
             )
         except (
             client_exceptions.WSServerHandshakeError,

--- a/zwave_js_server/dump.py
+++ b/zwave_js_server/dump.py
@@ -13,7 +13,7 @@ async def dump_msgs(
     timeout: Optional[float] = None,
 ) -> List[dict]:
     """Dump server state."""
-    client = await session.ws_connect(url, compress=15)
+    client = await session.ws_connect(url, compress=15, max_msg_size=0)
     msgs = []
 
     version = await client.receive_json()


### PR DESCRIPTION
If we assume that we can trust the server that the client is connecting to, we don't need to worry about the max message size (which controls the max decompressed message size accepted by the client).

This would fix https://github.com/home-assistant/core/issues/56922 and future proof us when Z-Wave long range (supports 25600 nodes) gets introduced.