### PR TITLE
Pass Node instead of node ID into controller node commands

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -649,53 +649,52 @@ async def test_hash(controller):
     assert hash(controller) == hash(controller.home_id)
 
 
-async def test_remove_failed_node(controller, uuid4, mock_command):
+async def test_remove_failed_node(controller, multisensor_6, uuid4, mock_command):
     """Test remove failed node."""
     ack_commands = mock_command(
         {"command": "controller.remove_failed_node"},
         {},
     )
 
-    node_id = 52
-    assert await controller.async_remove_failed_node(node_id) is None
+    assert await controller.async_remove_failed_node(multisensor_6) is None
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.remove_failed_node",
         "messageId": uuid4,
-        "nodeId": node_id,
+        "nodeId": multisensor_6.node_id,
     }
 
 
-async def test_replace_failed_node(controller, uuid4, mock_command):
+async def test_replace_failed_node(controller, multisensor_6, uuid4, mock_command):
     """Test replace_failed_node."""
     ack_commands = mock_command(
         {"command": "controller.replace_failed_node"},
         {"success": True},
     )
-    assert await controller.async_replace_failed_node(1, InclusionStrategy.SECURITY_S0)
+    assert await controller.async_replace_failed_node(multisensor_6, InclusionStrategy.SECURITY_S0)
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.replace_failed_node",
-        "nodeId": 1,
+        "nodeId": multisensor_6.node_id,
         "options": {"strategy": InclusionStrategy.SECURITY_S0},
         "messageId": uuid4,
     }
 
 
-async def test_replace_failed_node_default(controller, uuid4, mock_command):
+async def test_replace_failed_node_default(controller, multisensor_6, uuid4, mock_command):
     """Test replace_failed_node."""
     ack_commands = mock_command(
         {"command": "controller.replace_failed_node"},
         {"success": True},
     )
-    assert await controller.async_replace_failed_node(1, InclusionStrategy.DEFAULT)
+    assert await controller.async_replace_failed_node(multisensor_6, InclusionStrategy.DEFAULT)
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.replace_failed_node",
-        "nodeId": 1,
+        "nodeId": multisensor_6.node_id,
         "options": {
             "strategy": InclusionStrategy.DEFAULT,
         },
