### PR TITLE
Add lib support to zwave-js 9.6.0 and upstream server changes

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -211,7 +211,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 20,
+        "maxSchemaVersion": 21,
     }
 
 

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1626,9 +1626,7 @@ async def test_begin_ota_firmware_update(multisensor_6, uuid4, mock_command):
     )
     await multisensor_6.client.driver.controller.async_begin_ota_firmware_update(
         multisensor_6,
-        FirmwareUpdateFileInfo(
-            {"target": 0, "url": "http://example.com", "integrity": "test"}
-        ),
+        FirmwareUpdateFileInfo(target=0, url="http://example.com", integrity="test"),
     )
 
     assert len(ack_commands) == 1

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1625,7 +1625,10 @@ async def test_begin_ota_firmware_update(multisensor_6, uuid4, mock_command):
         {},
     )
     await multisensor_6.client.driver.controller.async_begin_ota_firmware_update(
-        multisensor_6, FirmwareUpdateFileInfo({"target": 0, "url": "http://example.com", "integrity": "test"})
+        multisensor_6,
+        FirmwareUpdateFileInfo(
+            {"target": 0, "url": "http://example.com", "integrity": "test"}
+        ),
     )
 
     assert len(ack_commands) == 1

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1757,6 +1757,46 @@ async def test_get_firmware_update_capabilities_string(
     }
 
 
+async def test_get_firmware_update_capabilities_cached(
+    multisensor_6: node_pkg.Node, uuid4, mock_command
+):
+    """Test node.get_firmware_update_capabilities_cached command."""
+    node = multisensor_6
+    ack_commands = mock_command(
+        {
+            "command": "node.get_firmware_update_capabilities_cached",
+            "nodeId": node.node_id,
+        },
+        {
+            "capabilities": {
+                "firmwareUpgradable": True,
+                "firmwareTargets": [0],
+                "continuesToFunction": True,
+                "supportsActivation": True,
+            }
+        },
+    )
+    capabilities = await node.async_get_firmware_update_capabilities_cached()
+    assert capabilities.firmware_upgradable
+    assert capabilities.firmware_targets == [0]
+    assert capabilities.continues_to_function
+    assert capabilities.supports_activation
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.get_firmware_update_capabilities_cached",
+        "nodeId": node.node_id,
+        "messageId": uuid4,
+    }
+
+    assert capabilities.to_dict() == {
+        "firmware_upgradable": True,
+        "firmware_targets": [0],
+        "continues_to_function": True,
+        "supports_activation": True,
+    }
+
+
 async def test_is_firmware_update_in_progress(
     multisensor_6: node_pkg.Node, uuid4, mock_command
 ):

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -749,7 +749,9 @@ async def test_notification(lock_schlage_be469: node_pkg.Node):
             "ccId": 111,
             "args": {
                 "eventType": 0,
+                "eventTypeLabel": "a",
                 "dataType": 0,
+                "dataTypeLabel": "b",
                 "eventData": "test",
             },
         },
@@ -759,7 +761,9 @@ async def test_notification(lock_schlage_be469: node_pkg.Node):
     assert event.data["notification"].command_class == CommandClass.ENTRY_CONTROL
     assert event.data["notification"].node_id == 23
     assert event.data["notification"].event_type == EntryControlEventType.CACHING
+    assert event.data["notification"].event_type_label == "a"
     assert event.data["notification"].data_type == EntryControlDataType.NONE
+    assert event.data["notification"].data_type_label == "b"
     assert event.data["notification"].event_data == "test"
 
     # Validate that Notification CC notification event is received as expected
@@ -816,7 +820,7 @@ async def test_notification(lock_schlage_be469: node_pkg.Node):
             "event": "notification",
             "nodeId": 23,
             "ccId": CommandClass.SWITCH_MULTILEVEL.value,
-            "args": {"direction": "up", "eventType": 4},
+            "args": {"direction": "up", "eventType": 4, "eventTypeLabel": "c"},
         },
     )
 
@@ -828,6 +832,7 @@ async def test_notification(lock_schlage_be469: node_pkg.Node):
         event.data["notification"].event_type
         == MultilevelSwitchCommand.START_LEVEL_CHANGE
     )
