### PR TITLE
Handle node.isSecure = unknown

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -102,6 +102,12 @@ def ring_keypad_state_fixture():
     return json.loads(load_fixture("ring_keypad_state.json"))
 
 
+@pytest.fixture(name="is_secure_unknown_state", scope="session")
+def is_secure_unknown_state_fixture():
+    """Load the isSecure = `unknown` node state fixture data."""
+    return json.loads(load_fixture("is_secure_unknown_state.json"))
+
+
 def create_ws_message(result):
     """Return a mock WSMessage."""
     message = Mock(spec_set=WSMessage)
@@ -468,5 +474,13 @@ def invalid_multilevel_sensor_type_fixture(
 ):
     """Mock a node that has invalid multilevel sensor type."""
     node = Node(driver.client, deepcopy(invalid_multilevel_sensor_type_state))
+    driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="is_secure_unknown")
+def is_secure_unknown_fixture(driver, is_secure_unknown_state):
+    """Mock a node that has inSecure = `unknown`."""
+    node = Node(driver.client, deepcopy(is_secure_unknown_state))
     driver.controller.nodes[node.node_id] = node
     return node

--- a/test/fixtures/is_secure_unknown_state.json
+++ b/test/fixtures/is_secure_unknown_state.json
@@ -1,0 +1,132 @@
+{
+  "nodeId": 45,
+  "index": 0,
+  "installerIcon": 1536,
+  "userIcon": 1536,
+  "status": 0,
+  "ready": false,
+  "isListening": true,
+  "isRouting": true,
+  "isSecure": "unknown",
+  "manufacturerId": 798,
+  "productId": 1,
+  "productType": 1,
+  "firmwareVersion": "1.57",
+  "zwavePlusVersion": 1,
+  "deviceConfig": {
+    "filename": "/data/db/devices/0x031e/lzw31-sn.json",
+    "isEmbedded": true,
+    "manufacturer": "Inovelli",
+    "manufacturerId": 798,
+    "label": "LZW31-SN",
+    "description": "Red Series Dimmer",
+    "devices": [{ "productType": 1, "productId": 1 }],
+    "firmwareVersion": { "min": "0.0", "max": "255.255" },
+    "paramInformation": { "_map": {} },
+    "metadata": {
+      "inclusion": "Start the inclusion process again on your HUB and tap the Configuration Button three (3) times.\\n\\nPlease Note: If this doesn't work, you can check to see if your switch is within Z-Wave Range by holding down the Configuration Button for 5-10 seconds (if it's not within range, the LED Bar will indicate Red and if it is within Range, the LED Bar will indicate Green). If your switch indicates Red, please move the switch closer to the HUB. If your switch indicates Green, please try running an Exclusion to reset your switch",
+      "exclusion": "To Exclude your dimmer, put your HUB in exclusion mode and press the Configuration Button three (3) times",
+      "reset": "You may factory reset the switch by holding down the Config Button for twenty (20) or more seconds. The LED Bar will turn Red and blink three (3) times to confirm. \\n\\nHowever, we recommend using a certified Z-Wave controller to remove the device from your network for factory resetting the switch. \\n\\nOnly use either of these procedures in the event that the network primary controller is missing or otherwise inoperable",
+      "manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/4206/LZW31-SN%20Manual%20-%20Inovelli%20Dimmer%20Switch%20(Red%20Series)%20-%2006.28.21.pdf"
+    }
+  },
+  "label": "LZW31-SN",
+  "interviewAttempts": 0,
+  "endpoints": [
+    {
+      "nodeId": 45,
+      "index": 0,
+      "installerIcon": 1536,
+      "userIcon": 1536,
+      "deviceClass": {
+        "basic": { "key": 4, "label": "Routing Slave" },
+        "generic": { "key": 17, "label": "Multilevel Switch" },
+        "specific": { "key": 1, "label": "Multilevel Power Switch" },
+        "mandatorySupportedCCs": [32, 38, 39],
+        "mandatoryControlledCCs": []
+      },
+      "commandClasses": [
+        {
+          "id": 38,
+          "name": "Multilevel Switch",
+          "version": 2,
+          "isSecure": false
+        },
+        { "id": 50, "name": "Meter", "version": 3, "isSecure": false },
+        {
+          "id": 85,
+          "name": "Transport Service",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 89,
+          "name": "Association Group Information",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 90,
+          "name": "Device Reset Locally",
+          "version": 1,
+          "isSecure": false
+        },
+        { "id": 91, "name": "Central Scene", "version": 3, "isSecure": false },
+        {
+          "id": 94,
+          "name": "Z-Wave Plus Info",
+          "version": 2,
+          "isSecure": false
+        },
+        { "id": 108, "name": "Supervision", "version": 1, "isSecure": false },
+        { "id": 112, "name": "Configuration", "version": 1, "isSecure": false },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 2,
+          "isSecure": false
+        },
+        { "id": 115, "name": "Powerlevel", "version": 1, "isSecure": false },
+        { "id": 117, "name": "Protection", "version": 2, "isSecure": false },
+        {
+          "id": 122,
+          "name": "Firmware Update Meta Data",
+          "version": 4,
+          "isSecure": false
+        },
+        { "id": 133, "name": "Association", "version": 2, "isSecure": false },
+        { "id": 134, "name": "Version", "version": 2, "isSecure": false },
+        { "id": 152, "name": "Security", "version": 1, "isSecure": true },
+        { "id": 159, "name": "Security 2", "version": 1, "isSecure": true }
+      ]
+    }
+  ],
+  "values": [],
+  "isFrequentListening": false,
+  "maxDataRate": 100000,
+  "supportedDataRates": [40000, 100000],
+  "protocolVersion": 3,
+  "supportsBeaming": true,
+  "supportsSecurity": false,
+  "nodeType": 1,
+  "zwavePlusNodeType": 0,
+  "zwavePlusRoleType": 5,
+  "deviceClass": {
+    "basic": { "key": 4, "label": "Routing Slave" },
+    "generic": { "key": 17, "label": "Multilevel Switch" },
+    "specific": { "key": 1, "label": "Multilevel Power Switch" },
+    "mandatorySupportedCCs": [32, 38, 39],
+    "mandatoryControlledCCs": []
+  },
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x031e:0x0001:0x0001:1.57",
+  "statistics": {
+    "commandsTX": 0,
+    "commandsRX": 0,
+    "commandsDroppedRX": 0,
+    "commandsDroppedTX": 0,
+    "timeoutResponse": 0
+  },
+  "isControllerNode": false,
+  "keepAwake": false
+}

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1456,3 +1456,8 @@ async def test_unknown_event(multisensor_6: node_pkg.Node):
     """Test that an unknown event type causes an exception."""
     with pytest.raises(KeyError):
         assert multisensor_6.receive_event(Event("unknown_event", {"source": "node"}))
