### PR TITLE
Update node state data when values get added/updated/removed

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -552,6 +552,34 @@ async def test_value_updated_events(multisensor_6):
     assert "prevValue" not in val.data
 
 
+async def test_value_removed_events(multisensor_6):
+    """Test Node value removed events."""
+    node = multisensor_6
+    event = Event(
+        type="value removed",
+        data={
+            "source": "node",
+            "event": "value removed",
+            "nodeId": 52,
+            "args": {
+                "commandClassName": "Configuration",
+                "commandClass": 112,
+                "endpoint": 0,
+                "property": 2,
+                "propertyName": "Stay Awake in Battery Mode",
+                "prevValue": 0,
+            },
+        },
+    )
+    node.handle_value_removed(event)
+    assert isinstance(event.data["value"], ConfigurationValue)
+    # ensure that the value was removed form the nodes value's dict
+    assert node.values.get("52-112-0-2") is None
+    # ensure that the value was removed from the node's state data
+    with pytest.raises(StopIteration):
+        node.value_idx_from_val_data("52-112-0-2")
+
+
 async def test_value_notification(wallmote_central_scene: node_pkg.Node):
     """Test value notification events."""
     node = wallmote_central_scene

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -473,9 +473,10 @@ async def test_node_status_events(multisensor_6):
 async def test_value_added_events(multisensor_6):
     """Test Node value added events for new value."""
     node = multisensor_6
+    value_id = "52-112-0-6"
     # Validate that the value doesn't exist in the node state data
     with pytest.raises(StopIteration):
