### PR TITLE
Fix: async_get_associations missing that a list of associations reported in a group

### DIFF
--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -441,7 +441,7 @@ class Controller(EventBase):
             )
         return groups
 
-    async def async_get_associations(self, node_id: int) -> Dict[int, Association]:
+    async def async_get_associations(self, node_id: int) -> Dict[int, List[Association]]:
         """Send getAssociations command to Controller."""
         data = await self.client.async_send_command(
             {
@@ -450,10 +450,12 @@ class Controller(EventBase):
             }
         )
         associations = {}
-        for key, association in data["associations"].items():
-            associations[key] = Association(
-                node_id=association["nodeId"], endpoint=association.get("endpoint")
-            )
+        for key, groupassociations in data["associations"].items():
+            associations[key] = list()
+            for association in groupassociations:
+                associations[key].append(
+                    Association(node_id=association["nodeId"], endpoint=association.get("endpoint"))
+                )
         return associations
 
     async def async_is_association_allowed(


### PR DESCRIPTION
async_get_associations is not working as "controller.get_associations" returns N associations for each key (group)
associations: {
      '1': [ { nodeId: 1 } ],
      '2': [ { nodeId: 1 } ],
      '3': [ { nodeId: 8 }, { nodeId: 7 } ]
    }