### PR TITLE
Add functionality to record messages between lib and server

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -342,7 +342,7 @@ async def test_command_error_handling(client, mock_command):
 async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
     """Test recording messages."""
     client = wallmote_central_scene.client
-    assert not client.messages_are_being_recorded
+    assert not client.recording_messages
     assert not client._recorded_commands
     assert not client._recorded_events
     client.begin_recording_messages()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -354,7 +354,9 @@ async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
     with pytest.raises(InvalidState):
         client.begin_recording_messages()
 
-    with patch("zwave_js_server.client._now", return_value=datetime(2022, 1, 7, 1)):
+    with patch("zwave_js_server.client.datetime") as mock_dt:
+        mock_dt.utcnow.return_value = datetime(2022, 1, 7, 1)
+
         await client.async_send_command({"command": "some_command"})
 
     assert len(client._recorded_commands) == 1
@@ -375,7 +377,8 @@ async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
     assert "ts" in client._recorded_commands[uuid4]
     assert "result_ts" in client._recorded_commands[uuid4]
 
-    with patch("zwave_js_server.client._now", return_value=datetime(2022, 1, 7, 0)):
+    with patch("zwave_js_server.client.datetime") as mock_dt:
+        mock_dt.utcnow.return_value = datetime(2022, 1, 7, 0)
         client._handle_incoming_message(
             {
                 "type": "event",

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -354,7 +354,9 @@ async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
     with pytest.raises(InvalidState):
         client.begin_recording_messages()
 
-    with patch("zwave_js_server.client.Client._now", return_value=datetime(2022, 1, 7, 1)):
+    with patch(
+        "zwave_js_server.client.Client._now", return_value=datetime(2022, 1, 7, 1)
+    ):
         await client.async_send_command({"command": "some_command"})
 
     assert len(client._recorded_commands) == 1
@@ -375,7 +377,9 @@ async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
     assert "ts" in client._recorded_commands[uuid4]
     assert "result_ts" in client._recorded_commands[uuid4]
 
-    with patch("zwave_js_server.client.Client._now", return_value=datetime(2022, 1, 7, 0)):
+    with patch(
+        "zwave_js_server.client.Client._now", return_value=datetime(2022, 1, 7, 0)
+    ):
         client._handle_incoming_message(
             {
                 "type": "event",

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -350,6 +350,9 @@ async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
         {},
     )
 
+    with pytest.raises(InvalidState):
+        client.begin_recording_messages()
+
     await client.async_send_command({"command": "some_command"})
 
     assert len(client._recorded_commands) == 1
@@ -417,3 +420,6 @@ async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
     assert len(client.end_recording_messages()) == 2
     assert len(client._recorded_commands) == 0
     assert len(client._recorded_events) == 0
+
+    with pytest.raises(InvalidState):
+        client.end_recording_messages()

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -354,9 +354,7 @@ async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
     with pytest.raises(InvalidState):
         client.begin_recording_messages()
 
-    with patch(
-        "zwave_js_server.client.Client._now", return_value=datetime(2022, 1, 7, 1)
-    ):
+    with patch("zwave_js_server.client._now", return_value=datetime(2022, 1, 7, 1)):
         await client.async_send_command({"command": "some_command"})
 
     assert len(client._recorded_commands) == 1
@@ -377,9 +375,7 @@ async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
     assert "ts" in client._recorded_commands[uuid4]
     assert "result_ts" in client._recorded_commands[uuid4]
 
-    with patch(
-        "zwave_js_server.client.Client._now", return_value=datetime(2022, 1, 7, 0)
-    ):
+    with patch("zwave_js_server.client._now", return_value=datetime(2022, 1, 7, 0)):
         client._handle_incoming_message(
             {
                 "type": "event",

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,5 +1,6 @@
 """Test the client."""
 import asyncio
+import logging
 from unittest.mock import Mock
 
 import pytest
@@ -335,3 +336,84 @@ async def test_command_error_handling(client, mock_command):
     assert raised.value.error_code == "zwave_error"
     assert raised.value.zwave_error_code == 3
     assert raised.value.zwave_error_message == "Node 5 is dead"
+
+
+async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
+    """Test recording messages."""
+    client = wallmote_central_scene.client
+    assert not client.messages_are_being_recorded
+    assert not client._recorded_commands
+    assert not client._recorded_events
+    client.begin_recording_messages()
+    mock_command(
+        {"command": "some_command"},
+        {},
+    )
+
+    await client.async_send_command({"command": "some_command"})
+
+    assert len(client._recorded_commands) == 1
+    assert len(client._recorded_events) == 0
+    assert uuid4 in client._recorded_commands
+    assert client._recorded_commands[uuid4]["record_type"] == "command"
+    assert client._recorded_commands[uuid4]["command"] == "some_command"
+    assert client._recorded_commands[uuid4]["command_msg"] == {
+        "command": "some_command",
+        "messageId": uuid4,
+    }
+    assert client._recorded_commands[uuid4]["result_msg"] == {
+        "messageId": "1234",
+        "result": {},
+        "success": True,
+        "type": "result",
+    }
+    assert "ts" in client._recorded_commands[uuid4]
+    assert "result_ts" in client._recorded_commands[uuid4]
+
+    client._handle_incoming_message(
+        {
+            "type": "event",
+            "event": {
+                "source": "node",
+                "event": "value updated",
+                "nodeId": wallmote_central_scene.node_id,
+                "args": {
+                    "commandClassName": "Binary Switch",
+                    "commandClass": 37,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "newValue": False,
+                    "prevValue": True,
+                    "propertyName": "currentValue",
+                },
+            },
+        }
+    )
+    assert len(client._recorded_commands) == 1
+    assert len(client._recorded_events) == 1
+    logging.getLogger(__name__).error(client._recorded_events)
+    event = client._recorded_events[0]
+    assert event["record_type"] == "event"
+    assert event["type"] == "value updated"
+    assert event["event"] == {
+        "type": "event",
+        "event": {
+            "source": "node",
+            "event": "value updated",
+            "nodeId": wallmote_central_scene.node_id,
+            "args": {
+                "commandClassName": "Binary Switch",
+                "commandClass": 37,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": False,
+                "prevValue": True,
+                "propertyName": "currentValue",
+            },
+        },
+    }
+    assert "ts" in event
+
+    assert len(client.end_recording_messages()) == 2
+    assert len(client._recorded_commands) == 0
+    assert len(client._recorded_events) == 0

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -302,6 +302,10 @@ class Client:
 
         return list(data)
 
+    @classmethod
+    def _now(self) -> datetime:
+        return datetime.utcnow()
+
     async def _receive_json_or_raise(self) -> dict:
         """Receive json or raise."""
         assert self._client
@@ -344,7 +348,7 @@ class Client:
             if self._record_messages and msg["messageId"] not in LISTEN_MESSAGE_IDS:
                 self._recorded_commands[msg["messageId"]].update(
                     {
-                        "result_ts": datetime.utcnow().isoformat(),
+                        "result_ts": self._now().isoformat(),
                         "result_msg": deepcopy(msg),
                     }
                 )
@@ -376,7 +380,7 @@ class Client:
             self._recorded_events.append(
                 {
                     "record_type": "event",
-                    "ts": datetime.utcnow().isoformat(),
+                    "ts": self._now().isoformat(),
                     "type": msg["event"]["event"],
                     "event": deepcopy(msg),
                 }
@@ -403,7 +407,7 @@ class Client:
             self._recorded_commands[message["messageId"]].update(
                 {
                     "record_type": "command",
-                    "ts": datetime.utcnow().isoformat(),
+                    "ts": self._now().isoformat(),
                     "command": message["command"],
                     "command_msg": message,
                 }

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -292,14 +292,14 @@ class Client:
 
         self._record_messages = False
 
-        data: List[dict] = sorted(
+        data = sorted(
             (*self._recorded_commands.values(), *self._recorded_events),
             key=lambda x: x["ts"],
         )
         self._recorded_commands.clear()
         self._recorded_events.clear()
 
-        return data
+        return list(data)
 
     async def _receive_json_or_raise(self) -> dict:
         """Receive json or raise."""

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -344,7 +344,7 @@ class Client:
             if self._record_messages and msg["messageId"] not in LISTEN_MESSAGE_IDS:
                 self._recorded_commands[msg["messageId"]].update(
                     {
-                        "result_ts": _now().isoformat(),
+                        "result_ts": datetime.utcnow().isoformat(),
                         "result_msg": deepcopy(msg),
                     }
                 )
@@ -376,7 +376,7 @@ class Client:
             self._recorded_events.append(
                 {
                     "record_type": "event",
-                    "ts": _now().isoformat(),
+                    "ts": datetime.utcnow().isoformat(),
                     "type": msg["event"]["event"],
                     "event": deepcopy(msg),
                 }
@@ -400,10 +400,12 @@ class Client:
         assert "messageId" in message
 
         if self._record_messages and message["messageId"] not in LISTEN_MESSAGE_IDS:
+            # We don't need to deepcopy command_msg because it is always released by
+            # the caller after the command is sent.
             self._recorded_commands[message["messageId"]].update(
                 {
                     "record_type": "command",
-                    "ts": _now().isoformat(),
+                    "ts": datetime.utcnow().isoformat(),
                     "command": message["command"],
                     "command_msg": message,
                 }
@@ -421,7 +423,3 @@ class Client:
     ) -> None:
         """Disconnect from the websocket."""
         await self.disconnect()
-
-
-def _now() -> datetime:
-    return datetime.utcnow()

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -80,7 +80,7 @@ class Client:
         return self._client is not None and not self._client.closed
 
     @property
-    def messages_are_being_recorded(self) -> bool:
+    def recording_messages(self) -> bool:
         """Return True if messages are being recorded."""
         return self._record_messages
 

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -7,7 +7,7 @@ import logging
 import pprint
 import uuid
 from types import TracebackType
-from typing import Any, DefaultDict, Dict, Optional, cast
+from typing import Any, DefaultDict, Dict, List, Optional, cast
 
 from aiohttp import ClientSession, ClientWebSocketResponse, WSMsgType, client_exceptions
 
@@ -66,7 +66,7 @@ class Client:
         self._shutdown_complete_event: Optional[asyncio.Event] = None
         self._record_messages = record_messages
         self._recorded_commands: DefaultDict[str, dict] = defaultdict(dict)
-        self._recorded_events: list[dict] = []
+        self._recorded_events: List[dict] = []
 
     def __repr__(self) -> str:
         """Return the representation."""
@@ -285,14 +285,14 @@ class Client:
 
         self._record_messages = True
 
-    def end_recording_messages(self) -> list[dict]:
+    def end_recording_messages(self) -> List[dict]:
         """End recording messages and return messages that were recorded."""
         if not self._record_messages:
             raise InvalidState("Not recording messages")
 
         self._record_messages = False
 
-        data = sorted(
+        data: List[dict] = sorted(
             (*self._recorded_commands.values(), *self._recorded_events),
             key=lambda x: x["ts"],
         )

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -302,10 +302,6 @@ class Client:
 
         return list(data)
 
-    @classmethod
-    def _now(self) -> datetime:
-        return datetime.utcnow()
-
     async def _receive_json_or_raise(self) -> dict:
         """Receive json or raise."""
         assert self._client
@@ -425,3 +421,7 @@ class Client:
     ) -> None:
         """Disconnect from the websocket."""
         await self.disconnect()
+
+    @classmethod
+    def _now(cls) -> datetime:
+        return datetime.utcnow()

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime
 import logging
+from operator import itemgetter
 import pprint
 import uuid
 from types import TracebackType
@@ -294,7 +295,7 @@ class Client:
 
         data = sorted(
             (*self._recorded_commands.values(), *self._recorded_events),
-            key=lambda x: x["ts"],
+            key=itemgetter("ts"),
         )
         self._recorded_commands.clear()
         self._recorded_events.clear()

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -1,10 +1,12 @@
 """Client."""
 import asyncio
+from collections import defaultdict
+from datetime import datetime
 import logging
 import pprint
 import uuid
 from types import TracebackType
-from typing import Any, Dict, Optional, cast
+from typing import Any, DefaultDict, Dict, Optional, cast
 
 from aiohttp import ClientSession, ClientWebSocketResponse, WSMsgType, client_exceptions
 
@@ -26,6 +28,17 @@ from .model.version import VersionInfo
 
 SIZE_PARSE_JSON_EXECUTOR = 8192
 
+# Message IDs
+SET_API_SCHEMA_MESSAGE_ID = "api-schema-id"
+GET_INITIAL_LOG_CONFIG_MESSAGE_ID = "get-initial-log-config"
+START_LISTENING_MESSAGE_ID = "listen-id"
+
+LISTEN_MESSAGE_IDS = (
+    GET_INITIAL_LOG_CONFIG_MESSAGE_ID,
+    SET_API_SCHEMA_MESSAGE_ID,
+    START_LISTENING_MESSAGE_ID,
+)
+
 
 class Client:
     """Class to manage the IoT connection."""
@@ -35,6 +48,7 @@ class Client:
         ws_server_url: str,
         aiohttp_session: ClientSession,
         schema_version: int = MAX_SERVER_SCHEMA_VERSION,
+        record_messages: bool = False,
     ):
         """Initialize the Client class."""
         self.ws_server_url = ws_server_url
@@ -49,6 +63,9 @@ class Client:
         self._loop = asyncio.get_running_loop()
         self._result_futures: Dict[str, asyncio.Future] = {}
         self._shutdown_complete_event: Optional[asyncio.Event] = None
+        self._record_messages = record_messages
+        self._recorded_commands: DefaultDict[str, dict] = defaultdict(dict)
+        self._recorded_events: list[dict] = []
 
     def __repr__(self) -> str:
         """Return the representation."""
@@ -59,6 +76,11 @@ class Client:
     def connected(self) -> bool:
         """Return if we're currently connected."""
         return self._client is not None and not self._client.closed
+
+    @property
+    def messages_are_being_recorded(self) -> bool:
+        """Return True if messages are being recorded."""
+        return self._record_messages
 
     async def async_send_command(
         self,
@@ -150,7 +172,7 @@ class Client:
         await self._send_json_message(
             {
                 "command": "set_api_schema",
-                "messageId": "api-schema-id",
+                "messageId": SET_API_SCHEMA_MESSAGE_ID,
                 "schemaVersion": self.schema_version,
             }
         )
@@ -174,7 +196,7 @@ class Client:
             await self._send_json_message(
                 {
                     "command": "driver.get_log_config",
-                    "messageId": "get-initial-log-config",
+                    "messageId": GET_INITIAL_LOG_CONFIG_MESSAGE_ID,
                 }
             )
 
@@ -188,7 +210,7 @@ class Client:
             # send start_listening command to the server
             # we will receive a full state dump and from now on get events
             await self._send_json_message(
-                {"command": "start_listening", "messageId": "listen-id"}
+                {"command": "start_listening", "messageId": START_LISTENING_MESSAGE_ID}
             )
 
             state_msg = await self._receive_json_or_raise()
@@ -255,6 +277,29 @@ class Client:
         self._shutdown_complete_event = None
         self.driver = None
 
+    async def begin_recording_messages(self) -> None:
+        """Begin recording messages for replay later."""
+        if self._record_messages:
+            raise InvalidState("Already recording messages")
+
+        self._record_messages = True
+
+    async def end_recording_messages(self) -> list[dict]:
+        """End recording messages and return messages that were recorded."""
+        if not self._record_messages:
+            raise InvalidState("Not recording messages")
+
+        self._record_messages = False
+
+        data = sorted(
+            (*self._recorded_commands.values(), *self._recorded_events),
+            key=lambda x: x["ts"],
+        )
+        self._recorded_commands.clear()
+        self._recorded_events.clear()
+
+        return data
+
     async def _receive_json_or_raise(self) -> dict:
         """Receive json or raise."""
         assert self._client
@@ -294,6 +339,14 @@ class Client:
                 # no listener for this result
                 return
 
+            if self._record_messages and msg["messageId"] in LISTEN_MESSAGE_IDS:
+                self._recorded_commands[msg["messageId"]].update(
+                    {
+                        "response_ts": datetime.utcnow().isoformat(),
+                        "response_msg": msg,
+                    }
+                )
+
             if msg["success"]:
                 future.set_result(msg["result"])
                 return
@@ -317,6 +370,16 @@ class Client:
             )
             return
 
+        if self._record_messages:
+            self._recorded_events.append(
+                {
+                    "record_type": "event",
+                    "ts": datetime.utcnow().isoformat(),
+                    "type": msg["event"]["event"],
+                    "event": msg,
+                }
+            )
+
         event = Event(type=msg["event"]["event"], data=msg["event"])
         self.driver.receive_event(event)  # type: ignore
 
@@ -333,6 +396,16 @@ class Client:
 
         assert self._client
         assert "messageId" in message
+
+        if self._record_messages and message["messageId"] not in LISTEN_MESSAGE_IDS:
+            self._recorded_commands[message["messageId"]].update(
+                {
+                    "record_type": "command",
+                    "ts": datetime.utcnow().isoformat(),
+                    "command": message["command"],
+                    "command_msg": message,
+                }
+            )
 
         await self._client.send_json(message)
 

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -344,7 +344,7 @@ class Client:
             if self._record_messages and msg["messageId"] not in LISTEN_MESSAGE_IDS:
                 self._recorded_commands[msg["messageId"]].update(
                     {
-                        "result_ts": self._now().isoformat(),
+                        "result_ts": _now().isoformat(),
                         "result_msg": deepcopy(msg),
                     }
                 )
@@ -376,7 +376,7 @@ class Client:
             self._recorded_events.append(
                 {
                     "record_type": "event",
-                    "ts": self._now().isoformat(),
+                    "ts": _now().isoformat(),
                     "type": msg["event"]["event"],
                     "event": deepcopy(msg),
                 }
@@ -403,7 +403,7 @@ class Client:
             self._recorded_commands[message["messageId"]].update(
                 {
                     "record_type": "command",
-                    "ts": self._now().isoformat(),
+                    "ts": _now().isoformat(),
                     "command": message["command"],
                     "command_msg": message,
                 }
@@ -422,6 +422,6 @@ class Client:
         """Disconnect from the websocket."""
         await self.disconnect()
 
-    @classmethod
-    def _now(cls) -> datetime:
-        return datetime.utcnow()
+
+def _now() -> datetime:
+    return datetime.utcnow()


### PR DESCRIPTION
Here's my proposal for how we will record messages. My current best idea for how to implement this in HA is:
Add a UI control somewhere that, when clicked, reloads the integration but sets `record_messages` to `True` in the client initialization. We can detect whether or not the record message functionality is enabled and display a different UI control in the same place to allow the user stop the recording and download the recording once they are done trying to repro their given issue.

As a bonus, we could offer a mechanism in the UI control to allow the user to either reload the config entry to watch everything from startup or just record from that moment onwards depending on the use case (the implementation supports both)