-        node.value_idx_from_val_data("52-112-0-6")
+        node.value_data_idx(value_id)
     event = Event(
         type="value added",
         data={
@@ -509,14 +510,15 @@ async def test_value_added_events(multisensor_6):
     )
     node.handle_value_added(event)
     assert isinstance(event.data["value"], ConfigurationValue)
-    assert isinstance(node.values["52-112-0-6"], ConfigurationValue)
+    assert isinstance(node.values[value_id], ConfigurationValue)
     # ensure that the value was added to the node's state data
-    assert node.value_idx_from_val_data("52-112-0-6")
+    assert node.value_data_idx(value_id)
 
 
 async def test_value_updated_events(multisensor_6):
     """Test Node value updated events."""
     node = multisensor_6
+    value_id = "52-112-0-2"
     event = Event(
         type="value updated",
         data={
@@ -536,9 +538,9 @@ async def test_value_updated_events(multisensor_6):
     )
     node.handle_value_updated(event)
     assert isinstance(event.data["value"], ConfigurationValue)
-    assert isinstance(node.values["52-112-0-2"], ConfigurationValue)
+    assert isinstance(node.values[value_id], ConfigurationValue)
     # ensure that the value was added to the node's state data
-    assert (value_idx := node.value_idx_from_val_data("52-112-0-2"))
+    assert (value_idx := node.value_data_idx(value_id))
     # ensure that the node's state data was updated and that old keys were removed
     assert (value_data := node.data["values"][value_idx]) is not None
     assert value_data["metadata"]
@@ -546,7 +548,7 @@ async def test_value_updated_events(multisensor_6):
     assert "newValue" not in value_data
     assert "prevValue" not in value_data
     # ensure that the value's state data was updated and that old keys were removed
-    val = node.values["52-112-0-2"]
+    val = node.values[value_id]
     assert val.data["value"] == 1
     assert "newValue" not in val.data
     assert "prevValue" not in val.data
@@ -555,6 +557,7 @@ async def test_value_updated_events(multisensor_6):
 async def test_value_removed_events(multisensor_6):
     """Test Node value removed events."""
     node = multisensor_6
+    value_id = "52-112-0-2"
     event = Event(
         type="value removed",
         data={
@@ -574,10 +577,10 @@ async def test_value_removed_events(multisensor_6):
     node.handle_value_removed(event)
     assert isinstance(event.data["value"], ConfigurationValue)
     # ensure that the value was removed form the nodes value's dict
-    assert node.values.get("52-112-0-2") is None
+    assert node.values.get(value_id) is None
     # ensure that the value was removed from the node's state data
     with pytest.raises(StopIteration):
-        node.value_idx_from_val_data("52-112-0-2")
+        node.value_data_idx(value_id)
 
 
 async def test_value_notification(wallmote_central_scene: node_pkg.Node):

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -519,6 +519,11 @@ async def test_value_updated_events(multisensor_6):
     """Test Node value updated events."""
     node = multisensor_6
     value_id = "52-112-0-2"
+    # ensure that the value is in the node's state data
+    assert (value_idx := node.value_data_idx(value_id))
+    # assert the old value of the ZwaveValue
+    assert (value_data := node.data["values"][value_idx]) is not None
+    assert value_data["value"] == node.values[value_id].value == 0
     event = Event(
         type="value updated",
         data={
@@ -539,7 +544,7 @@ async def test_value_updated_events(multisensor_6):
     node.handle_value_updated(event)
     assert isinstance(event.data["value"], ConfigurationValue)
     assert isinstance(node.values[value_id], ConfigurationValue)
-    # ensure that the value was added to the node's state data
+    # ensure that the value is in to the node's state data
     assert (value_idx := node.value_data_idx(value_id))
     # ensure that the node's state data was updated and that old keys were removed
     assert (value_data := node.data["values"][value_idx]) is not None

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -576,7 +576,7 @@ async def test_value_removed_events(multisensor_6):
     )
     node.handle_value_removed(event)
     assert isinstance(event.data["value"], ConfigurationValue)
-    # ensure that the value was removed form the nodes value's dict
+    # ensure that the value was removed from the nodes value's dict
     assert node.values.get(value_id) is None
     # ensure that the value was removed from the node's state data
     with pytest.raises(StopIteration):

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -773,9 +773,7 @@ class Node(EventBase):
         else:
             value.receive_event(event)
             event.data["value"] = value
-            self.data["values"][self.value_data_idx(value_id)].update(
-                evt_val_data
-            )
+            self.data["values"][self.value_data_idx(value_id)].update(evt_val_data)
 
         node_val_data = self.data["values"][self.value_data_idx(value_id)]
         if "newValue" in evt_val_data:

--- a/zwave_js_server/model/node.py
+++ b/zwave_js_server/model/node.py
@@ -752,8 +752,8 @@ class Node(EventBase):
         """Process a node value added event."""
         self.handle_value_updated(event)
 
-    def value_idx_from_val_data(self, value_id: str) -> int:
-        """Get the index of the value dict in the node's value data."""
+    def value_data_idx(self, value_id: str) -> int:
+        """Get the index for the given value ID in the node's value data."""
         values = self.data["values"]
         return next(
             idx
@@ -773,11 +773,11 @@ class Node(EventBase):
         else:
             value.receive_event(event)
             event.data["value"] = value
-            self.data["values"][self.value_idx_from_val_data(value_id)].update(
+            self.data["values"][self.value_data_idx(value_id)].update(
                 evt_val_data
             )
 
-        node_val_data = self.data["values"][self.value_idx_from_val_data(value_id)]
+        node_val_data = self.data["values"][self.value_data_idx(value_id)]
         if "newValue" in evt_val_data:
             node_val_data["value"] = evt_val_data["newValue"]
 
@@ -788,7 +788,7 @@ class Node(EventBase):
         """Process a node value removed event."""
         value_id = _get_value_id_from_dict(self, event.data["args"])
         event.data["value"] = self.values.pop(value_id)
-        self.data["values"].pop(self.value_idx_from_val_data(value_id))
+        self.data["values"].pop(self.value_data_idx(value_id))
 
     def handle_value_notification(self, event: Event) -> None:
         """Process a node value notification event."""

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -254,11 +254,14 @@ class Value:
         """Update data."""
         self.data.update(data)
         if "newValue" in data:
-            self._value = data["newValue"]
+            self._value = self.data["value"] = data["newValue"]
         if "value" in data:
-            self._value = data["value"]
+            self._value = self.data["value"] = data["value"]
         if "metadata" in data:
             self._metadata.update(data["metadata"])
+
+        self.data.pop("newValue", None)
+        self.data.pop("prevValue", None)
 
         # Handle buffer dict and json string in value.
         if self.metadata.type == "buffer":


### PR DESCRIPTION
As discussed in a previous PR, this PR updates the node and value state data when we get value added/updated/removed events and makes it appear to be the same format as we get for value data when we get the first dump