### PR TITLE
Add new commands and event handlers introduced in zwave-js 8.9.0

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -261,7 +261,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 12,
+        "maxSchemaVersion": 13,
     }
 
 

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -20,7 +20,12 @@ from zwave_js_server.event import Event
 from zwave_js_server.exceptions import FailedCommand, NotFoundError, UnwriteableValue
 from zwave_js_server.model import node as node_pkg
 from zwave_js_server.model.firmware import FirmwareUpdateStatus
-from zwave_js_server.model.node import LifelineHealthCheckResultDataType, Node, NodeStatistics, RouteHealthCheckResultDataType
+from zwave_js_server.model.node import (
+    LifelineHealthCheckResultDataType,
+    Node,
+    NodeStatistics,
+    RouteHealthCheckResultDataType,
+)
 from zwave_js_server.model.value import ConfigurationValue
 
 from .. import load_fixture
@@ -1008,9 +1013,7 @@ async def test_test_powerlevel(multisensor_6: Node, uuid4, mock_command):
         {"command": "node.test_powerlevel", "nodeId": node.node_id},
         {"framesAcked": 1},
     )
-    assert (
-        await node.async_test_powerlevel(2, Powerlevel.DBM_MINUS_1, 3) == 1
-    )
+    assert await node.async_test_powerlevel(2, Powerlevel.DBM_MINUS_1, 3) == 1
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
@@ -1046,7 +1049,22 @@ async def test_check_lifeline_health(multisensor_6: Node, uuid4, mock_command):
     node = multisensor_6
     ack_commands = mock_command(
         {"command": "node.check_lifeline_health", "nodeId": node.node_id},
-        {"summary": {"rating": 10, "results": [LifelineHealthCheckResultDataType(latency=1, numNeighbors=2, failedPingsNode=3, routeChanges=4, minPowerlevel=5, failedPingsController=6, snrMargin=7)]}},
+        {
+            "summary": {
+                "rating": 10,
+                "results": [
+                    LifelineHealthCheckResultDataType(
+                        latency=1,
+                        numNeighbors=2,
+                        failedPingsNode=3,
+                        routeChanges=4,
+                        minPowerlevel=5,
+                        failedPingsController=6,
+                        snrMargin=7,
+                    )
+                ],
+            }
+        },
     )
     summary = await node.async_check_lifeline_health(1)
 
@@ -1068,7 +1086,9 @@ async def test_check_lifeline_health(multisensor_6: Node, uuid4, mock_command):
     }
 
 
-async def test_check_lifeline_health_progress_event(multisensor_6: Node, uuid4, mock_command):
+async def test_check_lifeline_health_progress_event(
+    multisensor_6: Node, uuid4, mock_command
+):
     """Test check lifeline health progress event."""
     event = Event(
         "check lifeline health progress",
@@ -1093,7 +1113,21 @@ async def test_check_route_health(multisensor_6: Node, uuid4, mock_command):
     node = multisensor_6
     ack_commands = mock_command(
         {"command": "node.check_route_health", "nodeId": node.node_id},
-        {"summary": {"rating": 10, "results": [RouteHealthCheckResultDataType(numNeighbors=1, rating=10, failedPingsToSource=2, failedPingsToTarget=3, minPowerlevelSource=4, minPowerlevelTarget=5)]}},
+        {
+            "summary": {
+                "rating": 10,
+                "results": [
+                    RouteHealthCheckResultDataType(
+                        numNeighbors=1,
+                        rating=10,
+                        failedPingsToSource=2,
+                        failedPingsToTarget=3,
+                        minPowerlevelSource=4,
+                        minPowerlevelTarget=5,
+                    )
+                ],
+            }
+        },
     )
     summary = await node.async_check_route_health(15, 1)
 
@@ -1115,7 +1149,9 @@ async def test_check_route_health(multisensor_6: Node, uuid4, mock_command):
     }
 
 
