### PR TITLE
Bump zwave-js-server-python to 0.37.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.37.1"
+VERSION = "0.37.2"
 
 
 setup(


### PR DESCRIPTION
This will allow us to release the firmware fix and move it into core so people can help with testing the firmware feature. Should be merged ahead of the other two open PRs