### PR TITLE
Log a warning instead of raising for unrecognized notification CCs

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1,5 +1,6 @@
 """Test the node model."""
 import json
+import logging
 from copy import deepcopy
 from unittest.mock import patch
 
@@ -819,7 +820,7 @@ async def test_notification_unknown(lock_schlage_be469: node_pkg.Node, caplog):
 
     node.handle_notification(event)
 
-    assert "Unhandled notification command class" in caplog.text
+    assert "notification" not in event.data
 
 
 async def test_entry_control_notification(ring_keypad):

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1,6 +1,5 @@
 """Test the node model."""
 import json
-import logging
 from copy import deepcopy
 from unittest.mock import patch
 

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -22,7 +22,6 @@ from zwave_js_server.event import Event
 from zwave_js_server.exceptions import (
     FailedCommand,
     NotFoundError,
-    NotificationHasUnsupportedCommandClass,
     UnwriteableValue,
 )
 from zwave_js_server.model import endpoint as endpoint_pkg, node as node_pkg
@@ -803,7 +802,11 @@ async def test_notification(lock_schlage_be469: node_pkg.Node):
     assert event.data["notification"].status == PowerLevelTestStatus.FAILED
     assert event.data["notification"].acknowledged_frames == 2
 
+
+async def test_notification_unknown(lock_schlage_be469: node_pkg.Node, caplog):
+    """Test unrecognized command class notification events."""
     # Validate that an unrecognized CC notification event raises Exception
+    node = lock_schlage_be469
     event = Event(
         type="notification",
         data={
@@ -814,8 +817,9 @@ async def test_notification(lock_schlage_be469: node_pkg.Node):
         },
     )
 
-    with pytest.raises(NotificationHasUnsupportedCommandClass):
-        node.handle_notification(event)
+    node.handle_notification(event)
+
+    assert "Unhandled notification command class" in caplog.text
 
 
 async def test_entry_control_notification(ring_keypad):

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Optional
 from .const import CommandClass
 
 if TYPE_CHECKING:
-    from .event import Event
     from .model.value import Value
 
 

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -157,16 +157,3 @@ class UnknownValueData(BaseZwaveJSServerError):
             "upstream issue with the driver or missing support for this data in the "
             "library"
         )
-
-
-class NotificationHasUnsupportedCommandClass(BaseZwaveJSServerError):
-    """Exception raised when notification is received for an unsupported CC."""
-
-    def __init__(self, event: "Event", command_class: CommandClass) -> None:
-        """Initialize an invalid Command Class error."""
-        self.event_data = event.data
-        self.command_class = command_class
-        super().__init__(
-            "Notification received with unsupported command class "
-            f"{command_class.name}: {event.data}"
-        )

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -792,7 +792,9 @@ class Node(EventBase):
                 self, cast(PowerLevelNotificationDataType, event.data)
             )
         else:
-            _LOGGER.warning("Unhandled notification command class: %s", command_class.name)
+            _LOGGER.warning(
+                "Unhandled notification command class: %s", command_class.name
+            )
 
     def handle_firmware_update_progress(self, event: Event) -> None:
         """Process a node firmware update progress event."""

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -792,7 +792,7 @@ class Node(EventBase):
                 self, cast(PowerLevelNotificationDataType, event.data)
             )
         else:
-            _LOGGER.warning(
+            _LOGGER.info(
                 "Unhandled notification command class: %s", command_class.name
             )
 

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
     from ...client import Client
 
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__package__)
 
 
 class Node(EventBase):

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -792,9 +792,7 @@ class Node(EventBase):
                 self, cast(PowerLevelNotificationDataType, event.data)
             )
         else:
-            _LOGGER.info(
-                "Unhandled notification command class: %s", command_class.name
-            )
+            _LOGGER.info("Unhandled notification command class: %s", command_class.name)
 
     def handle_firmware_update_progress(self, event: Event) -> None:
         """Process a node firmware update progress event."""

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -1,4 +1,5 @@
 """Provide a model for the Z-Wave JS node."""
+import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 from ...const import (
@@ -12,7 +13,6 @@ from ...event import Event, EventBase
 from ...exceptions import (
     FailedCommand,
     NotFoundError,
-    NotificationHasUnsupportedCommandClass,
     UnparseableValue,
     UnwriteableValue,
 )
@@ -56,6 +56,9 @@ from .statistics import NodeStatistics
 
 if TYPE_CHECKING:
     from ...client import Client
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class Node(EventBase):
@@ -789,7 +792,7 @@ class Node(EventBase):
                 self, cast(PowerLevelNotificationDataType, event.data)
             )
         else:
-            raise NotificationHasUnsupportedCommandClass(event, command_class)
+            _LOGGER.warning("Unhandled notification command class: %s", command_class.name)
 
     def handle_firmware_update_progress(self, event: Event) -> None:
         """Process a node firmware update progress event."""


### PR DESCRIPTION
raising an exception currently raises an exception which causes the HA integration to disconnect. This is the wrong way to handle this, we should just log a warning and let the consumer figure out how to handle this scenario