### PR TITLE
Wait for result when aborting firmware update

### DIFF
--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -498,7 +498,7 @@ class Node(EventBase):
 
     async def async_abort_firmware_update(self) -> None:
         """Send abortFirmwareUpdate command to Node."""
-        await self.async_send_command("abort_firmware_update", wait_for_result=False)
+        await self.async_send_command("abort_firmware_update", wait_for_result=True)
 
     async def async_poll_value(self, val: Union[Value, str]) -> None:
         """Send pollValue command to Node for given value (or value_id)."""


### PR DESCRIPTION
zwave-js can throw an error when aborting so we should wait for the result