### PR TITLE
Fix release drafter breaking change label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,7 +2,7 @@ change-template: "- #$NUMBER - $TITLE (@$AUTHOR)"
 categories:
   - title: "⚠ Breaking Changes"
     labels:
-      - "breaking change"
+      - "breaking-change"
   - title: "⬆️ Dependencies"
     collapse-after: 1
     labels:


### PR DESCRIPTION
Align label with core `breaking-change` label