### PR TITLE
Make a copy of listeners

### DIFF
--- a/zwave_js_server/event.py
+++ b/zwave_js_server/event.py
@@ -57,7 +57,7 @@ class EventBase:
 
     def emit(self, event_name: str, data: dict) -> None:
         """Run all callbacks for an event."""
-        for listener in self._listeners.get(event_name, []):
+        for listener in self._listeners.get(event_name, []).copy():
             listener(data)
 
     def _handle_event_protocol(self, event: Event) -> None:


### PR DESCRIPTION
So that an unsubscribe during iteration will not mess with the other listeners

When an listener would unsubscribe during iteration of the listeners, the list would change and not all listeners would be called.

Especially when using `once` listeners