### PR TITLE
Handle upstream changes and new commands for Smart Start

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -261,7 +261,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 10,
+        "maxSchemaVersion": 11,
     }
 
 

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -446,25 +446,6 @@ async def test_get_provisioning_entries(controller, uuid4, mock_command):
     }
 
 
-async def test_begin_inclusion_default_deprecated_cmd(controller, uuid4, mock_command):
-    """Test begin inclusion (deprecated command)."""
-    ack_commands = mock_command(
-        {"command": "controller.begin_inclusion"},
-        {"success": True},
-    )
-    assert await controller.async_begin_inclusion_default()
-
-    assert len(ack_commands) == 1
-    assert ack_commands[0] == {
-        "command": "controller.begin_inclusion",
-        "options": {
-            "strategy": InclusionStrategy.DEFAULT,
-            "forceSecurity": None,
-        },
-        "messageId": uuid4,
-    }
-
-
 async def test_stop_inclusion(controller, uuid4, mock_command):
     """Test stop inclusion."""
     ack_commands = mock_command(

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -467,6 +467,21 @@ async def test_begin_exclusion(controller, uuid4, mock_command):
         {"command": "controller.begin_exclusion"},
         {"success": True},
     )
+    assert await controller.async_begin_exclusion()
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.begin_exclusion",
+        "messageId": uuid4,
+    }
+
+
+async def test_begin_exclusion_unprovision(controller, uuid4, mock_command):
+    """Test begin exclusion with unprovision set."""
+    ack_commands = mock_command(
+        {"command": "controller.begin_exclusion"},
+        {"success": True},
+    )
     assert await controller.async_begin_exclusion(True)
 
     assert len(ack_commands) == 1

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -292,7 +292,7 @@ async def test_begin_inclusion_s2_qr_info(controller, uuid4, mock_command):
     }
 
 
-async def test_begin_inclusion_errors(controller, uuid4, mock_command):
+async def test_begin_inclusion_errors(controller):
     """Test begin inclusion error scenarios."""
     provisioning_entry = controller_pkg.ProvisioningEntry(
         "test", [SecurityClass.S2_UNAUTHENTICATED], {"test": "test"}

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -566,7 +566,9 @@ async def test_replace_failed_node_default(controller, uuid4, mock_command):
     }
 
 
