### PR TITLE
Add support for node.get_firmware_update_progress command

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -266,7 +266,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 17,
+        "maxSchemaVersion": 18,
     }
 
 

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1655,6 +1655,26 @@ async def test_set_keep_awake(multisensor_6: node_pkg.Node, uuid4, mock_command)
     }
 
 
+async def test_get_firmware_update_progress(
+    multisensor_6: node_pkg.Node, uuid4, mock_command
+):
+    """Test node.get_firmware_update_progress command."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "node.get_firmware_update_progress", "nodeId": node.node_id},
+        {"progress": True},
+    )
+
+    assert await node.async_get_firmware_update_progress()
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.get_firmware_update_progress",
+        "nodeId": node.node_id,
+        "messageId": uuid4,
+    }
+
+
 async def test_unknown_event(multisensor_6: node_pkg.Node):
     """Test that an unknown event type causes an exception."""
     with pytest.raises(KeyError):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -64,7 +64,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 17}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 18}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -3,9 +3,9 @@ import sys
 from enum import Enum, IntEnum
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 17
+MIN_SERVER_SCHEMA_VERSION = 18
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 17
+MAX_SERVER_SCHEMA_VERSION = 18
 
 TYPING_EXTENSION_FOR_TYPEDDICT_REQUIRED = sys.version_info < (3, 9, 2)
 

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -644,6 +644,14 @@ class Node(EventBase):
         )
         self.data["location"] = location
 
+    async def async_get_firmware_update_progress(self) -> bool:
+        """Send getFirmwareUpdateProgress command to Node."""
+        data = await self.async_send_command(
+            "get_firmware_update_progress", require_schema=18, wait_for_result=True
+        )
+        assert data
+        return cast(bool, data["progress"])
+
     async def async_set_keep_awake(self, keep_awake: bool) -> None:
         """Set node keep awake state."""
         await self.async_send_command(

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -645,7 +645,11 @@ class Node(EventBase):
         self.data["location"] = location
 
     async def async_get_firmware_update_progress(self) -> bool:
-        """Send getFirmwareUpdateProgress command to Node."""
+        """
+        Send getFirmwareUpdateProgress command to Node.
+
+        If `True`, a firmware update for this node is in progress.
+        """
         data = await self.async_send_command(
             "get_firmware_update_progress", require_schema=18, wait_for_result=True
         )


### PR DESCRIPTION
The server now keeps track of when a firmware update is in progress. This is necessary for the frontend work to support firmware updates