### PR TITLE
Fix firmware update logic

### DIFF
--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -238,10 +238,7 @@ class Client:
                 "Z-Wave JS initialized. %s nodes", len(self.driver.controller.nodes)
             )
 
-            while not self._client.closed:
-                data = await self._receive_json_or_raise()
-
-                self._handle_incoming_message(data)
+            await self.receive_until_closed()
         except ConnectionClosed:
             pass
 
@@ -301,6 +298,13 @@ class Client:
         self._recorded_events.clear()
 
         return list(data)
+
+    async def receive_until_closed(self) -> None:
+        """Receive messages until client is closed."""
+        while not self._client.closed:
+            data = await self._receive_json_or_raise()
+
+            self._handle_incoming_message(data)
 
     async def _receive_json_or_raise(self) -> dict:
         """Receive json or raise."""

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -301,6 +301,8 @@ class Client:
 
     async def receive_until_closed(self) -> None:
         """Receive messages until client is closed."""
+        assert self._client
+
         while not self._client.closed:
             data = await self._receive_json_or_raise()
 

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -22,7 +22,7 @@ async def begin_firmware_update(
     await client.connect()
     await client.set_api_schema()
 
-    asyncio.get_running_loop().create_task(client.receive_until_closed())
+    listen_task = asyncio.get_running_loop().create_task(client.receive_until_closed())
 
     cmd = {
         "command": "node.begin_firmware_update",
@@ -35,3 +35,5 @@ async def begin_firmware_update(
 
     await client.async_send_command(cmd, require_schema=5)
     await client.disconnect()
+    if not listen_task.done():
+        listen_task.cancel()

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -1,4 +1,5 @@
 """Firmware update helper."""
+import asyncio
 from typing import Optional
 
 import aiohttp
@@ -20,6 +21,8 @@ async def begin_firmware_update(
     client = Client(url, session)
     await client.connect()
     await client.set_api_schema()
+
+    asyncio.get_running_loop().create_task(client.receive_until_closed())
 
     cmd = {
         "command": "node.begin_firmware_update",

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -22,7 +22,7 @@ async def begin_firmware_update(
     await client.connect()
     await client.set_api_schema()
 
-    listen_task = asyncio.get_running_loop().create_task(client.receive_until_closed())
+    receive_task = asyncio.get_running_loop().create_task(client.receive_until_closed())
 
     cmd = {
         "command": "node.begin_firmware_update",
@@ -35,5 +35,5 @@ async def begin_firmware_update(
 
     await client.async_send_command(cmd, require_schema=5)
     await client.disconnect()
-    if not listen_task.done():
-        listen_task.cancel()
+    if not receive_task.done():
+        receive_task.cancel()


### PR DESCRIPTION
This PR supersedes https://github.com/home-assistant-libs/zwave-js-server-python/pull/440 which will switch to a test refactor.

The reason we weren't receiving messages before is because the loop to receive connections wasn't running. I broke that out into a separate function so now we can start the loop in the firmware upload logic. This requires no change to tests while eliminating repeat logic