+    assert event.data["notification"].event_type_label == "c"
 
     # Validate that Multilevel Switch CC notification event without a direction is valid
     event = Event(
@@ -1752,21 +1757,21 @@ async def test_get_firmware_update_capabilities_string(
     }
 
 
-async def test_get_firmware_update_progress(
+async def test_is_firmware_update_in_progress(
     multisensor_6: node_pkg.Node, uuid4, mock_command
 ):
-    """Test node.get_firmware_update_progress command."""
+    """Test node.is_firmware_update_in_progress command."""
     node = multisensor_6
     ack_commands = mock_command(
-        {"command": "node.get_firmware_update_progress", "nodeId": node.node_id},
+        {"command": "node.is_firmware_update_in_progress", "nodeId": node.node_id},
         {"progress": True},
     )
 
-    assert await node.async_get_firmware_update_progress()
+    assert await node.async_is_firmware_update_in_progress()
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
-        "command": "node.get_firmware_update_progress",
+        "command": "node.is_firmware_update_in_progress",
         "nodeId": node.node_id,
         "messageId": uuid4,
     }

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -55,7 +55,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 20}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 21}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -3,9 +3,9 @@ import sys
 from enum import Enum, IntEnum
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 20
+MIN_SERVER_SCHEMA_VERSION = 21
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 20
+MAX_SERVER_SCHEMA_VERSION = 21
 
 TYPING_EXTENSION_FOR_TYPEDDICT_REQUIRED = sys.version_info < (3, 9, 2)
 

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -1,5 +1,5 @@
 """Provide a model for the Z-Wave JS controller."""
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, cast
 
 from zwave_js_server.model.firmware import FirmwareUpdateFileInfo, FirmwareUpdateInfo
@@ -718,7 +718,7 @@ class Controller(EventBase):
             require_schema=21,
         )
         assert data
-        return [FirmwareUpdateInfo(update) for update in data["updates"]]
+        return [FirmwareUpdateInfo(**update) for update in data["updates"]]
 
     async def async_begin_ota_firmware_update(
         self, node: Node, update: FirmwareUpdateFileInfo
@@ -728,7 +728,7 @@ class Controller(EventBase):
             {
                 "command": "controller.begin_ota_firmware_update",
                 "nodeId": node.node_id,
-                "update": update.data,
+                "update": asdict(update),
             },
             require_schema=21,
         )

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -718,7 +718,7 @@ class Controller(EventBase):
             require_schema=21,
         )
         assert data