@@ -704,7 +703,7 @@ async def test_replace_failed_node_default(controller, uuid4, mock_command):
 
 
 async def test_replace_failed_node_default_force_security(
-    controller, uuid4, mock_command
+    controller, multisensor_6, uuid4, mock_command
 ):
     """Test replace_failed_node with force_security provided."""
     ack_commands = mock_command(
@@ -712,13 +711,13 @@ async def test_replace_failed_node_default_force_security(
         {"success": True},
     )
     assert await controller.async_replace_failed_node(
-        1, InclusionStrategy.DEFAULT, force_security=False
+        multisensor_6, InclusionStrategy.DEFAULT, force_security=False
     )
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.replace_failed_node",
-        "nodeId": 1,
+        "nodeId": multisensor_6.node_id,
         "options": {
             "strategy": InclusionStrategy.DEFAULT,
             "forceSecurity": False,
@@ -727,31 +726,31 @@ async def test_replace_failed_node_default_force_security(
     }
 
 
-async def test_replace_failed_node_s2_no_input(controller, uuid4, mock_command):
+async def test_replace_failed_node_s2_no_input(controller, multisensor_6, uuid4, mock_command):
     """Test replace_failed_node S2 Mode."""
     ack_commands = mock_command(
         {"command": "controller.replace_failed_node"},
         {"success": True},
     )
-    assert await controller.async_replace_failed_node(1, InclusionStrategy.SECURITY_S2)
+    assert await controller.async_replace_failed_node(multisensor_6, InclusionStrategy.SECURITY_S2)
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.replace_failed_node",
-        "nodeId": 1,
+        "nodeId": multisensor_6.node_id,
         "options": {"strategy": InclusionStrategy.SECURITY_S2},
         "messageId": uuid4,
     }
 
 
-async def test_replace_failed_node_s2_qr_code_string(controller, uuid4, mock_command):
+async def test_replace_failed_node_s2_qr_code_string(controller, multisensor_6, uuid4, mock_command):
     """Test replace_failed_node S2 Mode with a QR code string."""
     ack_commands = mock_command(
         {"command": "controller.replace_failed_node"},
         {"success": True},
     )
     assert await controller.async_replace_failed_node(
-        1,
+        multisensor_6,
         InclusionStrategy.SECURITY_S2,
         provisioning="90testtesttesttesttesttesttesttesttesttesttesttesttest",
     )
@@ -759,7 +758,7 @@ async def test_replace_failed_node_s2_qr_code_string(controller, uuid4, mock_com
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.replace_failed_node",
-        "nodeId": 1,
+        "nodeId": multisensor_6.node_id,
         "options": {
             "strategy": InclusionStrategy.SECURITY_S2,
             "provisioning": "90testtesttesttesttesttesttesttesttesttesttesttesttest",
@@ -770,14 +769,14 @@ async def test_replace_failed_node_s2_qr_code_string(controller, uuid4, mock_com
     # Test invalid QR code length fails
     with pytest.raises(ValueError):
         await controller.async_replace_failed_node(
-            1,
+            multisensor_6,
             InclusionStrategy.SECURITY_S2,
             provisioning="test",
         )
 
 
 async def test_replace_failed_node_s2_provisioning_entry(
-    controller, uuid4, mock_command
+    controller, multisensor_6, uuid4, mock_command
 ):
     """Test replace_failed_node S2 Mode with a provisioning entry."""
     ack_commands = mock_command(
@@ -791,13 +790,13 @@ async def test_replace_failed_node_s2_provisioning_entry(
         additional_properties={"test": "test"},
     )
     assert await controller.async_replace_failed_node(
-        1, InclusionStrategy.SECURITY_S2, provisioning=provisioning_entry
+        multisensor_6, InclusionStrategy.SECURITY_S2, provisioning=provisioning_entry
     )
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.replace_failed_node",
-        "nodeId": 1,
+        "nodeId": multisensor_6.node_id,
         "options": {
             "strategy": InclusionStrategy.SECURITY_S2,
             "provisioning": {
@@ -812,7 +811,7 @@ async def test_replace_failed_node_s2_provisioning_entry(
     }
 
 
-async def test_replace_failed_node_s2_qr_info(controller, uuid4, mock_command):
+async def test_replace_failed_node_s2_qr_info(controller, multisensor_6, uuid4, mock_command):
     """Test replace_failed_node S2 Mode with QR info."""
     ack_commands = mock_command(
         {"command": "controller.replace_failed_node"},
@@ -836,13 +835,13 @@ async def test_replace_failed_node_s2_qr_info(controller, uuid4, mock_command):
         supported_protocols=None,
     )
     assert await controller.async_replace_failed_node(
-        1, InclusionStrategy.SECURITY_S2, provisioning=provisioning_entry
+        multisensor_6, InclusionStrategy.SECURITY_S2, provisioning=provisioning_entry
     )
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.replace_failed_node",
-        "nodeId": 1,
+        "nodeId": multisensor_6.node_id,
         "options": {
             "strategy": InclusionStrategy.SECURITY_S2,
             "provisioning": {
@@ -866,7 +865,7 @@ async def test_replace_failed_node_s2_qr_info(controller, uuid4, mock_command):
     }
 
 
-async def test_replace_failed_node_errors(controller):
+async def test_replace_failed_node_errors(controller, multisensor_6):
     """Test replace_failed_node error scenarios."""
     provisioning_entry = controller_pkg.ProvisioningEntry(
         "test",
@@ -878,30 +877,29 @@ async def test_replace_failed_node_errors(controller):
     # entry
     with pytest.raises(ValueError):
         await controller.async_replace_failed_node(
-            1, InclusionStrategy.SECURITY_S0, provisioning=provisioning_entry
+            multisensor_6, InclusionStrategy.SECURITY_S0, provisioning=provisioning_entry
         )
     # Test that Security S2 inclusion strategy can't use force_security
     with pytest.raises(ValueError):
         await controller.async_replace_failed_node(
-            1, InclusionStrategy.SECURITY_S2, force_security=True
+            multisensor_6, InclusionStrategy.SECURITY_S2, force_security=True
         )
 
 
-async def test_heal_node(controller, uuid4, mock_command):
+async def test_heal_node(controller, multisensor_6, uuid4, mock_command):
     """Test heal node."""
     ack_commands = mock_command(
         {"command": "controller.heal_node"},
         {"success": True},
     )
 
-    node_id = 52
-    assert await controller.async_heal_node(node_id)
+    assert await controller.async_heal_node(multisensor_6)
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.heal_node",
         "messageId": uuid4,
-        "nodeId": node_id,
+        "nodeId": multisensor_6.node_id,
     }
 
 
@@ -950,21 +948,20 @@ async def test_stop_healing_network(controller, uuid4, mock_command):
     assert controller.heal_network_progress is None
 
 
-async def test_is_failed_node(controller, uuid4, mock_command):
+async def test_is_failed_node(controller, multisensor_6, uuid4, mock_command):
     """Test is failed node."""
     ack_commands = mock_command(
         {"command": "controller.is_failed_node"},
         {"failed": False},
     )
 
-    node_id = 52
-    assert await controller.async_is_failed_node(node_id) is False
+    assert await controller.async_is_failed_node(multisensor_6) is False
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.is_failed_node",
         "messageId": uuid4,
-        "nodeId": node_id,
+        "nodeId": multisensor_6.node_id,
     }
 
 
@@ -1203,7 +1200,7 @@ async def test_remove_associations(controller, uuid4, mock_command):
     }
 
 
-async def test_remove_node_from_all_associations(controller, uuid4, mock_command):
+async def test_remove_node_from_all_associations(controller, multisensor_6, uuid4, mock_command):
     """Test remove associations."""
 
     ack_commands = mock_command(
@@ -1211,42 +1208,39 @@ async def test_remove_node_from_all_associations(controller, uuid4, mock_command
         {},
     )
 
-    node_id = 52
-    await controller.async_remove_node_from_all_associations(node_id)
+    await controller.async_remove_node_from_all_associations(multisensor_6)
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.remove_node_from_all_associations",
         "messageId": uuid4,
-        "nodeId": node_id,
+        "nodeId": multisensor_6.node_id,
     }
 
-    node_id = 53
-    await controller.async_remove_node_from_all_associations(node_id, True)
+    await controller.async_remove_node_from_all_associations(multisensor_6, True)
 
     assert len(ack_commands) == 2
     assert ack_commands[1] == {
         "command": "controller.remove_node_from_all_associations",
         "messageId": uuid4,
-        "nodeId": node_id,
+        "nodeId": multisensor_6.node_id,
     }
 
 
-async def test_get_node_neighbors(controller, uuid4, mock_command):
+async def test_get_node_neighbors(controller, multisensor_6, uuid4, mock_command):
     """Test get node neighbors."""
 
     ack_commands = mock_command(
         {"command": "controller.get_node_neighbors"}, {"neighbors": [1, 2]}
     )
 
-    node_id = 52
-    assert await controller.async_get_node_neighbors(node_id) == [1, 2]
+    assert await controller.async_get_node_neighbors(multisensor_6) == [1, 2]
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.get_node_neighbors",
         "messageId": uuid4,
-        "nodeId": node_id,
+        "nodeId": multisensor_6.node_id,
     }
 
 

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -672,7 +672,9 @@ async def test_replace_failed_node(controller, multisensor_6, uuid4, mock_comman
         {"command": "controller.replace_failed_node"},
         {"success": True},
     )
-    assert await controller.async_replace_failed_node(multisensor_6, InclusionStrategy.SECURITY_S0)
+    assert await controller.async_replace_failed_node(
+        multisensor_6, InclusionStrategy.SECURITY_S0
+    )
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
@@ -683,13 +685,17 @@ async def test_replace_failed_node(controller, multisensor_6, uuid4, mock_comman
     }
 
 
-async def test_replace_failed_node_default(controller, multisensor_6, uuid4, mock_command):
+async def test_replace_failed_node_default(
+    controller, multisensor_6, uuid4, mock_command
+):
     """Test replace_failed_node."""
     ack_commands = mock_command(
         {"command": "controller.replace_failed_node"},
         {"success": True},
     )
-    assert await controller.async_replace_failed_node(multisensor_6, InclusionStrategy.DEFAULT)
+    assert await controller.async_replace_failed_node(
+        multisensor_6, InclusionStrategy.DEFAULT
+    )
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
@@ -726,13 +732,17 @@ async def test_replace_failed_node_default_force_security(
     }
 
 
-async def test_replace_failed_node_s2_no_input(controller, multisensor_6, uuid4, mock_command):
+async def test_replace_failed_node_s2_no_input(
+    controller, multisensor_6, uuid4, mock_command
+):
     """Test replace_failed_node S2 Mode."""
     ack_commands = mock_command(
         {"command": "controller.replace_failed_node"},
         {"success": True},
     )
-    assert await controller.async_replace_failed_node(multisensor_6, InclusionStrategy.SECURITY_S2)
+    assert await controller.async_replace_failed_node(
+        multisensor_6, InclusionStrategy.SECURITY_S2
+    )
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
@@ -743,7 +753,9 @@ async def test_replace_failed_node_s2_no_input(controller, multisensor_6, uuid4,
     }
 
 
-async def test_replace_failed_node_s2_qr_code_string(controller, multisensor_6, uuid4, mock_command):
+async def test_replace_failed_node_s2_qr_code_string(
+    controller, multisensor_6, uuid4, mock_command
+):
     """Test replace_failed_node S2 Mode with a QR code string."""
     ack_commands = mock_command(
         {"command": "controller.replace_failed_node"},
@@ -811,7 +823,9 @@ async def test_replace_failed_node_s2_provisioning_entry(
     }
 
 
-async def test_replace_failed_node_s2_qr_info(controller, multisensor_6, uuid4, mock_command):
+async def test_replace_failed_node_s2_qr_info(
+    controller, multisensor_6, uuid4, mock_command
+):
     """Test replace_failed_node S2 Mode with QR info."""
     ack_commands = mock_command(
         {"command": "controller.replace_failed_node"},
@@ -877,7 +891,9 @@ async def test_replace_failed_node_errors(controller, multisensor_6):
     # entry
     with pytest.raises(ValueError):
         await controller.async_replace_failed_node(
-            multisensor_6, InclusionStrategy.SECURITY_S0, provisioning=provisioning_entry
+            multisensor_6,
+            InclusionStrategy.SECURITY_S0,
+            provisioning=provisioning_entry,
         )
     # Test that Security S2 inclusion strategy can't use force_security
     with pytest.raises(ValueError):
@@ -1200,7 +1216,9 @@ async def test_remove_associations(controller, uuid4, mock_command):
     }
 
 
-async def test_remove_node_from_all_associations(controller, multisensor_6, uuid4, mock_command):
+async def test_remove_node_from_all_associations(
+    controller, multisensor_6, uuid4, mock_command
+):
     """Test remove associations."""
 
     ack_commands = mock_command(

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1356,20 +1356,30 @@ async def test_get_highest_security_class(
     }
 
 
-async def test_test_power_level(multisensor_6: node_pkg.Node, uuid4, mock_command):
+async def test_test_power_level(
+    multisensor_6: node_pkg.Node,
+    wallmote_central_scene: node_pkg.Node,
+    uuid4,
+    mock_command,
+):
     """Test node.test_powerlevel command."""
     node = multisensor_6
     ack_commands = mock_command(
         {"command": "node.test_powerlevel", "nodeId": node.node_id},
         {"framesAcked": 1},
     )
-    assert await node.async_test_power_level(2, PowerLevel.DBM_MINUS_1, 3) == 1
+    assert (
+        await node.async_test_power_level(
+            wallmote_central_scene, PowerLevel.DBM_MINUS_1, 3
+        )
+        == 1
+    )
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "node.test_powerlevel",
         "nodeId": node.node_id,
-        "testNodeId": 2,
+        "testNodeId": wallmote_central_scene.node_id,
         "powerlevel": PowerLevel.DBM_MINUS_1.value,
         "testFrameCount": 3,
         "messageId": uuid4,
@@ -1460,7 +1470,12 @@ async def test_check_lifeline_health_progress_event(
     assert event.data["check_lifeline_health_progress"].last_rating == 10
 
 
-async def test_check_route_health(multisensor_6: node_pkg.Node, uuid4, mock_command):
+async def test_check_route_health(
+    multisensor_6: node_pkg.Node,
+    wallmote_central_scene: node_pkg.Node,
+    uuid4,
+    mock_command,
+):
     """Test node.check_route_health command."""
     node = multisensor_6
     ack_commands = mock_command(
@@ -1481,7 +1496,7 @@ async def test_check_route_health(multisensor_6: node_pkg.Node, uuid4, mock_comm
             }
         },
     )
-    summary = await node.async_check_route_health(15, 1)
+    summary = await node.async_check_route_health(wallmote_central_scene, 1)
 
     assert summary.rating == 10
     assert summary.results[0].num_neighbors == 1
@@ -1495,7 +1510,7 @@ async def test_check_route_health(multisensor_6: node_pkg.Node, uuid4, mock_comm
     assert ack_commands[0] == {
         "command": "node.check_route_health",
         "nodeId": node.node_id,
-        "targetNodeId": 15,
+        "targetNodeId": wallmote_central_scene.node_id,
         "rounds": 1,
         "messageId": uuid4,
     }

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -326,15 +326,15 @@ class Controller(EventBase):
         )
         return cast(bool, data["success"])
 
-    async def async_remove_failed_node(self, node_id: int) -> None:
+    async def async_remove_failed_node(self, node: Node) -> None:
         """Send removeFailedNode command to Controller."""
         await self.client.async_send_command(
-            {"command": "controller.remove_failed_node", "nodeId": node_id}
+            {"command": "controller.remove_failed_node", "nodeId": node.node_id}
         )
 
     async def async_replace_failed_node(
         self,
-        node_id: int,
+        node: Node,
         inclusion_strategy: Literal[
             InclusionStrategy.DEFAULT,
             InclusionStrategy.SECURITY_S0,
@@ -385,17 +385,17 @@ class Controller(EventBase):
         data = await self.client.async_send_command(
             {
                 "command": "controller.replace_failed_node",
-                "nodeId": node_id,
+                "nodeId": node.node_id,
                 "options": options,
             },
             require_schema=require_schema,
         )
         return cast(bool, data["success"])
 
-    async def async_heal_node(self, node_id: int) -> bool:
+    async def async_heal_node(self, node: Node) -> bool:
         """Send healNode command to Controller."""
         data = await self.client.async_send_command(
-            {"command": "controller.heal_node", "nodeId": node_id}
+            {"command": "controller.heal_node", "nodeId": node.node_id}
         )
         return cast(bool, data["success"])
 
@@ -417,10 +417,10 @@ class Controller(EventBase):
             self.data["isHealNetworkActive"] = False
         return success
 
-    async def async_is_failed_node(self, node_id: int) -> bool:
+    async def async_is_failed_node(self, node: Node) -> bool:
         """Send isFailedNode command to Controller."""
         data = await self.client.async_send_command(
-            {"command": "controller.is_failed_node", "nodeId": node_id}
+            {"command": "controller.is_failed_node", "nodeId": node.node_id}
         )
         return cast(bool, data["failed"])
 
@@ -556,25 +556,25 @@ class Controller(EventBase):
 
     async def async_remove_node_from_all_associations(
         self,
-        node_id: int,
+        node: Node,
         wait_for_result: bool = False,
     ) -> None:
         """Send removeNodeFromAllAssociations command to Controller."""
         cmd = {
             "command": "controller.remove_node_from_all_associations",
-            "nodeId": node_id,
+            "nodeId": node.node_id,
         }
         if wait_for_result:
             await self.client.async_send_command(cmd)
         else:
             await self.client.async_send_command_no_wait(cmd)
 
-    async def async_get_node_neighbors(self, node_id: int) -> List[int]:
+    async def async_get_node_neighbors(self, node: Node) -> List[int]:
         """Send getNodeNeighbors command to Controller to get node's neighbors."""
         data = await self.client.async_send_command(
             {
                 "command": "controller.get_node_neighbors",
-                "nodeId": node_id,
+                "nodeId": node.node_id,
             }
         )
         return cast(List[int], data["neighbors"])

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -553,12 +553,12 @@ class Node(EventBase):
         return SecurityClass(data["highestSecurityClass"])
 
     async def async_test_power_level(
-        self, test_node_id: int, power_level: PowerLevel, test_frame_count: int
+        self, test_node: "Node", power_level: PowerLevel, test_frame_count: int
     ) -> int:
         """Send testPowerLevel command to Node."""
         data = await self.async_send_command(
             "test_powerlevel",
-            testNodeId=test_node_id,
+            testNodeId=test_node.node_id,
             powerlevel=power_level,
             testFrameCount=test_frame_count,
             require_schema=13,
@@ -584,10 +584,10 @@ class Node(EventBase):
         return LifelineHealthCheckSummary(data["summary"])
 
     async def async_check_route_health(
-        self, target_node_id: int, rounds: Optional[int] = None
+        self, target_node: "Node", rounds: Optional[int] = None
     ) -> RouteHealthCheckSummary:
         """Send checkRouteHealth command to Node."""
-        kwargs = {"targetNodeId": target_node_id}
+        kwargs = {"targetNodeId": target_node.node_id}
         if rounds is not None:
             kwargs["rounds"] = rounds
         data = await self.async_send_command(


### PR DESCRIPTION
In each of these commands, the node ID referenced will be from a node already included in the model, so why not let the called pass the node in instead of the node ID?