-async def test_replace_failed_node_default_force_security(controller, uuid4, mock_command):
+async def test_replace_failed_node_default_force_security(
+    controller, uuid4, mock_command
+):
     """Test replace_failed_node with force_security provided."""
     ack_commands = mock_command(
         {"command": "controller.replace_failed_node"},
@@ -624,7 +626,9 @@ async def test_replace_failed_node_s2_qr_code_string(controller, uuid4, mock_com
     }
 
 
-async def test_replace_failed_node_s2_provisioning_entry(controller, uuid4, mock_command):
+async def test_replace_failed_node_s2_provisioning_entry(
+    controller, uuid4, mock_command
+):
     """Test replace_failed_node S2 Mode with a provisioning entry."""
     ack_commands = mock_command(
         {"command": "controller.replace_failed_node"},

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -243,21 +243,6 @@ async def test_begin_inclusion_s2_provisioning_entry(controller, uuid4, mock_com
     }
 
 
-async def test_begin_inclusion_errors(controller, uuid4, mock_command):
-    """Test begin inclusion error scenarios."""
-    provisioning_entry = controller_pkg.ProvisioningEntry(
-        "test", [SecurityClass.S2_UNAUTHENTICATED], {"test": "test"}
-    )
-    with pytest.raises(ValueError):
-        await controller.async_begin_inclusion(
-            InclusionStrategy.SECURITY_S0, provisioning=provisioning_entry
-        )
-    with pytest.raises(ValueError):
-        await controller.async_begin_inclusion(
-            InclusionStrategy.SECURITY_S2, force_security=True
-        )
-
-
 async def test_begin_inclusion_s2_qr_info(controller, uuid4, mock_command):
     """Test begin inclusion S2 Mode with QR info."""
     ack_commands = mock_command(
@@ -305,6 +290,21 @@ async def test_begin_inclusion_s2_qr_info(controller, uuid4, mock_command):
         },
         "messageId": uuid4,
     }
+
+
+async def test_begin_inclusion_errors(controller, uuid4, mock_command):
+    """Test begin inclusion error scenarios."""
+    provisioning_entry = controller_pkg.ProvisioningEntry(
+        "test", [SecurityClass.S2_UNAUTHENTICATED], {"test": "test"}
+    )
+    with pytest.raises(ValueError):
+        await controller.async_begin_inclusion(
+            InclusionStrategy.SECURITY_S0, provisioning=provisioning_entry
+        )
+    with pytest.raises(ValueError):
+        await controller.async_begin_inclusion(
+            InclusionStrategy.SECURITY_S2, force_security=True
+        )
 
 
 async def test_provision_smart_start_node_qr_code_string(

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1,7 +1,12 @@
 """Test the controller model."""
 import json
 
-from zwave_js_server.const import InclusionStrategy, Protocols, QRCodeVersion, SecurityClass
+from zwave_js_server.const import (
+    InclusionStrategy,
+    Protocols,
+    QRCodeVersion,
+    SecurityClass,
+)
 from zwave_js_server.event import Event
 from zwave_js_server.model import association as association_pkg
 from zwave_js_server.model import controller as controller_pkg
@@ -324,9 +329,7 @@ async def test_provision_smart_start_node_qr_info(controller, uuid4, mock_comman
     }
 
 
-async def test_unprovision_smart_start_node(
-    controller, uuid4, mock_command
-):
+async def test_unprovision_smart_start_node(controller, uuid4, mock_command):
     """Test unprovision smart start node."""
     ack_commands = mock_command(
         {"command": "controller.unprovision_smart_start_node"},
@@ -342,9 +345,7 @@ async def test_unprovision_smart_start_node(
     }
 
 
-async def test_get_provisioning_entry(
-    controller, uuid4, mock_command
-):
+async def test_get_provisioning_entry(controller, uuid4, mock_command):
     """Test get_provisioning_entry."""
     ack_commands = mock_command(
         {"command": "controller.get_provisioning_entry"},
@@ -363,18 +364,18 @@ async def test_get_provisioning_entry(
     }
 
 
-async def test_get_provisioning_entries(
-    controller, uuid4, mock_command
-):
+async def test_get_provisioning_entries(controller, uuid4, mock_command):
     """Test get_provisioning_entries."""
     ack_commands = mock_command(
         {"command": "controller.get_provisioning_entries"},
         {"entries": [{"dsk": "test", "securityClasses": [0], "test": "test"}]},
     )
     provisioning_entry = await controller.async_get_provisioning_entries()
-    assert provisioning_entry == [controller_pkg.ProvisioningEntry(
-        "test", [SecurityClass.S2_UNAUTHENTICATED], {"test": "test"}
-    )]
+    assert provisioning_entry == [
+        controller_pkg.ProvisioningEntry(
+            "test", [SecurityClass.S2_UNAUTHENTICATED], {"test": "test"}
+        )
+    ]
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1,7 +1,7 @@
 """Test the controller model."""
 import json
 
-from zwave_js_server.const import InclusionStrategy, SecurityClass
+from zwave_js_server.const import InclusionStrategy, Protocols, QRCodeVersion, SecurityClass
 from zwave_js_server.event import Event
 from zwave_js_server.model import association as association_pkg
 from zwave_js_server.model import controller as controller_pkg
@@ -139,6 +139,250 @@ async def test_begin_inclusion(controller, uuid4, mock_command):
     }
 
 
+async def test_begin_inclusion_s2_no_input(controller, uuid4, mock_command):
+    """Test begin inclusion S2 Mode."""
+    ack_commands = mock_command(
+        {"command": "controller.begin_inclusion"},
+        {"success": True},
+    )
+    assert await controller.async_begin_inclusion_s2()
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.begin_inclusion",
+        "options": {"strategy": InclusionStrategy.SECURITY_S2},
+        "messageId": uuid4,
+    }
+
+
+async def test_begin_inclusion_s2_qr_code_string(controller, uuid4, mock_command):
+    """Test begin inclusion S2 Mode with a QR code string."""
+    ack_commands = mock_command(
+        {"command": "controller.begin_inclusion"},
+        {"success": True},
+    )
+    assert await controller.async_begin_inclusion_s2("test")
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.begin_inclusion",
+        "options": {"strategy": InclusionStrategy.SECURITY_S2, "provisioning": "test"},
+        "messageId": uuid4,
+    }
+
+
+async def test_begin_inclusion_s2_provisioning_entry(controller, uuid4, mock_command):
+    """Test begin inclusion S2 Mode with a provisioning entry."""
+    ack_commands = mock_command(
+        {"command": "controller.begin_inclusion"},
+        {"success": True},
+    )
+    provisioning_entry = controller_pkg.ProvisioningEntry(
+        "test", [SecurityClass.S2_UNAUTHENTICATED], {"test": "test"}
+    )
+    assert await controller.async_begin_inclusion_s2(provisioning_entry)
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.begin_inclusion",
+        "options": {
+            "strategy": InclusionStrategy.SECURITY_S2,
+            "provisioning": {"dsk": "test", "securityClasses": [0], "test": "test"},
+        },
+        "messageId": uuid4,
+    }
+
+
+async def test_begin_inclusion_s2_qr_info(controller, uuid4, mock_command):
+    """Test begin inclusion S2 Mode with QR info."""
+    ack_commands = mock_command(
+        {"command": "controller.begin_inclusion"},
+        {"success": True},
+    )
+    provisioning_entry = controller_pkg.QRProvisioningInformation(
+        QRCodeVersion.S2,
+        [SecurityClass.S2_UNAUTHENTICATED],
+        "test",
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        "test",
+        1,
+        "test",
+        None,
+    )
+    assert await controller.async_begin_inclusion_s2(provisioning_entry)
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.begin_inclusion",
+        "options": {
+            "strategy": InclusionStrategy.SECURITY_S2,
+            "provisioning": {
+                "version": 0,
+                "securityClasses": [0],
+                "dsk": "test",
+                "genericDeviceClass": 1,
+                "specificDeviceClass": 1,
+                "installerIconType": 1,
+                "manufacturerId": 1,
+                "productType": 1,
+                "productId": 1,
+                "applicationVersion": "test",
+                "maxInclusionRequestInterval": 1,
+                "uuid": "test",
+            },
+        },
+        "messageId": uuid4,
+    }
+
+
+async def test_provision_smart_start_node_qr_code_string(
+    controller, uuid4, mock_command
+):
+    """Test provision smart start node with a QR code string."""
+    ack_commands = mock_command(
+        {"command": "controller.provision_smart_start_node"},
+        {"success": True},
+    )
+    await controller.async_provision_smart_start_node("test")
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.provision_smart_start_node",
+        "entry": "test",
+        "messageId": uuid4,
+    }
+
+
+async def test_provision_smart_start_node_provisioning_entry(
+    controller, uuid4, mock_command
+):
+    """Test provision smart start node with a provisioning entry."""
+    ack_commands = mock_command(
+        {"command": "controller.provision_smart_start_node"},
+        {"success": True},
+    )
+    provisioning_entry = controller_pkg.ProvisioningEntry(
+        "test", [SecurityClass.S2_UNAUTHENTICATED], {"test": "test"}
+    )
+    await controller.async_provision_smart_start_node(provisioning_entry)
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.provision_smart_start_node",
+        "entry": {"dsk": "test", "securityClasses": [0], "test": "test"},
+        "messageId": uuid4,
+    }
+
+
+async def test_provision_smart_start_node_qr_info(controller, uuid4, mock_command):
+    """Test provision smart start with QR info."""
+    ack_commands = mock_command(
+        {"command": "controller.provision_smart_start_node"},
+        {"success": True},
+    )
+    provisioning_entry = controller_pkg.QRProvisioningInformation(
+        QRCodeVersion.S2,
+        [SecurityClass.S2_UNAUTHENTICATED],
+        "test",
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        "test",
+        1,
+        "test",
+        [Protocols.ZWAVE],
+    )
+    await controller.async_provision_smart_start_node(provisioning_entry)
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.provision_smart_start_node",
+        "entry": {
+            "version": 0,
+            "securityClasses": [0],
+            "dsk": "test",
+            "genericDeviceClass": 1,
+            "specificDeviceClass": 1,
+            "installerIconType": 1,
+            "manufacturerId": 1,
+            "productType": 1,
+            "productId": 1,
+            "applicationVersion": "test",
+            "maxInclusionRequestInterval": 1,
+            "uuid": "test",
+            "supportedProtocols": [0],
+        },
+        "messageId": uuid4,
+    }
+
+
+async def test_unprovision_smart_start_node(
+    controller, uuid4, mock_command
+):
+    """Test unprovision smart start node."""
+    ack_commands = mock_command(
+        {"command": "controller.unprovision_smart_start_node"},
+        {"success": True},
+    )
+    await controller.async_unprovision_smart_start_node("test")
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.unprovision_smart_start_node",
+        "dskOrNodeId": "test",
+        "messageId": uuid4,
+    }
+
+
+async def test_get_provisioning_entry(
+    controller, uuid4, mock_command
+):
+    """Test get_provisioning_entry."""
+    ack_commands = mock_command(
+        {"command": "controller.get_provisioning_entry"},
+        {"entry": {"dsk": "test", "securityClasses": [0], "test": "test"}},
+    )
+    provisioning_entry = await controller.async_get_provisioning_entry("test")
+    assert provisioning_entry == controller_pkg.ProvisioningEntry(
+        "test", [SecurityClass.S2_UNAUTHENTICATED], {"test": "test"}
+    )
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.get_provisioning_entry",
+        "dsk": "test",
+        "messageId": uuid4,
+    }
+
+
+async def test_get_provisioning_entries(
+    controller, uuid4, mock_command
+):
+    """Test get_provisioning_entries."""
+    ack_commands = mock_command(
+        {"command": "controller.get_provisioning_entries"},
+        {"entries": [{"dsk": "test", "securityClasses": [0], "test": "test"}]},
+    )
+    provisioning_entry = await controller.async_get_provisioning_entries()
+    assert provisioning_entry == [controller_pkg.ProvisioningEntry(
+        "test", [SecurityClass.S2_UNAUTHENTICATED], {"test": "test"}
+    )]
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.get_provisioning_entries",
+        "messageId": uuid4,
+    }
+
+
 async def test_begin_inclusion_default(controller, uuid4, mock_command):
     """Test begin inclusion."""
     ack_commands = mock_command(
@@ -179,11 +423,12 @@ async def test_begin_exclusion(controller, uuid4, mock_command):
         {"command": "controller.begin_exclusion"},
         {"success": True},
     )
