### PR TITLE
Bump zwave-js-server-python to 0.39.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.38.0"
+VERSION = "0.39.0"
 
 
 setup(


### PR DESCRIPTION
It's a minor bump because I find it helpful for the versions (both server and lib) to map well to the schema version. let me know if you disagree