### PR TITLE
Add thermostat fan `mode`, `off` and `state` property constants

### DIFF
--- a/zwave_js_server/const/command_class/thermostat.py
+++ b/zwave_js_server/const/command_class/thermostat.py
@@ -14,6 +14,7 @@ THERMOSTAT_CURRENT_TEMP_PROPERTY = "Air temperature"
 THERMOSTAT_HUMIDITY_PROPERTY = "Humidity"
 THERMOSTAT_FAN_MODE_PROPERTY = "mode"
 THERMOSTAT_FAN_OFF_PROPERTY = "off"
+THERMOSTAT_FAN_STATE_PROPERTY = "state"
 
 class ThermostatMode(IntEnum):
     """Enum with all (known/used) Z-Wave ThermostatModes."""

--- a/zwave_js_server/const/command_class/thermostat.py
+++ b/zwave_js_server/const/command_class/thermostat.py
@@ -16,6 +16,7 @@ THERMOSTAT_FAN_MODE_PROPERTY = "mode"
 THERMOSTAT_FAN_OFF_PROPERTY = "off"
 THERMOSTAT_FAN_STATE_PROPERTY = "state"
 
+
 class ThermostatMode(IntEnum):
     """Enum with all (known/used) Z-Wave ThermostatModes."""
 

--- a/zwave_js_server/const/command_class/thermostat.py
+++ b/zwave_js_server/const/command_class/thermostat.py
@@ -12,7 +12,8 @@ THERMOSTAT_SETPOINT_PROPERTY = "setpoint"
 THERMOSTAT_OPERATING_STATE_PROPERTY = "state"
 THERMOSTAT_CURRENT_TEMP_PROPERTY = "Air temperature"
 THERMOSTAT_HUMIDITY_PROPERTY = "Humidity"
-
+THERMOSTAT_FAN_MODE_PROPERTY = "mode"
+THERMOSTAT_FAN_OFF_PROPERTY = "off"
 
 class ThermostatMode(IntEnum):
     """Enum with all (known/used) Z-Wave ThermostatModes."""


### PR DESCRIPTION
I noticed the `off` constant for the [`ThermostatFanMode` CC](https://github.com/zwave-js/node-zwave-js/blob/583645c6618ae1abb2666eb81806f8d73c97d719/packages/zwave-js/src/lib/commandclass/ThermostatFanModeCC.ts#L117-L125) is missing. For completeness, I also added `mode` and `state` which is a property used on the [`ThermostatFanState` CC](https://github.com/zwave-js/node-zwave-js/blob/583645c6618ae1abb2666eb81806f8d73c97d719/packages/zwave-js/src/lib/commandclass/ThermostatFanStateCC.ts#L63-L64). The `climate` platform in core uses the `THERMOSTAT_MODE_PROPERTY` and `THERMOSTAT_OPERATING_STATE_PROPERTY` which are set to the same value (mode/state), but I thought it would be better to have correctly named properties to avoid confusion when using the ThermostatFan CCs.