-    assert await controller.async_begin_exclusion()
+    assert await controller.async_begin_exclusion(True)
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.begin_exclusion",
+        "unprovision": True,
         "messageId": uuid4,
     }
 

--- a/test/model/test_utils.py
+++ b/test/model/test_utils.py
@@ -1,0 +1,56 @@
+"""Test general utility functions."""
+from zwave_js_server.const import Protocols, QRCodeVersion, SecurityClass
+from zwave_js_server.model.utils import async_parse_qr_code_string
+
+
+async def test_parse_qr_code_string(client, mock_command, uuid4):
+    """Test parsing a QR code string."""
+    ack_commands = mock_command(
+        {"command": "utils.parse_qr_code_string"},
+        {
+            "qrProvisioningInformation": {
+                "version": 0,
+                "securityClasses": [0, 1, 2],
+                "dsk": "test",
+                "genericDeviceClass": 1,
+                "specificDeviceClass": 1,
+                "installerIconType": 1,
+                "manufacturerId": 1,
+                "productType": 1,
+                "productId": 1,
+                "applicationVersion": "test",
+                "maxInclusionRequestInterval": 1,
+                "uuid": "test",
+                "supportedProtocols": [0],
+            }
+        },
+    )
+    qr_provisioning_info = await async_parse_qr_code_string(client, "test")
+    assert ack_commands[0] == {
+        "command": "utils.parse_qr_code_string",
+        "qr": "test",
+        "messageId": uuid4,
+    }
+    assert qr_provisioning_info.version == QRCodeVersion.S2
+    assert set(qr_provisioning_info.security_classes) == {
+        SecurityClass.S2_ACCESS_CONTROL,
+        SecurityClass.S2_AUTHENTICATED,
+        SecurityClass.S2_UNAUTHENTICATED,
+    }
+    assert (
+        qr_provisioning_info.dsk
+        == qr_provisioning_info.application_version
+        == qr_provisioning_info.uuid
+        == "test"
+    )
+    assert (
+        qr_provisioning_info.generic_device_class
+        == qr_provisioning_info.specific_device_class
+        == qr_provisioning_info.installer_icon_type
+        == qr_provisioning_info.manufacturer_id
+        == qr_provisioning_info.product_type
+        == qr_provisioning_info.product_id
+        == qr_provisioning_info.max_inclusion_request_interval
+        == 1
+    )
+    assert qr_provisioning_info.supported_protocols == [Protocols.ZWAVE]

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -64,7 +64,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 10}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 11}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -2,9 +2,9 @@
 from enum import Enum, IntEnum
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 10
+MIN_SERVER_SCHEMA_VERSION = 11
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 10
+MAX_SERVER_SCHEMA_VERSION = 11
 
 VALUE_UNKNOWN = "unknown"
 
