### PR TITLE
Update node and controller data when statistics are updated

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1292,7 +1292,7 @@ async def test_statistics_updated(controller):
         "timeoutCallback": 1,
         "messagesDroppedTX": 1,
     }
-    assert controller.data["statistics"] != statistics_data
+    assert controller.data.get("statistics") != statistics_data
     event = Event(
         "statistics updated",
         {

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1281,22 +1281,24 @@ async def test_heal_network_active(client, controller):
 async def test_statistics_updated(controller):
     """Test that statistics get updated on events."""
     assert controller.statistics.nak == 0
+    statistics_data = {
+        "messagesTX": 1,
+        "messagesRX": 1,
+        "messagesDroppedRX": 1,
+        "NAK": 1,
+        "CAN": 1,
+        "timeoutACK": 1,
+        "timeoutResponse": 1,
+        "timeoutCallback": 1,
+        "messagesDroppedTX": 1,
+    }
+    assert controller.data["statistics"] != statistics_data
     event = Event(
         "statistics updated",
         {
             "source": "controller",
             "event": "statistics updated",
-            "statistics": {
-                "messagesTX": 1,
-                "messagesRX": 1,
-                "messagesDroppedRX": 1,
-                "NAK": 1,
-                "CAN": 1,
-                "timeoutACK": 1,
-                "timeoutResponse": 1,
-                "timeoutCallback": 1,
-                "messagesDroppedTX": 1,
-            },
+            "statistics": statistics_data,
         },
     )
     controller.receive_event(event)
@@ -1306,6 +1308,7 @@ async def test_statistics_updated(controller):
     assert isinstance(event_stats, ControllerStatistics)
     assert controller.statistics.nak == 1
     assert controller.statistics == event_stats
+    assert controller.data["statistics"] == statistics_data
 
 
 async def test_grant_security_classes(controller, uuid4, mock_command) -> None:

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1239,6 +1239,7 @@ async def test_statistics_updated(
         "commandsDroppedRX": 4,
         "timeoutResponse": 5,
     }
+    assert node.data["statistics"] != statistics_data
     event = Event(
         "statistics updated",
         {

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1239,7 +1239,7 @@ async def test_statistics_updated(
         "commandsDroppedRX": 4,
         "timeoutResponse": 5,
     }
-    assert node.data["statistics"] != statistics_data
+    assert node.data.get("statistics") != statistics_data
     event = Event(
         "statistics updated",
         {

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1232,19 +1232,20 @@ async def test_statistics_updated(
         ),
     }
 
+    statistics_data = {
+        "commandsTX": 1,
+        "commandsRX": 2,
+        "commandsDroppedTX": 3,
+        "commandsDroppedRX": 4,
+        "timeoutResponse": 5,
+    }
     event = Event(
         "statistics updated",
         {
             "source": "node",
             "event": "statistics updated",
             "nodeId": node.node_id,
-            "statistics": {
-                "commandsTX": 1,
-                "commandsRX": 2,
-                "commandsDroppedTX": 3,
-                "commandsDroppedRX": 4,
-                "timeoutResponse": 5,
-            },
+            "statistics": statistics_data,
         },
     )
     node.receive_event(event)
@@ -1262,6 +1263,7 @@ async def test_statistics_updated(
     assert not event_stats.lwr
     assert not event_stats.nlwr
     assert node.statistics == event_stats
+    assert node.data["statistics"] == statistics_data
 
 
 async def test_statistics_updated_rssi_error(

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -757,8 +757,9 @@ class Controller(EventBase):
 
     def handle_statistics_updated(self, event: Event) -> None:
         """Process a statistics updated event."""
+        self.data["statistics"] = statistics = event.data["statistics"]
         self._statistics = event.data["statistics_updated"] = ControllerStatistics(
-            event.data["statistics"]
+            statistics
         )
 
     def handle_grant_security_classes(self, event: Event) -> None:

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -817,6 +817,7 @@ class Node(EventBase):
 
     def handle_statistics_updated(self, event: Event) -> None:
         """Process a statistics updated event."""
+        self.data["statistics"] = statistics = event.data["statistics"]
         event.data["statistics_updated"] = self._statistics = NodeStatistics(
-            self.client, event.data["statistics"]
+            self.client, statistics
         )


### PR DESCRIPTION
Currently the statistics dict in the node and controller data is stale. This change makes it so that it is updated when we receive a new statistics event