### PR TITLE
Add support for new firmware progress information

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -211,7 +211,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 18,
+        "maxSchemaVersion": 19,
     }
 
 

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1759,10 +1759,30 @@ async def test_get_firmware_update_progress(
     node = multisensor_6
     ack_commands = mock_command(
         {"command": "node.get_firmware_update_progress", "nodeId": node.node_id},
-        {"progress": True},
+        {"progress": True, "anyProgress": True},
     )
 
     assert await node.async_get_firmware_update_progress()
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.get_firmware_update_progress",
+        "nodeId": node.node_id,
+        "messageId": uuid4,
+    }
+
+
+async def test_get_firmware_update_any_progress(
+    multisensor_6: node_pkg.Node, uuid4, mock_command
+):
+    """Test node.get_firmware_update_progress command."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "node.get_firmware_update_progress", "nodeId": node.node_id},
+        {"progress": False, "anyProgress": True},
+    )
+
+    assert await node.async_get_firmware_update_progress(any_node=True)
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -55,7 +55,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 18}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 19}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -3,9 +3,9 @@ import sys
 from enum import Enum, IntEnum
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 18
+MIN_SERVER_SCHEMA_VERSION = 19
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 18
+MAX_SERVER_SCHEMA_VERSION = 19
 
 TYPING_EXTENSION_FOR_TYPEDDICT_REQUIRED = sys.version_info < (3, 9, 2)
 

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -670,16 +670,19 @@ class Node(EventBase):
         )
         self.data["location"] = location
 
-    async def async_get_firmware_update_progress(self) -> bool:
+    async def async_get_firmware_update_progress(self, any_node: bool = False) -> bool:
         """
         Send getFirmwareUpdateProgress command to Node.
 
-        If `True`, a firmware update for this node is in progress.
+        By default, if `True`, a firmware update for this node is in progress. If
+        `any_node` is `True`, a firmware update for any node is in progress.
         """
         data = await self.async_send_command(
             "get_firmware_update_progress", require_schema=18, wait_for_result=True
         )
         assert data
+        if any_node:
+            return cast(bool, data["anyProgress"])
         return cast(bool, data["progress"])
 
     async def async_set_keep_awake(self, keep_awake: bool) -> None:


### PR DESCRIPTION
Adds support for this change: https://github.com/zwave-js/zwave-js-server/pull/666

Also bumping the schema version required because of this bug which is properly fixed here: https://github.com/zwave-js/zwave-js-server/pull/665 . It was technically fixed here: https://github.com/zwave-js/zwave-js-server/pull/662 but then the clients wouldn't have this node in their model so it would serve no utility