-async def test_check_route_health_progress_event(multisensor_6: Node, uuid4, mock_command):
+async def test_check_route_health_progress_event(
+    multisensor_6: Node, uuid4, mock_command
+):
     """Test check route health progress event."""
     event = Event(
         "check route health progress",

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -8,7 +8,7 @@ from zwave_js_server.const import (
     INTERVIEW_FAILED,
     CommandClass,
     NodeStatus,
-    Powerlevel,
+    PowerLevel,
     ProtocolVersion,
     SecurityClass,
 )
@@ -1006,28 +1006,28 @@ async def test_get_highest_security_class(multisensor_6: Node, uuid4, mock_comma
     }
 
 
-async def test_test_powerlevel(multisensor_6: Node, uuid4, mock_command):
+async def test_test_power_level(multisensor_6: Node, uuid4, mock_command):
     """Test node.test_powerlevel command."""
     node = multisensor_6
     ack_commands = mock_command(
         {"command": "node.test_powerlevel", "nodeId": node.node_id},
         {"framesAcked": 1},
     )
-    assert await node.async_test_powerlevel(2, Powerlevel.DBM_MINUS_1, 3) == 1
+    assert await node.async_test_power_level(2, PowerLevel.DBM_MINUS_1, 3) == 1
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "node.test_powerlevel",
         "nodeId": node.node_id,
         "testNodeId": 2,
-        "powerlevel": Powerlevel.DBM_MINUS_1.value,
+        "powerlevel": PowerLevel.DBM_MINUS_1.value,
         "testFrameCount": 3,
         "messageId": uuid4,
     }
 
 