@@ -221,3 +221,19 @@ class SecurityClass(IntEnum):
     S2_AUTHENTICATED = 1
     S2_ACCESS_CONTROL = 2
     S0_LEGACY = 7
+
+
+class QRCodeVersion(IntEnum):
+    """Enum for all known QR Code versions."""
+
+    # https://github.com/zwave-js/node-zwave-js/blob/master/packages/core/src/security/QR.ts#L43-L46
+    S2 = 0
+    SMART_START = 1
+
+
+class Protocols(IntEnum):
+    """Enum for all known protocols."""
+
+    # https://github.com/zwave-js/node-zwave-js/blob/master/packages/core/src/capabilities/Protocols.ts#L1-L4
+    ZWAVE = 0
+    ZWAVE_LONG_RANGE = 1

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -1,6 +1,5 @@
 """Provide a model for the Z-Wave JS controller."""
 from dataclasses import dataclass
-import logging
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -20,8 +19,6 @@ from .node import Node
 
 if TYPE_CHECKING:
     from ..client import Client
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class InclusionGrantDataType(TypedDict):
@@ -457,26 +454,6 @@ class Controller(EventBase):
                 "options": options,
             },
             require_schema=require_schema,
-        )
-        return cast(bool, data["success"])
-
-    async def async_begin_inclusion_default(
-        self,
-        force_security: Optional[bool] = None,
-    ) -> bool:
-        """Send beginInclusion command to Controller using Default inclusion method."""
-        _LOGGER.warning(
-            "This method has been deprecated, use async_begin_inclusion instead."
-        )
-        data = await self.client.async_send_command(
-            {
-                "command": "controller.begin_inclusion",
-                "options": {
-                    "strategy": InclusionStrategy.DEFAULT,
-                    "forceSecurity": force_security,
-                },
-            },
-            require_schema=8,
         )
         return cast(bool, data["success"])
 

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -116,18 +116,18 @@ class QRProvisioningInformation:
 
     def to_dict(self) -> QRProvisioningInformationDataType:
         """Return QRProvisioningInformationDataType dict from self."""
