### PR TITLE
Initialize firmware progress when an update has been sent

### DIFF
--- a/test/test_firmware.py
+++ b/test/test_firmware.py
@@ -28,6 +28,10 @@ async def test_begin_firmware_update_guess_format(url, client_session, multisens
             require_schema=5,
         )
         disconnect_mock.assert_called_once()
+        assert multisensor_6.firmware_update_progress.data == {
+            "sentFragments": 0,
+            "totalFragments": 0,
+        }
 
 
 async def test_begin_firmware_update_known_format(url, client_session, multisensor_6):
@@ -57,3 +61,7 @@ async def test_begin_firmware_update_known_format(url, client_session, multisens
             require_schema=5,
         )
         disconnect_mock.assert_called_once()
+        assert multisensor_6.firmware_update_progress.data == {
+            "sentFragments": 0,
+            "totalFragments": 0,
+        }

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -3,6 +3,11 @@ from typing import Optional
 
 import aiohttp
 
+from zwave_js_server.model.firmware import (
+    FirmwareUpdateProgress,
+    FirmwareUpdateProgressDataType,
+)
+
 from .client import Client
 from .model.node import Node
 from .util.helpers import convert_bytes_to_base64
@@ -31,4 +36,7 @@ async def begin_firmware_update(
         cmd["firmwareFileFormat"] = file_format
 
     await client.async_send_command(cmd, require_schema=5)
+    node.firmware_update_progress = FirmwareUpdateProgress(
+        node, FirmwareUpdateProgressDataType(sentFragments=0, totalFragments=0)
+    )
     await client.disconnect()

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -286,6 +286,11 @@ class Node(EventBase):
         """Return firmware update progress."""
         return self._firmware_update_progress
 
+    @firmware_update_progress.setter
+    def firmware_update_progress(self, value: FirmwareUpdateProgress) -> None:
+        """Set firmware update progress."""
+        self._firmware_update_progress = value
+
     @property
     def highest_security_class(self) -> Optional[SecurityClass]:
         """Return highest security class configured on the node."""
@@ -802,7 +807,7 @@ class Node(EventBase):
 
     def handle_firmware_update_progress(self, event: Event) -> None:
         """Process a node firmware update progress event."""
-        self._firmware_update_progress = event.data[
+        self.firmware_update_progress = event.data[
             "firmware_update_progress"
         ] = FirmwareUpdateProgress(
             self, cast(FirmwareUpdateProgressDataType, event.data)
@@ -810,7 +815,7 @@ class Node(EventBase):
 
     def handle_firmware_update_finished(self, event: Event) -> None:
         """Process a node firmware update finished event."""
-        self._firmware_update_progress = None
+        self.firmware_update_progress = None
         event.data["firmware_update_finished"] = FirmwareUpdateFinished(
             self, cast(FirmwareUpdateFinishedDataType, event.data)
         )


### PR DESCRIPTION
Right now, the lib only knows that a firmware update is in progress if we start receiving `firmware update progress` messages. There is a scenario where we attempt to update the firmware on a sleeping device - in this case, the controller will have accepted the upload, but we won't start receiving events until the device wakes up and the upload process starts. So in this change, we initialize the `firmware_update_progress` property of the node to indicate that the firmware is effectively queued.

Should we somehow handle this in the server instead? Right now we don't maintain state information about the network or its nodes in the server, but if the client disconnects, then it loses state, whereas if the server stops, then the queue and any occurring processes get terminated so the state will be correct when it restarts.