-async def test_test_powerlevel_progress_event(multisensor_6: Node, uuid4, mock_command):
-    """Test test powerlevel progress event."""
+async def test_test_power_level_progress_event(multisensor_6: Node, uuid4, mock_command):
+    """Test test power level progress event."""
     event = Event(
         "test powerlevel progress",
         {
@@ -1039,9 +1039,9 @@ async def test_test_powerlevel_progress_event(multisensor_6: Node, uuid4, mock_c
         },
     )
     multisensor_6.receive_event(event)
-    assert event.data["test_powerlevel_progress"]
-    assert event.data["test_powerlevel_progress"].acknowledged == 1
-    assert event.data["test_powerlevel_progress"].total == 2
+    assert event.data["test_power_level_progress"]
+    assert event.data["test_power_level_progress"].acknowledged == 1
+    assert event.data["test_power_level_progress"].total == 2
 
 
 async def test_check_lifeline_health(multisensor_6: Node, uuid4, mock_command):
@@ -1073,7 +1073,7 @@ async def test_check_lifeline_health(multisensor_6: Node, uuid4, mock_command):
     assert summary.results[0].num_neighbors == 2
     assert summary.results[0].failed_pings_node == 3
     assert summary.results[0].route_changes == 4
-    assert summary.results[0].min_powerlevel == Powerlevel.DBM_MINUS_5
+    assert summary.results[0].min_power_level == PowerLevel.DBM_MINUS_5
     assert summary.results[0].failed_pings_controller == 6
     assert summary.results[0].snr_margin == 7
 
@@ -1136,8 +1136,8 @@ async def test_check_route_health(multisensor_6: Node, uuid4, mock_command):
     assert summary.results[0].rating == 10
     assert summary.results[0].failed_pings_to_source == 2
     assert summary.results[0].failed_pings_to_target == 3
-    assert summary.results[0].min_powerlevel_source == Powerlevel.DBM_MINUS_4
-    assert summary.results[0].min_powerlevel_target == Powerlevel.DBM_MINUS_5
+    assert summary.results[0].min_power_level_source == PowerLevel.DBM_MINUS_4
+    assert summary.results[0].min_power_level_target == PowerLevel.DBM_MINUS_5
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -8,6 +8,7 @@ from zwave_js_server.const import (
     INTERVIEW_FAILED,
     CommandClass,
     NodeStatus,
+    Powerlevel,
     ProtocolVersion,
     SecurityClass,
 )
@@ -19,7 +20,7 @@ from zwave_js_server.event import Event
 from zwave_js_server.exceptions import FailedCommand, NotFoundError, UnwriteableValue
 from zwave_js_server.model import node as node_pkg
 from zwave_js_server.model.firmware import FirmwareUpdateStatus
-from zwave_js_server.model.node import Node, NodeStatistics
+from zwave_js_server.model.node import LifelineHealthCheckResultDataType, Node, NodeStatistics, RouteHealthCheckResultDataType
 from zwave_js_server.model.value import ConfigurationValue
 
 from .. import load_fixture
@@ -998,3 +999,137 @@ async def test_get_highest_security_class(multisensor_6: Node, uuid4, mock_comma
         "nodeId": node.node_id,
         "messageId": uuid4,
     }
+
+
+async def test_test_powerlevel(multisensor_6: Node, uuid4, mock_command):
+    """Test node.test_powerlevel command."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "node.test_powerlevel", "nodeId": node.node_id},
+        {"framesAcked": 1},
+    )
+    assert (
+        await node.async_test_powerlevel(2, Powerlevel.DBM_MINUS_1, 3) == 1
+    )
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.test_powerlevel",
+        "nodeId": node.node_id,
+        "testNodeId": 2,
+        "powerlevel": Powerlevel.DBM_MINUS_1.value,
+        "testFrameCount": 3,
+        "messageId": uuid4,
+    }
+
+
+async def test_test_powerlevel_progress_event(multisensor_6: Node, uuid4, mock_command):
+    """Test test powerlevel progress event."""
+    event = Event(
+        "test powerlevel progress",
+        {
+            "source": "node",
+            "event": "test powerlevel progress",
+            "nodeId": multisensor_6.node_id,
+            "acknowledged": 1,
+            "total": 2,
+        },
+    )
+    multisensor_6.receive_event(event)
+    assert event.data["test_powerlevel_progress"]
+    assert event.data["test_powerlevel_progress"].acknowledged == 1
+    assert event.data["test_powerlevel_progress"].total == 2
+
+
+async def test_check_lifeline_health(multisensor_6: Node, uuid4, mock_command):
+    """Test node.check_lifeline_health command."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "node.check_lifeline_health", "nodeId": node.node_id},
+        {"summary": {"rating": 10, "results": [LifelineHealthCheckResultDataType(latency=1, numNeighbors=2, failedPingsNode=3, routeChanges=4, minPowerlevel=5, failedPingsController=6, snrMargin=7)]}},
+    )
+    summary = await node.async_check_lifeline_health(1)
+
+    assert summary.rating == 10
+    assert summary.results[0].latency == 1
+    assert summary.results[0].num_neighbors == 2
+    assert summary.results[0].failed_pings_node == 3
+    assert summary.results[0].route_changes == 4
+    assert summary.results[0].min_powerlevel == Powerlevel.DBM_MINUS_5
+    assert summary.results[0].failed_pings_controller == 6
+    assert summary.results[0].snr_margin == 7
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.check_lifeline_health",
+        "nodeId": node.node_id,
+        "rounds": 1,
+        "messageId": uuid4,
+    }
+
+
+async def test_check_lifeline_health_progress_event(multisensor_6: Node, uuid4, mock_command):
+    """Test check lifeline health progress event."""
+    event = Event(
+        "check lifeline health progress",
+        {
+            "source": "node",
+            "event": "check lifeline health progress",
+            "nodeId": multisensor_6.node_id,
+            "rounds": 1,
+            "totalRounds": 2,
+            "lastRating": 10,
+        },
+    )
+    multisensor_6.receive_event(event)
+    assert event.data["check_lifeline_health_progress"]
+    assert event.data["check_lifeline_health_progress"].rounds == 1
+    assert event.data["check_lifeline_health_progress"].total_rounds == 2
+    assert event.data["check_lifeline_health_progress"].last_rating == 10
+
+
+async def test_check_route_health(multisensor_6: Node, uuid4, mock_command):
+    """Test node.check_route_health command."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "node.check_route_health", "nodeId": node.node_id},
+        {"summary": {"rating": 10, "results": [RouteHealthCheckResultDataType(numNeighbors=1, rating=10, failedPingsToSource=2, failedPingsToTarget=3, minPowerlevelSource=4, minPowerlevelTarget=5)]}},
+    )
+    summary = await node.async_check_route_health(15, 1)
+
+    assert summary.rating == 10
+    assert summary.results[0].num_neighbors == 1
+    assert summary.results[0].rating == 10
+    assert summary.results[0].failed_pings_to_source == 2
+    assert summary.results[0].failed_pings_to_target == 3
+    assert summary.results[0].min_powerlevel_source == Powerlevel.DBM_MINUS_4
+    assert summary.results[0].min_powerlevel_target == Powerlevel.DBM_MINUS_5
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.check_route_health",
+        "nodeId": node.node_id,
+        "targetNodeId": 15,
+        "rounds": 1,
+        "messageId": uuid4,
+    }
+
+
+async def test_check_route_health_progress_event(multisensor_6: Node, uuid4, mock_command):
+    """Test check route health progress event."""
+    event = Event(
+        "check route health progress",
+        {
+            "source": "node",
+            "event": "check route health progress",
+            "nodeId": multisensor_6.node_id,
+            "rounds": 1,
+            "totalRounds": 2,
+            "lastRating": 10,
+        },
+    )
+    multisensor_6.receive_event(event)
+    assert event.data["check_route_health_progress"]
+    assert event.data["check_route_health_progress"].rounds == 1
+    assert event.data["check_route_health_progress"].total_rounds == 2
+    assert event.data["check_route_health_progress"].last_rating == 10

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1026,7 +1026,9 @@ async def test_test_power_level(multisensor_6: Node, uuid4, mock_command):
     }
 
 
-async def test_test_power_level_progress_event(multisensor_6: Node, uuid4, mock_command):
+async def test_test_power_level_progress_event(
+    multisensor_6: Node, uuid4, mock_command
+):
     """Test test power level progress event."""
     event = Event(
         "test powerlevel progress",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -64,7 +64,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 12}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 13}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -4,7 +4,7 @@ from enum import Enum, IntEnum
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 12
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 12
+MAX_SERVER_SCHEMA_VERSION = 13
 
 VALUE_UNKNOWN = "unknown"
 
@@ -248,3 +248,19 @@ class ZwaveFeature(IntEnum):
 
     # https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/controller/Features.ts#L4
     SMART_START = 0
+
+
+class Powerlevel(IntEnum):
+    """Enum for all known power levels."""
+
+    # https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/PowerlevelCC.ts#L38
+    NORMAL_POWER = 0
+    DBM_MINUS_1 = 1
+    DBM_MINUS_2 = 2
+    DBM_MINUS_3 = 3
+    DBM_MINUS_4 = 4
+    DBM_MINUS_5 = 5
+    DBM_MINUS_6 = 6
+    DBM_MINUS_7 = 7
+    DBM_MINUS_8 = 8
+    DBM_MINUS_9 = 9

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -250,7 +250,7 @@ class ZwaveFeature(IntEnum):
     SMART_START = 0
 
 
-class Powerlevel(IntEnum):
+class PowerLevel(IntEnum):
     """Enum for all known power levels."""
 
     # https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/PowerlevelCC.ts#L38

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -154,7 +154,7 @@ class LifelineHealthCheckResult:
 
     @property
     def min_power_level(self) -> Optional[PowerLevel]:
-        """Return minimum power_level."""
+        """Return minimum power level."""
         power_level = self.data.get("minPowerlevel")
         if power_level is not None:
             return PowerLevel(power_level)
@@ -239,7 +239,7 @@ class RouteHealthCheckResult:
 
     @property
     def min_power_level_source(self) -> Optional[PowerLevel]:
-        """Return minimum power_level source."""
+        """Return minimum power level source."""
         power_level = self.data.get("minPowerlevelSource")
         if power_level is not None:
             return PowerLevel(power_level)
@@ -247,7 +247,7 @@ class RouteHealthCheckResult:
 
     @property
     def min_power_level_target(self) -> Optional[PowerLevel]:
-        """Return minimum power_level target."""
+        """Return minimum power level target."""
         power_level = self.data.get("minPowerlevelTarget")
         if power_level is not None:
             return PowerLevel(power_level)
@@ -780,7 +780,7 @@ class Node(Endpoint):
         return RouteHealthCheckSummary(data["summary"])
 
     def handle_test_powerlevel_progress(self, event: Event) -> None:
-        """Process a test powerelevel progress event."""
+        """Process a test power level progress event."""
         event.data["test_power_level_progress"] = TestPowerLevelProgress(
             event.data["acknowledged"], event.data["total"]
         )

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -6,7 +6,7 @@ from ..const import (
     INTERVIEW_FAILED,
     CommandClass,
     NodeStatus,
-    Powerlevel,
+    PowerLevel,
     SecurityClass,
 )
 from ..event import Event
@@ -153,11 +153,11 @@ class LifelineHealthCheckResult:
         return self.data.get("routeChanges")
 
     @property
-    def min_powerlevel(self) -> Optional[Powerlevel]:
-        """Return minimum powerlevel."""
-        powerlevel = self.data.get("minPowerlevel")
-        if powerlevel is not None:
-            return Powerlevel(powerlevel)
+    def min_power_level(self) -> Optional[PowerLevel]:
+        """Return minimum power_level."""
+        power_level = self.data.get("minPowerlevel")
+        if power_level is not None:
+            return PowerLevel(power_level)
         return None
 
     @property
@@ -238,19 +238,19 @@ class RouteHealthCheckResult:
         return self.data.get("failedPingsToSource")
 
     @property
-    def min_powerlevel_source(self) -> Optional[Powerlevel]:
-        """Return minimum powerlevel source."""
-        powerlevel = self.data.get("minPowerlevelSource")
-        if powerlevel is not None:
-            return Powerlevel(powerlevel)
+    def min_power_level_source(self) -> Optional[PowerLevel]:
+        """Return minimum power_level source."""
+        power_level = self.data.get("minPowerlevelSource")
+        if power_level is not None:
+            return PowerLevel(power_level)
         return None
 
     @property
-    def min_powerlevel_target(self) -> Optional[Powerlevel]:
-        """Return minimum powerlevel target."""
-        powerlevel = self.data.get("minPowerlevelTarget")
-        if powerlevel is not None:
-            return Powerlevel(powerlevel)
+    def min_power_level_target(self) -> Optional[PowerLevel]:
+        """Return minimum power_level target."""
+        power_level = self.data.get("minPowerlevelTarget")
+        if power_level is not None:
+            return PowerLevel(power_level)
         return None
 
 
@@ -274,8 +274,8 @@ class RouteHealthCheckSummary:
 
 
 @dataclass
-class TestPowerlevelProgress:
-    """Class to represent a test powerlevel progress update."""
+class TestPowerLevelProgress:
+    """Class to represent a test power level progress update."""
 
     acknowledged: int
     total: int
@@ -732,14 +732,14 @@ class Node(Endpoint):
         assert data
         return SecurityClass(data["highestSecurityClass"])
 
-    async def async_test_powerlevel(
-        self, test_node_id: int, powerlevel: Powerlevel, test_frame_count: int
+    async def async_test_power_level(
+        self, test_node_id: int, power_level: PowerLevel, test_frame_count: int
     ) -> int:
         """Send testPowerLevel command to Node."""
         data = await self.async_send_command(
             "test_powerlevel",
             testNodeId=test_node_id,
-            powerlevel=powerlevel,
+            powerlevel=power_level,
             testFrameCount=test_frame_count,
             require_schema=13,
             wait_for_result=True,
@@ -781,7 +781,7 @@ class Node(Endpoint):
 
     def handle_test_powerlevel_progress(self, event: Event) -> None:
         """Process a test powerelevel progress event."""
-        event.data["test_powerlevel_progress"] = TestPowerlevelProgress(
+        event.data["test_power_level_progress"] = TestPowerLevelProgress(
             event.data["acknowledged"], event.data["total"]
         )
 

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -177,9 +177,7 @@ class LifelineHealthCheckSummary:
     def __init__(self, data: LifelineHealthCheckSummaryDataType) -> None:
         """Initialize lifeline health check summary."""
         self._rating = data["rating"]
-        self._results = [
-            LifelineHealthCheckResult(r) for r in data.get("results", [])
-        ]
+        self._results = [LifelineHealthCheckResult(r) for r in data.get("results", [])]
 
     @property
     def rating(self) -> int:
@@ -262,9 +260,7 @@ class RouteHealthCheckSummary:
     def __init__(self, data: RouteHealthCheckSummaryDataType) -> None:
         """Initialize route health check summary."""
         self._rating = data["rating"]
-        self._results = [
-            RouteHealthCheckResult(r) for r in data.get("results", [])
-        ]
+        self._results = [RouteHealthCheckResult(r) for r in data.get("results", [])]
 
     @property
     def rating(self) -> int:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -751,14 +751,13 @@ class Node(Endpoint):
         self, rounds: Optional[int] = None
     ) -> LifelineHealthCheckSummary:
         """Send checkLifelineHealth command to Node."""
-        kwargs = {
-            "require_schema": 13,
-            "wait_for_result": True,
-        }
+        kwargs = {}
         if rounds is not None:
             kwargs["rounds"] = rounds
         data = await self.async_send_command(
             "check_lifeline_health",
+            require_schema=13,
+            wait_for_result=True,
             **kwargs,
         )
         assert data
@@ -768,15 +767,13 @@ class Node(Endpoint):
         self, target_node_id: int, rounds: Optional[int] = None
     ) -> RouteHealthCheckSummary:
         """Send checkRouteHealth command to Node."""
-        kwargs = {
-            "require_schema": 13,
-            "wait_for_result": True,
-            "targetNodeId": target_node_id,
-        }
+        kwargs = {"targetNodeId": target_node_id}
         if rounds is not None:
             kwargs["rounds"] = rounds
         data = await self.async_send_command(
             "check_route_health",
+            require_schema=13,
+            wait_for_result=True,
             **kwargs,
         )
         assert data


### PR DESCRIPTION
In this PR we add the following node level commands as well as the progress events that they emit:
- `test_power_level`
- `check_lifeline_health`
- `check_route_health`

Since no existing commands changed, I kept the minimum schema version to 12 even though I bumped up the max to 13. With that being said, if we want to force users to update to the latest to address that options initialization issue, we can bump the min version as well