+
+
+async def test_is_secure_unknown(is_secure_unknown: node_pkg.Node):
+    """Test that a node with isSecure = `unknown` gets handled appropriately."""
+    assert not is_secure_unknown.is_secure

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -152,7 +152,9 @@ class Node(EventBase):
     @property
     def is_secure(self) -> Optional[bool]:
         """Return the is_secure."""
-        return self.data.get("isSecure")
+        if (is_secure := self.data.get("isSecure")) == "unknown":
+            return False
+        return is_secure
 
     @property
     def protocol_version(self) -> Optional[int]:

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -153,7 +153,7 @@ class Node(EventBase):
     def is_secure(self) -> Optional[bool]:
         """Return the is_secure."""
         if (is_secure := self.data.get("isSecure")) == "unknown":
-            return False
+            return None
         return is_secure
 
     @property

--- a/zwave_js_server/model/node/data_model.py
+++ b/zwave_js_server/model/node/data_model.py
@@ -1,5 +1,5 @@
 """Data model for a Z-Wave JS node."""
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
 from ...const import TYPING_EXTENSION_FOR_TYPEDDICT_REQUIRED
 from ..device_class import DeviceClassDataType
@@ -56,4 +56,4 @@ class NodeDataType(TypedDict, total=False):
     values: List[ValueDataType]
     statistics: NodeStatisticsDataType
     highestSecurityClass: int
-    isControllerNode: bool
+    isControllerNode: Union[bool, Literal["unknown"]]

--- a/zwave_js_server/model/node/data_model.py
+++ b/zwave_js_server/model/node/data_model.py
@@ -33,7 +33,7 @@ class NodeDataType(TypedDict, total=False):
     isRouting: bool
     maxDataRate: int
     supportedDataRates: List[int]
-    isSecure: bool
+    isSecure: Union[bool, Literal["unknown"]]
     supportsBeaming: bool
     supportsSecurity: bool
     protocolVersion: int
@@ -56,4 +56,4 @@ class NodeDataType(TypedDict, total=False):
     values: List[ValueDataType]
     statistics: NodeStatisticsDataType
     highestSecurityClass: int
-    isControllerNode: Union[bool, Literal["unknown"]]
+    isControllerNode: bool


### PR DESCRIPTION
The error posted here: https://github.com/home-assistant/core/issues/67727 has to do with the fact that `pydantic` will raise an Exception when `isSecure` = `unknown`. This fixes that.

We will need a patch release once this is merged