### PR TITLE
Add model for controller `inclusion aborted` event

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1,6 +1,7 @@
 """Test the controller model."""
 import json
 from copy import deepcopy
+from unittest.mock import patch
 
 import pytest
 
@@ -1657,6 +1658,23 @@ async def test_node_removed(client, multisensor_6, multisensor_6_state):
     assert event.data["node"].node_id == 52
     assert event.data["node"].client is None
     assert 52 not in client.driver.controller.nodes
+
+
+async def test_inclusion_aborted(controller):
+    """Test inclusion aborted event."""
+    event_data = {
+        "source": "controller",
+        "event": "inclusion aborted",
+    }
+    event = Event("inclusion aborted", event_data.copy())
+    with patch(
+        "zwave_js_server.model.controller.Controller.handle_inclusion_aborted"
+    ) as mock:
+        controller.receive_event(event)
+        assert mock.called
+
+    # Ensure that the handler doesn't modify the event
+    assert {k: v for k, v in event.data.items() if k != "controller"} == event_data
 
 
 async def test_unknown_event(controller):

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -770,6 +770,9 @@ class Controller(EventBase):
     def handle_validate_dsk_and_enter_pin(self, event: Event) -> None:
         """Process a validate dsk and enter pin event."""
 
+    def handle_inclusion_aborted(self, event: Event) -> None:
+        """Process an inclusion aborted event."""
+
     def handle_nvm_backup_progress(self, event: Event) -> None:
         """Process a nvm backup progress event."""
         event.data["nvm_backup_progress"] = NVMProgress(

--- a/zwave_js_server/model/controller/event_model.py
+++ b/zwave_js_server/model/controller/event_model.py
@@ -64,6 +64,12 @@ class HealNetworkProgressEventModel(BaseControllerEventModel):
     progress: Dict[int, str]
 
 
+class InclusionAbortedEventModel(BaseControllerEventModel):
+    """Model for `inclusion aborted` event data."""
+
+    event: Literal["inclusion aborted"]
+
+
 class InclusionFailedEventModel(BaseControllerEventModel):
     """Model for `inclusion failed` event data."""
 
@@ -147,6 +153,7 @@ CONTROLLER_EVENT_MODEL_MAP: Dict[str, Type["BaseControllerEventModel"]] = {
     "grant security classes": GrantSecurityClassesEventModel,
     "heal network done": HealNetworkDoneEventModel,
     "heal network progress": HealNetworkProgressEventModel,
+    "inclusion aborted": InclusionAbortedEventModel,
     "inclusion failed": InclusionFailedEventModel,
     "inclusion started": InclusionStartedEventModel,
     "inclusion stopped": InclusionStoppedEventModel,


### PR DESCRIPTION
This event was missing from our models - it is a `zwave-js-server` specific event

Fixes #427 