-        data = {
-            "version": self.version.value,
-            "securityClasses": [sec_cls.value for sec_cls in self.security_classes],
-            "dsk": self.dsk,
-            "genericDeviceClass": self.generic_device_class,
-            "specificDeviceClass": self.specific_device_class,
-            "installerIconType": self.installer_icon_type,
-            "manufacturerId": self.manufacturer_id,
-            "productType": self.product_type,
-            "productId": self.product_id,
-            "applicationVersion": self.application_version,
-        }
+        data = QRProvisioningInformationDataType(
+            version=self.version.value,
+            securityClasses=[sec_cls.value for sec_cls in self.security_classes],
+            dsk=self.dsk,
+            genericDeviceClass=self.generic_device_class,
+            specificDeviceClass=self.specific_device_class,
+            installerIconType=self.installer_icon_type,
+            manufacturerId=self.manufacturer_id,
+            productType=self.product_type,
+            productId=self.product_id,
+            applicationVersion=self.application_version,
+        )
         if self.max_inclusion_request_interval is not None:
             data["maxInclusionRequestInterval"] = self.max_inclusion_request_interval
         if self.uuid is not None:
@@ -144,7 +144,7 @@ class QRProvisioningInformation:
     ) -> "QRProvisioningInformation":
         """Return QRProvisioningInformation from QRProvisioningInformationDataType dict."""
         return cls(
-            data["version"],
+            QRCodeVersion(data["version"]),
             [SecurityClass(sec_cls) for sec_cls in data["securityClasses"]],
             data["dsk"],
             data["genericDeviceClass"],
@@ -423,7 +423,7 @@ class Controller(EventBase):
         ] = None,
     ) -> bool:
         """Send beginInclusion command to Controller using S2 inclusion method."""
