### PR TITLE
Fix compat device config type

### DIFF
--- a/zwave_js_server/model/device_config.py
+++ b/zwave_js_server/model/device_config.py
@@ -3,7 +3,7 @@ Model for a Zwave Node's device config.
 
 https://zwave-js.github.io/node-zwave-js/#/api/node?id=deviceconfig
 """
-from typing import Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from ..const import TYPING_EXTENSION_FOR_TYPEDDICT_REQUIRED
 
@@ -138,7 +138,7 @@ class DeviceConfigDataType(TypedDict, total=False):
     paramInformation: Dict[str, dict]
     supportsZWavePlus: bool
     proprietary: dict
-    compat: Dict[str, dict]
+    compat: Dict[str, Any]
     metadata: DeviceMetadataDataType
     isEmbedded: bool
 


### PR DESCRIPTION
- Set compat dict value as Any.
- Fixes this error:

```
2022-02-21 14:13:24 ERROR (MainThread) [homeassistant.components.zwave_js] Unexpected exception: 1 validation error for ReadyEventModel
nodeState -> deviceConfig -> compat -> enableBasicSetMapping
  value is not a valid dict (type=type_error.dict)
Traceback (most recent call last):
  File "/home/martin/dev/home-assistant/core/homeassistant/components/zwave_js/__init__.py", line 600, in client_listen
    await client.listen(driver_ready)
  File "/home/martin/.virtualenvs/home-assistant/lib/python3.9/site-packages/zwave_js_server/client.py", line 244, in listen
    self._handle_incoming_message(data)
  File "/home/martin/.virtualenvs/home-assistant/lib/python3.9/site-packages/zwave_js_server/client.py", line 386, in _handle_incoming_message
    self.driver.receive_event(event)  # type: ignore
  File "/home/martin/.virtualenvs/home-assistant/lib/python3.9/site-packages/zwave_js_server/model/driver.py", line 80, in receive_event
    self.controller.receive_event(event)
  File "/home/martin/.virtualenvs/home-assistant/lib/python3.9/site-packages/zwave_js_server/model/controller/__init__.py", line 640, in receive_event
    node.receive_event(event)
  File "/home/martin/.virtualenvs/home-assistant/lib/python3.9/site-packages/zwave_js_server/model/node/__init__.py", line 368, in receive_event
    NODE_EVENT_MODEL_MAP[event.type](**event.data)
  File "pydantic/main.py", line 331, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for ReadyEventModel
nodeState -> deviceConfig -> compat -> enableBasicSetMapping
  value is not a valid dict (type=type_error.dict)
```