### PR TITLE
Fix value updated logic

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -568,6 +568,7 @@ async def test_value_updated_events(multisensor_6):
                 "endpoint": 0,
                 "property": 2,
                 "propertyName": "Stay Awake in Battery Mode",
+                "value": -1,
                 "newValue": 1,
                 "prevValue": 0,
             },
@@ -587,6 +588,7 @@ async def test_value_updated_events(multisensor_6):
     # ensure that the value's state data was updated and that old keys were removed
     val = node.values[value_id]
     assert val.data["value"] == 1
+    assert val.value == 1
     assert "newValue" not in val.data
     assert "prevValue" not in val.data
 

--- a/zwave_js_server/model/controller/inclusion_and_provisioning.py
+++ b/zwave_js_server/model/controller/inclusion_and_provisioning.py
@@ -151,6 +151,7 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "QRProvisioningInformation":
         """Return QRProvisioningInformation from data dict."""
+        # pylint: disable=unexpected-keyword-arg
         cls_instance = cls(
             version=QRCodeVersion(data["version"]),
             security_classes=[

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -265,7 +265,7 @@ class Value:
         self.data.update(data)
         if "newValue" in data:
             self._value = self.data["value"] = data["newValue"]
-        if "value" in data:
+        elif "value" in data:
             self._value = self.data["value"] = data["value"]
         if "metadata" in data:
             self._metadata.update(data["metadata"])


### PR DESCRIPTION
it appears that we have had a bug for some time. Some devices will include the `value` parameter in the `value updated` event. With the current logic, we would use the `value` data (which is basically `prevValue`) and overwrite `newValue`. The reason this didn't get caught before is because after a value update, a refresh would be performed on non supervised CCs that would update the state to the correct value. With v10 and the introduction of supervision to more CCs, this refresh doesn't occur, exposing the bug.

You can confirm this bug by removing the change to the `Value.update` method and keeping the changes to the tests.

Thanks to @kpine for finding this one