### PR TITLE
Fix invoke_cc_api bug

### DIFF
--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -168,7 +168,7 @@ class Endpoint(EventBase):
             require_schema=7,
             wait_for_result=wait_for_result,
         )
-        if result is None:
+        if not result:
             return None
         return result["response"]
 


### PR DESCRIPTION
When the response is `undefined`, typically because of a returned void, the result becomes `{}` instead of `{"response":  ...}`

The `None` check was too strict but this should resolve it