-        return [FirmwareUpdateInfo(**update) for update in data["updates"]]
+        return [FirmwareUpdateInfo.from_dict(update) for update in data["updates"]]
 
     async def async_begin_ota_firmware_update(
         self, node: Node, update: FirmwareUpdateFileInfo

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -2,6 +2,8 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, cast
 
+from zwave_js_server.model.firmware import FirmwareUpdateFileInfo, FirmwareUpdateInfo
+
 from ...const import (
     MINIMUM_QR_STRING_LENGTH,
     InclusionState,
@@ -691,18 +693,45 @@ class Controller(EventBase):
             for node_id, lifeline_routes in data["routes"].items()
         }
 
-    async def async_get_any_firmware_update_progress(self) -> bool:
+    async def async_is_any_ota_firmware_update_in_progress(self) -> bool:
         """
-        Send getAnyFirmwareUpdateProgress command to Node.
+        Send isAnyOTAFirmwareUpdateInProgress command to Controller.
 
         If `True`, a firmware update is in progress on at least one node.
         """
         data = await self.client.async_send_command(
-            {"command": "controller.get_any_firmware_update_progress"},
-            require_schema=20,
+            {"command": "controller.is_any_ota_firmware_update_in_progress"},
+            require_schema=21,
         )
         assert data
         return cast(bool, data["progress"])
+
+    async def async_get_available_firmware_updates(
+        self, node: Node
+    ) -> List[FirmwareUpdateInfo]:
+        """Send getAvailableFirmwareUpdates command to Controller."""
+        data = await self.client.async_send_command(
+            {
+                "command": "controller.get_available_firmware_updates",
+                "nodeId": node.node_id,
+            },
+            require_schema=21,
+        )
+        assert data
+        return [FirmwareUpdateInfo(update) for update in data["updates"]]
+
+    async def async_begin_ota_firmware_update(
+        self, node: Node, update: FirmwareUpdateFileInfo
+    ) -> None:
+        """Send beginOTAFirmwareUpdate command to Controller."""
+        await self.client.async_send_command(
+            {
+                "command": "controller.begin_ota_firmware_update",
+                "nodeId": node.node_id,
+                "update": update.data,
+            },
+            require_schema=21,
+        )
 
     def receive_event(self, event: Event) -> None:
         """Receive an event."""

--- a/zwave_js_server/model/firmware.py
+++ b/zwave_js_server/model/firmware.py
@@ -1,4 +1,5 @@
 """Provide a model for Z-Wave firmware."""
+from dataclasses import dataclass
 from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Union
 
@@ -163,27 +164,13 @@ class FirmwareUpdateFileInfoDataType(TypedDict):
     integrity: str  # sha256
 
 
+@dataclass
 class FirmwareUpdateFileInfo:
     """Represent a firmware update file info."""
 
-    def __init__(self, data: FirmwareUpdateFileInfoDataType) -> None:
-        """Initialize."""
-        self.data = data
-
-    @property
-    def target(self) -> int:
-        """Return the firmware target."""
-        return self.data["target"]
-
-    @property
-    def url(self) -> str:
-        """Return the firmware url."""
-        return self.data["url"]
-
-    @property
-    def integrity(self) -> str:
-        """Return the firmware file integrity hash."""
-        return self.data["integrity"]
+    target: int
+    url: str
+    integrity: str
 
 
 class FirmwareUpdateInfoDataType(TypedDict):
@@ -194,24 +181,14 @@ class FirmwareUpdateInfoDataType(TypedDict):
     files: List[FirmwareUpdateFileInfoDataType]
 
 
+@dataclass
 class FirmwareUpdateInfo:
     """Represent a firmware update info."""
 
-    def __init__(self, data: FirmwareUpdateInfoDataType) -> None:
-        """Initialize."""
-        self.data = data
+    version: str
+    changelog: str
+    files: Union[List[FirmwareUpdateFileInfo], List[FirmwareUpdateFileInfoDataType]]
 
-    @property
-    def version(self) -> str:
-        """Return the firmware version."""
-        return self.data["version"]
-
-    @property
-    def changelog(self) -> str:
-        """Return the firmware changelog."""
-        return self.data["changelog"]
-
-    @property
-    def files(self) -> List[FirmwareUpdateFileInfo]:
-        """Return the firmware files."""
-        return [FirmwareUpdateFileInfo(file) for file in self.data["files"]]
+    def __post_init__(self) -> None:
+        """Post initialization."""
+        self.files = [FirmwareUpdateFileInfo(**file) for file in self.files]

--- a/zwave_js_server/model/firmware.py
+++ b/zwave_js_server/model/firmware.py
@@ -192,7 +192,7 @@ class FirmwareUpdateInfo:
     @classmethod
     def from_dict(cls, data: FirmwareUpdateInfoDataType) -> "FirmwareUpdateInfo":
         """Initialize from dict."""
-        return FirmwareUpdateInfo(
+        return cls(
             version=data["version"],
             changelog=data["changelog"],
             files=[FirmwareUpdateFileInfo(**file) for file in data["files"]],

--- a/zwave_js_server/model/firmware.py
+++ b/zwave_js_server/model/firmware.py
@@ -153,3 +153,65 @@ class FirmwareUpdateFinished:
     def wait_time(self) -> Optional[int]:
         """Return the wait time in seconds before the device is functional again."""
         return self.data.get("waitTime")
+
+
+class FirmwareUpdateFileInfoDataType(TypedDict):
+    """Represent a firmware update file info data dict type."""
+
+    target: int
+    url: str
+    integrity: str  # sha256
+
+
+class FirmwareUpdateFileInfo:
+    """Represent a firmware update file info."""
+
+    def __init__(self, data: FirmwareUpdateFileInfoDataType) -> None:
+        """Initialize."""
+        self.data = data
+
+    @property
+    def target(self) -> int:
+        """Return the firmware target."""
+        return self.data["target"]
+
+    @property
+    def url(self) -> str:
+        """Return the firmware url."""
+        return self.data["url"]
+
+    @property
+    def integrity(self) -> str:
+        """Return the firmware file integrity hash."""
+        return self.data["integrity"]
+
+
+class FirmwareUpdateInfoDataType(TypedDict):
+    """Represent a firmware update info data dict type."""
+
+    version: str
+    changelog: str
+    files: List[FirmwareUpdateFileInfoDataType]
+
+
+class FirmwareUpdateInfo:
+    """Represent a firmware update info."""
+
+    def __init__(self, data: FirmwareUpdateInfoDataType) -> None:
+        """Initialize."""
+        self.data = data
+
+    @property
+    def version(self) -> str:
+        """Return the firmware version."""
+        return self.data["version"]
+
+    @property
+    def changelog(self) -> str:
+        """Return the firmware changelog."""
+        return self.data["changelog"]
+
+    @property
+    def files(self) -> List[FirmwareUpdateFileInfo]:
+        """Return the firmware files."""
+        return [FirmwareUpdateFileInfo(file) for file in self.data["files"]]

--- a/zwave_js_server/model/firmware.py
+++ b/zwave_js_server/model/firmware.py
@@ -187,8 +187,13 @@ class FirmwareUpdateInfo:
 
     version: str
     changelog: str
-    files: Union[List[FirmwareUpdateFileInfo], List[FirmwareUpdateFileInfoDataType]]
+    files: List[FirmwareUpdateFileInfo]
 
-    def __post_init__(self) -> None:
-        """Post initialization."""
-        self.files = [FirmwareUpdateFileInfo(**file) for file in self.files]
+    @classmethod
+    def from_dict(cls, data: FirmwareUpdateInfoDataType) -> "FirmwareUpdateInfo":
+        """Initialize from dict."""
+        return FirmwareUpdateInfo(
+            version=data["version"],
+            changelog=data["changelog"],
+            files=[FirmwareUpdateFileInfo(**file) for file in data["files"]],
+        )

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -670,14 +670,14 @@ class Node(EventBase):
         )
         self.data["location"] = location
 
-    async def async_get_firmware_update_progress(self) -> bool:
+    async def async_is_firmware_update_in_progress(self) -> bool:
         """
-        Send getFirmwareUpdateProgress command to Node.
+        Send isFirmwareUpdateInProgress command to Node.
 
         If `True`, a firmware update for this node is in progress.
         """
         data = await self.async_send_command(
-            "get_firmware_update_progress", require_schema=18, wait_for_result=True
+            "is_firmware_update_in_progress", require_schema=21, wait_for_result=True
         )
         assert data
         return cast(bool, data["progress"])

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -522,6 +522,20 @@ class Node(EventBase):
             cast(FirmwareUpdateCapabilitiesDataType, data["capabilities"])
         )
 
+    async def async_get_firmware_update_capabilities_cached(
+        self,
+    ) -> FirmwareUpdateCapabilities:
+        """Send getFirmwareUpdateCapabilitiesCached command to Node."""
+        data = await self.async_send_command(
+            "get_firmware_update_capabilities_cached",
+            require_schema=21,
+            wait_for_result=True,
+        )
+        assert data
+        return FirmwareUpdateCapabilities(
+            cast(FirmwareUpdateCapabilitiesDataType, data["capabilities"])
+        )
+
     async def async_abort_firmware_update(self) -> None:
         """Send abortFirmwareUpdate command to Node."""
         await self.async_send_command("abort_firmware_update", wait_for_result=True)

--- a/zwave_js_server/model/notification.py
+++ b/zwave_js_server/model/notification.py
@@ -33,7 +33,9 @@ class EntryControlNotificationArgsDataType(TypedDict, total=False):
     """Represent args for a Entry Control CC notification event data dict type."""
 
     eventType: int  # required
+    eventTypeLabel: str  # required
     dataType: int  # required
+    dataTypeLabel: str  # required
     eventData: Union[str, Dict[str, Any]]
 
 
@@ -67,9 +69,19 @@ class EntryControlNotification:
         return self.data["args"]["eventType"]
 
     @property
+    def event_type_label(self) -> str:
+        """Return event type label property."""
+        return self.data["args"]["eventTypeLabel"]
+
+    @property
     def data_type(self) -> int:
         """Return data type property."""
         return self.data["args"]["dataType"]
+
+    @property
+    def data_type_label(self) -> str:
+        """Return data type label property."""
+        return self.data["args"]["dataTypeLabel"]
 
     @property
     def event_data(self) -> Optional[str]:
@@ -191,6 +203,7 @@ class MultilevelSwitchNotificationArgsDataType(TypedDict, total=False):
     """Represent args for a Multi Level Switch CC notification event data dict type."""
 
     eventType: int  # required
+    eventTypeLabel: str  # required
     direction: str
 
 
@@ -224,6 +237,11 @@ class MultilevelSwitchNotification:
     def event_type(self) -> MultilevelSwitchCommand:
         """Return event type property."""
         return MultilevelSwitchCommand(self.data["args"]["eventType"])
+
+    @property
+    def event_type_label(self) -> str:
+        """Return event type label property."""
+        return self.data["args"]["eventTypeLabel"]
 
     @property
     def direction(self) -> Optional[str]:


### PR DESCRIPTION
9.6.0 introduced some new parameters to the Entry Control CC And Multilevel Switch CC notification events: https://github.com/zwave-js/node-zwave-js/releases/tag/v9.6.0

All other changes/additions are captured here: https://github.com/zwave-js/zwave-js-server/pull/685 and https://github.com/zwave-js/zwave-js-server/pull/686