### PR TITLE
Switch RouteStatistics.route_failed_between from list to tuple

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1435,10 +1435,10 @@ async def test_get_known_lifeline_routes(
     assert lifeline_routes.lwr.repeaters == [multisensor_6]
     assert not lifeline_routes.lwr.rssi
     assert lifeline_routes.lwr.repeater_rssi == [1]
-    assert lifeline_routes.lwr.route_failed_between == [
+    assert lifeline_routes.lwr.route_failed_between == (
         ring_keypad,
         wallmote_central_scene,
-    ]
+    )
     assert lifeline_routes.nlwr
     assert lifeline_routes.nlwr.protocol_data_rate == ProtocolDataRate.ZWAVE_40K
     assert lifeline_routes.nlwr.repeaters == []

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1226,10 +1226,10 @@ async def test_statistics_updated(
         "repeaters": [wallmote_central_scene.node_id],
         "repeater_rssi": [1],
         "rssi": None,
-        "route_failed_between": [
+        "route_failed_between": (
             ring_keypad.node_id,
             multisensor_6.node_id,
-        ],
+        ),
     }
 
     event = Event(

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -85,7 +85,9 @@ class RouteStatistics:
             return None
         assert self.client.driver
         assert len(node_ids) == 2
-        return (self.client.driver.controller.nodes[node_id] for node_id in node_ids)
+        return tuple(
+            self.client.driver.controller.nodes[node_id] for node_id in node_ids
+        )
 
     def as_dict(self) -> RouteStatisticsDict:
         """Return route statistics as dict."""
@@ -94,7 +96,9 @@ class RouteStatistics:
             "repeaters": [node.node_id for node in self.repeaters],
             "rssi": self.rssi,
             "repeater_rssi": self.repeater_rssi,
-            "route_failed_between": (node.node_id for node in self.route_failed_between)
+            "route_failed_between": tuple(
+                node.node_id for node in self.route_failed_between
+            )
             if self.route_failed_between
             else None,
         }

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -33,7 +33,7 @@ class RouteStatisticsDict(TypedDict):
     repeaters: List[int]
     rssi: Optional[int]
     repeater_rssi: List[int]
-    route_failed_between: Optional[Tuple[int, int]]
+    route_failed_between: Optional[Tuple[int, ...]]
 
 
 @dataclass
@@ -79,7 +79,7 @@ class RouteStatistics:
         return repeater_rssi
 
     @property
-    def route_failed_between(self) -> Optional[Tuple["Node", "Node"]]:
+    def route_failed_between(self) -> Optional[Tuple["Node", ...]]:
         """Return route failed between."""
         if (node_ids := self.data.get("routeFailedBetween")) is None:
             return None

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -33,7 +33,7 @@ class RouteStatisticsDict(TypedDict):
     repeaters: List[int]
     rssi: Optional[int]
     repeater_rssi: List[int]
-    route_failed_between: Optional[Tuple[int, ...]]
+    route_failed_between: Optional[Tuple[int, int]]
 
 
 @dataclass
@@ -79,14 +79,15 @@ class RouteStatistics:
         return repeater_rssi
 
     @property
-    def route_failed_between(self) -> Optional[Tuple["Node", ...]]:
+    def route_failed_between(self) -> Optional[Tuple["Node", "Node"]]:
         """Return route failed between."""
         if (node_ids := self.data.get("routeFailedBetween")) is None:
             return None
         assert self.client.driver
         assert len(node_ids) == 2
-        return tuple(
-            self.client.driver.controller.nodes[node_id] for node_id in node_ids
+        return (
+            self.client.driver.controller.nodes[node_ids[0]],
+            self.client.driver.controller.nodes[node_ids[1]],
         )
 
     def as_dict(self) -> RouteStatisticsDict:
@@ -96,8 +97,8 @@ class RouteStatistics:
             "repeaters": [node.node_id for node in self.repeaters],
             "rssi": self.rssi,
             "repeater_rssi": self.repeater_rssi,
-            "route_failed_between": tuple(
-                node.node_id for node in self.route_failed_between
+            "route_failed_between": (
+                self.route_failed_between[0].node_id, self.route_failed_between[1].node_id
             )
             if self.route_failed_between
             else None,

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -98,7 +98,8 @@ class RouteStatistics:
             "rssi": self.rssi,
             "repeater_rssi": self.repeater_rssi,
             "route_failed_between": (
-                self.route_failed_between[0].node_id, self.route_failed_between[1].node_id
+                self.route_failed_between[0].node_id,
+                self.route_failed_between[1].node_id,
             )
             if self.route_failed_between
             else None,

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -1,6 +1,6 @@
 """Common models for statistics."""
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from zwave_js_server.exceptions import RepeaterRssiErrorReceived, RssiErrorReceived
 
@@ -33,7 +33,7 @@ class RouteStatisticsDict(TypedDict):
     repeaters: List[int]
     rssi: Optional[int]
     repeater_rssi: List[int]
-    route_failed_between: Optional[List[int]]
+    route_failed_between: Optional[Tuple[int, int]]
 
 
 @dataclass
@@ -79,12 +79,13 @@ class RouteStatistics:
         return repeater_rssi
 
     @property
-    def route_failed_between(self) -> Optional[List["Node"]]:
+    def route_failed_between(self) -> Optional[Tuple["Node", "Node"]]:
         """Return route failed between."""
         if (node_ids := self.data.get("routeFailedBetween")) is None:
             return None
         assert self.client.driver
-        return [self.client.driver.controller.nodes[node_id] for node_id in node_ids]
+        assert len(node_ids) == 2
+        return (self.client.driver.controller.nodes[node_id] for node_id in node_ids)
 
     def as_dict(self) -> RouteStatisticsDict:
         """Return route statistics as dict."""
@@ -93,7 +94,7 @@ class RouteStatistics:
             "repeaters": [node.node_id for node in self.repeaters],
             "rssi": self.rssi,
             "repeater_rssi": self.repeater_rssi,
-            "route_failed_between": [node.node_id for node in self.route_failed_between]
+            "route_failed_between": (node.node_id for node in self.route_failed_between)
             if self.route_failed_between
             else None,
         }


### PR DESCRIPTION
`routeFailedBetween` will always be a list of length two so a `tuple` is a better representation