### PR TITLE
Update RouteStatistics.as_dict

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1223,7 +1223,7 @@ async def test_statistics_updated(
     assert node.statistics == event_stats
     assert event_stats.lwr.as_dict() == {
         "protocol_data_rate": 1,
-        "repeaters": [wallmote_central_scene.node_id],
+        "repeaters": [wallmote_central_scene],
         "repeater_rssi": [1],
         "rssi": None,
         "route_failed_between": (

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1227,8 +1227,8 @@ async def test_statistics_updated(
         "repeater_rssi": [1],
         "rssi": None,
         "route_failed_between": (
-            ring_keypad.node_id,
-            multisensor_6.node_id,
+            ring_keypad,
+            multisensor_6,
         ),
     }
 

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -95,8 +95,8 @@ class RouteStatistics:
         return {
             "protocol_data_rate": self.protocol_data_rate.value,
             "repeaters": [node.node_id for node in self.repeaters],
-            "rssi": self.rssi,
-            "repeater_rssi": self.repeater_rssi,
+            "rssi": self.data.get("rssi"),
+            "repeater_rssi": self.data.get("repeaterRSSI", []),
             "route_failed_between": (
                 self.route_failed_between[0],
                 self.route_failed_between[1],

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -94,7 +94,7 @@ class RouteStatistics:
         """Return route statistics as dict."""
         return {
             "protocol_data_rate": self.protocol_data_rate.value,
-            "repeaters": [node for node in self.repeaters],
+            "repeaters":self.repeaters,
             "rssi": self.data.get("rssi"),
             "repeater_rssi": self.data.get("repeaterRSSI", []),
             "route_failed_between": (

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -94,7 +94,7 @@ class RouteStatistics:
         """Return route statistics as dict."""
         return {
             "protocol_data_rate": self.protocol_data_rate.value,
-            "repeaters": [node.node_id for node in self.repeaters],
+            "repeaters": [node for node in self.repeaters],
             "rssi": self.data.get("rssi"),
             "repeater_rssi": self.data.get("repeaterRSSI", []),
             "route_failed_between": (

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -30,7 +30,7 @@ class RouteStatisticsDict(TypedDict):
     """Represent a route statistics data dict type."""
 
     protocol_data_rate: int
-    repeaters: List[int]
+    repeaters: List["Node"]
     rssi: Optional[int]
     repeater_rssi: List[int]
     route_failed_between: Optional[Tuple["Node", "Node"]]

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -33,7 +33,7 @@ class RouteStatisticsDict(TypedDict):
     repeaters: List[int]
     rssi: Optional[int]
     repeater_rssi: List[int]
-    route_failed_between: Optional[Tuple[int, int]]
+    route_failed_between: Optional[Tuple["Node", "Node"]]
 
 
 @dataclass
@@ -98,8 +98,8 @@ class RouteStatistics:
             "rssi": self.rssi,
             "repeater_rssi": self.repeater_rssi,
             "route_failed_between": (
-                self.route_failed_between[0].node_id,
-                self.route_failed_between[1].node_id,
+                self.route_failed_between[0],
+                self.route_failed_between[1],
             )
             if self.route_failed_between
             else None,

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -94,7 +94,7 @@ class RouteStatistics:
         """Return route statistics as dict."""
         return {
             "protocol_data_rate": self.protocol_data_rate.value,
-            "repeaters":self.repeaters,
+            "repeaters": self.repeaters,
             "rssi": self.data.get("rssi"),
             "repeater_rssi": self.data.get("repeaterRSSI", []),
             "route_failed_between": (


### PR DESCRIPTION
Revert change to return node IDs and instead return the nodes. Upstream we can then replace this with the device name in WS API command