### PR TITLE
Remove scripts package

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,0 @@
-"""Scripts module."""


### PR DESCRIPTION
- We don't want to install our scripts when installing our packages. The scripts are only for development.
- The scripts should probably be made standalone Python scripts with a shebang, but I didn't include that change here.