-        options = {"strategy": InclusionStrategy.SECURITY_S2}
+        options: Dict[str, Any] = {"strategy": InclusionStrategy.SECURITY_S2}
         if provisioning_info:
             # String is assumed to be the QR code string
             if isinstance(provisioning_info, str):
@@ -499,7 +499,7 @@ class Controller(EventBase):
             },
             require_schema=11,
         )
-        return ProvisioningEntry.from_dict(data.get("entry"))
+        return ProvisioningEntry.from_dict(data["entry"])
 
     async def async_get_provisioning_entries(self) -> List[ProvisioningEntry]:
         """Send getProvisioningEntries command to Controller."""
@@ -520,7 +520,7 @@ class Controller(EventBase):
 
     async def async_begin_exclusion(self, unprovision: Optional[bool] = None) -> bool:
         """Send beginExclusion command to Controller."""
-        payload = {"command": "controller.begin_exclusion"}
+        payload: Dict[str, Union[str, bool]] = {"command": "controller.begin_exclusion"}
         payload["unprovision"] = unprovision or False
         data = await self.client.async_send_command(payload)
         return cast(bool, data["success"])

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -471,7 +471,6 @@ class Controller(EventBase):
             },
             require_schema=11,
         )
-        return None
 
     async def async_unprovision_smart_start_node(
         self,

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -423,7 +423,7 @@ class Controller(EventBase):
         ] = None,
     ) -> bool:
         """Send beginInclusion command to Controller."""
-        options = {"strategy": inclusion_strategy}
+        options: Dict[str, Any] = {"strategy": inclusion_strategy}
         # forceSecurity can only be used with the default inclusion strategy
         if force_security is not None:
             if inclusion_strategy != InclusionStrategy.DEFAULT:
@@ -439,11 +439,12 @@ class Controller(EventBase):
                     "`provisioning` option is only supported with inclusion_strategy=SECURITY_S2"
                 )
             # String is assumed to be the QR code string so we can pass as is
+            if isinstance(provisioning, str):
+                options["provisioning"] = provisioning
             # Otherwise we assume the data is ProvisioningEntry or
             # QRProvisioningInformation
-            if not isinstance(provisioning, str):
-                provisioning = provisioning.to_dict()
-            options["provisioning"] = provisioning
+            else:
+                options["provisioning"] = provisioning.to_dict()
 
         data = await self.client.async_send_command(
             {

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -520,7 +520,8 @@ class Controller(EventBase):
     async def async_begin_exclusion(self, unprovision: Optional[bool] = None) -> bool:
         """Send beginExclusion command to Controller."""
         payload: Dict[str, Union[str, bool]] = {"command": "controller.begin_exclusion"}
-        payload["unprovision"] = unprovision or False
+        if unprovision is not None:
+            payload["unprovision"] = unprovision
         data = await self.client.async_send_command(payload)
         return cast(bool, data["success"])
 

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -484,7 +484,6 @@ class Controller(EventBase):
             },
             require_schema=11,
         )
-        return None
 
     async def async_get_provisioning_entry(
         self, dsk: str

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -423,6 +423,8 @@ class Controller(EventBase):
         ] = None,
     ) -> bool:
         """Send beginInclusion command to Controller."""
+        # Most functionality was introduced in Schema 8
+        require_schema = 8
         options: Dict[str, Any] = {"strategy": inclusion_strategy}
         # forceSecurity can only be used with the default inclusion strategy
         if force_security is not None:
@@ -432,12 +434,15 @@ class Controller(EventBase):
                 )
             options["forceSecurity"] = force_security
 
-        # provisioning can only be used with the S2 inclusion strategy and may need additional processing
+        # provisioning can only be used with the S2 inclusion strategy and may need
+        # additional processing
         if provisioning is not None:
             if inclusion_strategy != InclusionStrategy.SECURITY_S2:
                 raise ValueError(
                     "`provisioning` option is only supported with inclusion_strategy=SECURITY_S2"
                 )
+            # Provisioning option was introduced in Schema 11
+            require_schema = 11
             # String is assumed to be the QR code string so we can pass as is
             if isinstance(provisioning, str):
                 options["provisioning"] = provisioning
