### PR TITLE
Add context object to log message model

### DIFF
--- a/test/model/test_driver.py
+++ b/test/model/test_driver.py
@@ -164,6 +164,15 @@ async def test_listening_logs(driver, uuid4, mock_command):
             "timestamp": "2021-04-18T18:03:34.051Z",
             "multiline": True,
             "secondaryTagPadding": -1,
+            "context": {
+                "source": "controller",
+                "type": "node",
+                "nodeId": 5,
+                "header": "Notification",
+                "direction": "none",
+                "change": "notification",
+                "endpoint": 0,
+            },
         },
     )
     driver.receive_event(event)
@@ -183,6 +192,19 @@ async def test_listening_logs(driver, uuid4, mock_command):
     assert log_message.multiline
     assert log_message.secondary_tag_padding == -1
     assert log_message.timestamp == "2021-04-18T18:03:34.051Z"
+
+    context = log_message.context
+    assert context.change == "notification"
+    assert context.direction == "none"
+    assert context.endpoint == 0
+    assert context.header == "Notification"
+    assert context.node_id == 5
+    assert context.source == "controller"
+    assert context.type == "node"
+    assert context.internal is None
+    assert context.property_ is None
+    assert context.property_key is None
+    assert context.command_class is None
 
 
 async def test_statistics(driver, uuid4, mock_command):

--- a/zwave_js_server/model/log_message.py
+++ b/zwave_js_server/model/log_message.py
@@ -1,6 +1,91 @@
 """Provide a model for a log message event."""
 from typing import List, Literal, Optional, TypedDict, Union
 
+from ..const import CommandClass
+
+
+class LogMessageContextDataType(TypedDict, total=False):
+    """Represent a log message context data dict type."""
+
+    source: Literal["config", "serial", "controller", "driver"]  # required
+    type: Literal["value", "node"]
+    nodeId: int
+    header: str
+    direction: Literal["inbound", "outbound", "none"]
+    change: Literal["added", "removed", "updated", "notification"]
+    internal: bool
+    endpoint: int
+    commandClass: int
+    property: Union[int, str]
+    propertyKey: Union[int, str]
+
+
+class LogMessageContext:
+    """Represent log message context information."""
+
+    def __init__(self, data: LogMessageContextDataType) -> None:
+        """Initialize log message context."""
+        self.data = data
+
+    @property
+    def source(self) -> Literal["config", "serial", "controller", "driver"]:
+        """Return the log message source."""
+        return self.data["source"]
+
+    @property
+    def type(self) -> Optional[Literal["value", "node"]]:
+        """Return the object type for the log message if applicable."""
+        return self.data.get("type")
+
+    @property
+    def node_id(self) -> Optional[int]:
+        """Return the Node ID for the log message if applicable."""
+        return self.data.get("nodeId")
+
+    @property
+    def header(self) -> Optional[str]:
+        """Return the header for the log message if applicable."""
+        return self.data.get("header")
+
+    @property
+    def direction(self) -> Optional[Literal["inbound", "outbound", "none"]]:
+        """Return the direction for the log message if applicable."""
+        return self.data.get("direction")
+
+    @property
+    def change(
+        self,
+    ) -> Optional[Literal["added", "removed", "updated", "notification"]]:
+        """Return the change type for the log message if applicable."""
+        return self.data.get("change")
+
+    @property
+    def internal(self) -> Optional[bool]:
+        """Return the internal flag for the log message if applicable."""
+        return self.data.get("internal")
+
+    @property
+    def endpoint(self) -> Optional[int]:
+        """Return the Node/Value endpoint for the log message if applicable."""
+        return self.data.get("endpoint")
+
+    @property
+    def command_class(self) -> Optional[CommandClass]:
+        """Return the Value command class for the log message if applicable."""
+        if command_class := self.data.get("commandClass"):
+            return CommandClass(command_class)
+        return None
+
+    @property
+    def property_(self) -> Optional[Union[int, str]]:
+        """Return the Value property for the log message if applicable."""
+        return self.data.get("property")
+
+    @property
+    def property_key(self) -> Optional[Union[int, str]]:
+        """Return the Value property key for the log message if applicable."""
+        return self.data.get("propertyKey")
+
 
 class LogMessageDataType(TypedDict, total=False):
     """Represent a log message data dict type."""
@@ -11,6 +96,7 @@ class LogMessageDataType(TypedDict, total=False):
     formattedMessage: Union[str, List[str]]  # required
     direction: str  # required
     level: str  # required
+    context: LogMessageContextDataType  # required
     primaryTags: str
     secondaryTags: str
     secondaryTagPadding: int
@@ -86,3 +172,8 @@ class LogMessage:
     def label(self) -> Optional[str]:
         """Return label."""
         return self.data.get("label")
+
+    @property
+    def context(self) -> LogMessageContext:
+        """Return context."""
+        return LogMessageContext(self.data["context"])


### PR DESCRIPTION
Implements the feature added here: https://github.com/zwave-js/node-zwave-js/pull/3251

This feature would allow clients of the library to selectively filter log messages. Imagine being able to pick an entity in HA and just watch the logs for the value associated with it.