### PR TITLE
Add test coverage for remaining pydantic event models

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1698,3 +1698,37 @@ async def test_unknown_event(controller):
         assert controller.receive_event(
             Event("unknown_event", {"source": "controller"})
         )
+
+
+async def test_additional_events(controller):
+    """Test that remaining events pass pydantic validation."""
+    event = Event(
+        "exclusion failed", {"source": "controller", "event": "exclusion failed"}
+    )
+    controller.receive_event(event)
+    event = Event(
+        "exclusion started", {"source": "controller", "event": "exclusion started"}
+    )
+    controller.receive_event(event)
+    event = Event(
+        "exclusion stopped", {"source": "controller", "event": "exclusion stopped"}
+    )
+    controller.receive_event(event)
+    event = Event(
+        "inclusion failed", {"source": "controller", "event": "inclusion failed"}
+    )
+    controller.receive_event(event)
+    event = Event(
+        "inclusion started",
+        {"source": "controller", "event": "inclusion started", "secure": True},
+    )
+    controller.receive_event(event)
+    event = Event(
+        "inclusion stopped", {"source": "controller", "event": "inclusion stopped"}
+    )
+    controller.receive_event(event)
+    event = Event(
+        "validate dsk and enter pin",
+        {"source": "controller", "event": "validate dsk and enter pin", "dsk": "1234"},
+    )
+    controller.receive_event(event)

--- a/test/model/test_driver.py
+++ b/test/model/test_driver.py
@@ -342,3 +342,9 @@ async def test_unknown_event(driver):
     """Test that an unknown event type causes an exception."""
     with pytest.raises(KeyError):
         assert driver.receive_event(Event("unknown_event", {"source": "driver"}))
+
+
+async def test_all_nodes_ready_event(driver):
+    """Test that the all nodes ready event is succesfully validated by pydantic."""
+    event = Event("all nodes ready", {"source": "driver", "event": "all nodes ready"})
+    driver.receive_event(event)


### PR DESCRIPTION
There's nothing to do with these events, we just want to make sure `pydantic` doesn't raise any validation errors when the event is received.