@@ -451,7 +456,7 @@ class Controller(EventBase):
                 "command": "controller.begin_inclusion",
                 "options": options,
             },
-            require_schema=8,
+            require_schema=require_schema,
         )
         return cast(bool, data["success"])
 

--- a/zwave_js_server/model/controller.py
+++ b/zwave_js_server/model/controller.py
@@ -47,8 +47,8 @@ class InclusionGrant:
     def from_dict(cls, data: InclusionGrantDataType) -> "InclusionGrant":
         """Return InclusionGrant from InclusionGrantDataType dict."""
         return cls(
-            [SecurityClass(sec_cls) for sec_cls in data["securityClasses"]],
-            data["clientSideAuth"],
+            security_classes=[SecurityClass(sec_cls) for sec_cls in data["securityClasses"]],
+            client_side_auth=data["clientSideAuth"],
         )
 
 
@@ -72,9 +72,9 @@ class ProvisioningEntry:
     def from_dict(cls, data: Dict[str, Any]) -> "ProvisioningEntry":
         """Return ProvisioningEntry from data dict."""
         return cls(
-            data["dsk"],
-            [SecurityClass(sec_cls) for sec_cls in data["securityClasses"]],
-            {k: v for k, v in data.items() if k not in {"dsk", "securityClasses"}},
+            dsk=data["dsk"],
+            security_classes=[SecurityClass(sec_cls) for sec_cls in data["securityClasses"]],
+            additional_properties={k: v for k, v in data.items() if k not in {"dsk", "securityClasses"}},
         )
 
 
@@ -144,19 +144,19 @@ class QRProvisioningInformation:
     ) -> "QRProvisioningInformation":
         """Return QRProvisioningInformation from QRProvisioningInformationDataType dict."""
         return cls(
-            QRCodeVersion(data["version"]),
-            [SecurityClass(sec_cls) for sec_cls in data["securityClasses"]],
-            data["dsk"],
-            data["genericDeviceClass"],
-            data["specificDeviceClass"],
-            data["installerIconType"],
-            data["manufacturerId"],
-            data["productType"],
-            data["productId"],
-            data["applicationVersion"],
-            data.get("maxInclusionRequestInterval"),
-            data.get("uuid"),
-            [
+            version=QRCodeVersion(data["version"]),
+            security_classes=[SecurityClass(sec_cls) for sec_cls in data["securityClasses"]],
+            dsk=data["dsk"],
+            generic_device_class=data["genericDeviceClass"],
+            specific_device_class=data["specificDeviceClass"],
+            installer_icon_type=data["installerIconType"],
+            manufacturer_id=data["manufacturerId"],
+            product_type=data["productType"],
+            product_id=data["productId"],
+            application_version=data["applicationVersion"],
+            max_inclusion_request_interval=data.get("maxInclusionRequestInterval"),
+            uuid=data.get("uuid"),
+            supported_protocols=[
                 Protocols(supported_protocol)
                 for supported_protocol in data.get("supportedProtocols", [])
             ],

--- a/zwave_js_server/model/utils.py
+++ b/zwave_js_server/model/utils.py
@@ -1,0 +1,13 @@
+"""Model for utils commands."""
+from ..client import Client
+from .controller import QRProvisioningInformation
+
+
+async def async_parse_qr_code_string(
+    client: Client, qr_code_string: str
+) -> QRProvisioningInformation:
+    """Parse a QR code string into a QRProvisioningInformation object."""
+    data = await client.async_send_command(
+        {"command": "utils.parse_qr_code_string", "qr": qr_code_string}
+    )
+    return QRProvisioningInformation.from_dict(data["qrProvisioningInformation"])


### PR DESCRIPTION
Related to https://github.com/zwave-js/zwave-js-server/pull/432

- Adds support for the new SmartStart provisioning workflows as well as using the S2 inclusion workflow using a QR code. 
- Adds a command to be able to call `parseQRCodeString`.
- Update `beginExclusion` command to include new option.

One thing that I have done is moved the S2 security `beginInclusion` command into its own method given the multiple ways that that workflow can work. The existing `async_begin_inclusion` method will still work for S2 security as the inclusion strategy but does not support all of the various options that are now available in the linked PR