### PR TITLE
Filter value ID dict data

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -231,11 +231,7 @@ async def test_set_value(multisensor_6, uuid4, mock_command):
     assert ack_commands[0] == {
         "command": "node.set_value",
         "nodeId": node.node_id,
-        "valueId": {
-            "commandClass": 32,
-            "endpoint": 0,
-            "property": "targetValue"
-        },
+        "valueId": {"commandClass": 32, "endpoint": 0, "property": "targetValue"},
         "value": 42,
         "messageId": uuid4,
     }
@@ -247,11 +243,7 @@ async def test_set_value(multisensor_6, uuid4, mock_command):
     assert ack_commands[1] == {
         "command": "node.set_value",
         "nodeId": node.node_id,
-        "valueId": {
-            "commandClass": 32,
-            "endpoint": 0,
-            "property": "targetValue"
-        },
+        "valueId": {"commandClass": 32, "endpoint": 0, "property": "targetValue"},
         "value": 42,
         "options": {"transitionDuration": 1},
         "messageId": uuid4,
@@ -280,11 +272,7 @@ async def test_poll_value(multisensor_6, uuid4, mock_command):
     assert ack_commands[0] == {
         "command": "node.poll_value",
         "nodeId": node.node_id,
-        "valueId": {
-            "commandClass": 32,
-            "endpoint": 0,
-            "property": "currentValue"
-        },
+        "valueId": {"commandClass": 32, "endpoint": 0, "property": "currentValue"},
         "messageId": uuid4,
     }
 
@@ -438,11 +426,7 @@ async def test_get_value_metadata(multisensor_6, uuid4, mock_command):
     assert ack_commands[0] == {
         "command": "node.get_value_metadata",
         "nodeId": node.node_id,
-        "valueId": {
-            "commandClass": 32,
-            "endpoint": 0,
-            "property": "targetValue"
-        },
+        "valueId": {"commandClass": 32, "endpoint": 0, "property": "targetValue"},
         "messageId": uuid4,
     }
 

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -37,7 +37,7 @@ from zwave_js_server.model.node.health_check import (
     RouteHealthCheckResultDataType,
 )
 from zwave_js_server.model.node.statistics import NodeStatistics
-from zwave_js_server.model.value import ConfigurationValue, get_value_id
+from zwave_js_server.model.value import ConfigurationValue, get_value_id_str
 
 from .. import load_fixture
 
@@ -225,14 +225,17 @@ async def test_set_value(multisensor_6, uuid4, mock_command):
         {"success": True},
     )
     value_id = "52-32-0-targetValue"
-    value = node.values[value_id]
     assert await node.async_set_value(value_id, 42) is None
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "node.set_value",
         "nodeId": node.node_id,
-        "valueId": value.data,
+        "valueId": {
+            "commandClass": 32,
+            "endpoint": 0,
+            "property": "targetValue"
+        },
         "value": 42,
         "messageId": uuid4,
     }
@@ -244,7 +247,11 @@ async def test_set_value(multisensor_6, uuid4, mock_command):
     assert ack_commands[1] == {
         "command": "node.set_value",
         "nodeId": node.node_id,
-        "valueId": value.data,
+        "valueId": {
+            "commandClass": 32,
+            "endpoint": 0,
+            "property": "targetValue"
+        },
         "value": 42,
         "options": {"transitionDuration": 1},
         "messageId": uuid4,
@@ -267,14 +274,17 @@ async def test_poll_value(multisensor_6, uuid4, mock_command):
         {"result": "something"},
     )
     value_id = "52-32-0-currentValue"
-    value = node.values[value_id]
     assert await node.async_poll_value(value_id) is None
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "node.poll_value",
         "nodeId": node.node_id,
-        "valueId": value.data,
+        "valueId": {
+            "commandClass": 32,
+            "endpoint": 0,
+            "property": "currentValue"
+        },
         "messageId": uuid4,
     }
 
@@ -428,7 +438,11 @@ async def test_get_value_metadata(multisensor_6, uuid4, mock_command):
     assert ack_commands[0] == {
         "command": "node.get_value_metadata",
         "nodeId": node.node_id,
-        "valueId": value.data,
+        "valueId": {
+            "commandClass": 32,
+            "endpoint": 0,
+            "property": "targetValue"
+        },
         "messageId": uuid4,
     }
 
@@ -1555,7 +1569,7 @@ async def test_get_state(
 ):
     """Test node.get_state command."""
     node = multisensor_6
-    value_id = get_value_id(node, 32, "currentValue", 0)
+    value_id = get_value_id_str(node, 32, "currentValue", 0)
 
     # Verify original values
     assert node.endpoints[0].installer_icon == 3079

--- a/test/model/test_value.py
+++ b/test/model/test_value.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 from zwave_js_server.const import ConfigurationValueType
 from zwave_js_server.model.node import Node
-from zwave_js_server.model.value import get_value_id
+from zwave_js_server.model.value import get_value_id_str
 
 
 def test_value_size(lock_schlage_be469):
@@ -18,7 +18,7 @@ def test_buffer_dict(client, idl_101_lock_state):
     node_data = deepcopy(idl_101_lock_state)
     node = Node(client, node_data)
 
-    value_id = get_value_id(node, 99, "userCode", 0, 3)
+    value_id = get_value_id_str(node, 99, "userCode", 0, 3)
 
     assert value_id == "26-99-0-userCode-3"
 
@@ -32,7 +32,7 @@ def test_unparseable_value(client, unparseable_json_string_value_state):
     """Test that we handle string value with unparseable format."""
     node = Node(client, unparseable_json_string_value_state)
 
-    value_id = get_value_id(node, 99, "userCode", 0, 4)
+    value_id = get_value_id_str(node, 99, "userCode", 0, 4)
 
     assert value_id == "20-99-0-userCode-4"
     assert value_id not in node.values
@@ -43,13 +43,13 @@ def test_allow_manual_entry(client, inovelli_switch_state):
     node = Node(client, inovelli_switch_state)
 
     config_values = node.get_configuration_values()
-    value_id = get_value_id(node, 112, 8, 0, 255)
+    value_id = get_value_id_str(node, 112, 8, 0, 255)
 
     zwave_value = config_values[value_id]
 
     assert zwave_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
 
-    value_id = get_value_id(node, 112, 8, 0, 65280)
+    value_id = get_value_id_str(node, 112, 8, 0, 65280)
     zwave_value = config_values[value_id]
 
     assert zwave_value.configuration_value_type == ConfigurationValueType.ENUMERATED

--- a/test/util/command_class/test_meter.py
+++ b/test/util/command_class/test_meter.py
@@ -10,7 +10,12 @@ from zwave_js_server.const.command_class.meter import (
 )
 from zwave_js_server.exceptions import InvalidCommandClass, UnknownValueData
 from zwave_js_server.model.node import Node
-from zwave_js_server.model.value import MetaDataType, Value, ValueDataType, get_value_id_str
+from zwave_js_server.model.value import (
+    MetaDataType,
+    Value,
+    ValueDataType,
+    get_value_id_str,
+)
 from zwave_js_server.util.command_class.meter import (
     get_meter_scale_type,
     get_meter_type,

--- a/test/util/command_class/test_meter.py
+++ b/test/util/command_class/test_meter.py
@@ -10,7 +10,7 @@ from zwave_js_server.const.command_class.meter import (
 )
 from zwave_js_server.exceptions import InvalidCommandClass, UnknownValueData
 from zwave_js_server.model.node import Node
-from zwave_js_server.model.value import MetaDataType, Value, ValueDataType, get_value_id
+from zwave_js_server.model.value import MetaDataType, Value, ValueDataType, get_value_id_str
 from zwave_js_server.util.command_class.meter import (
     get_meter_scale_type,
     get_meter_type,
@@ -21,11 +21,11 @@ async def test_get_meter_type(inovelli_switch: Node):
     """Test get_meter_type function."""
     node = inovelli_switch
 
-    value_id = get_value_id(node, CommandClass.SWITCH_BINARY, "currentValue")
+    value_id = get_value_id_str(node, CommandClass.SWITCH_BINARY, "currentValue")
     with pytest.raises(InvalidCommandClass):
         get_meter_type(node.values.get(value_id))
 
-    value_id = get_value_id(node, CommandClass.METER, "value", property_key=65537)
+    value_id = get_value_id_str(node, CommandClass.METER, "value", property_key=65537)
     assert get_meter_type(node.values.get(value_id)) == MeterType.ELECTRIC
 
 
@@ -52,7 +52,7 @@ async def test_get_meter_scale_type(inovelli_switch: Node):
     """Test get_meter_scale_type function."""
     node = inovelli_switch
 
-    value_id = get_value_id(node, CommandClass.METER, "value", property_key=65537)
+    value_id = get_value_id_str(node, CommandClass.METER, "value", property_key=65537)
     assert (
         get_meter_scale_type(node.values.get(value_id)) == ElectricScale.KILOWATT_HOUR
     )

--- a/test/util/command_class/test_multilevel_sensor.py
+++ b/test/util/command_class/test_multilevel_sensor.py
@@ -8,7 +8,12 @@ from zwave_js_server.const.command_class.multilevel_sensor import (
 )
 from zwave_js_server.exceptions import InvalidCommandClass, UnknownValueData
 from zwave_js_server.model.node import Node
-from zwave_js_server.model.value import MetaDataType, Value, ValueDataType, get_value_id_str
+from zwave_js_server.model.value import (
+    MetaDataType,
+    Value,
+    ValueDataType,
+    get_value_id_str,
+)
 from zwave_js_server.util.command_class.multilevel_sensor import (
     CC_SPECIFIC_SCALE,
     CC_SPECIFIC_SENSOR_TYPE,

--- a/test/util/command_class/test_multilevel_sensor.py
+++ b/test/util/command_class/test_multilevel_sensor.py
@@ -8,7 +8,7 @@ from zwave_js_server.const.command_class.multilevel_sensor import (
 )
 from zwave_js_server.exceptions import InvalidCommandClass, UnknownValueData
 from zwave_js_server.model.node import Node
-from zwave_js_server.model.value import MetaDataType, Value, ValueDataType, get_value_id
+from zwave_js_server.model.value import MetaDataType, Value, ValueDataType, get_value_id_str
 from zwave_js_server.util.command_class.multilevel_sensor import (
     CC_SPECIFIC_SCALE,
     CC_SPECIFIC_SENSOR_TYPE,
@@ -21,11 +21,11 @@ async def test_get_multilevel_sensor_type(multisensor_6: Node):
     """Test get_multilevel_sensor_type function."""
     node = multisensor_6
 
-    value_id = get_value_id(node, CommandClass.SENSOR_BINARY, "Any")
+    value_id = get_value_id_str(node, CommandClass.SENSOR_BINARY, "Any")
     with pytest.raises(InvalidCommandClass):
         get_multilevel_sensor_type(node.values.get(value_id))
 
-    value_id = get_value_id(node, CommandClass.SENSOR_MULTILEVEL, "Air temperature")
+    value_id = get_value_id_str(node, CommandClass.SENSOR_MULTILEVEL, "Air temperature")
     assert (
         get_multilevel_sensor_type(node.values.get(value_id))
         == MultilevelSensorType.AIR_TEMPERATURE
@@ -36,7 +36,7 @@ async def test_get_invalid_multilevel_sensor_type(invalid_multilevel_sensor_type
     """Test receiving an invalid multilevel sensor type."""
     node = invalid_multilevel_sensor_type
 
-    value_id = get_value_id(
+    value_id = get_value_id_str(
         node, CommandClass.SENSOR_MULTILEVEL, "UNKNOWN (0x00)", endpoint=2
     )
     with pytest.raises(UnknownValueData):
@@ -47,7 +47,7 @@ async def test_get_multilevel_sensor_scale_type(multisensor_6: Node):
     """Test get_multilevel_sensor_scale_type function."""
     node = multisensor_6
 
-    value_id = get_value_id(node, CommandClass.SENSOR_MULTILEVEL, "Air temperature")
+    value_id = get_value_id_str(node, CommandClass.SENSOR_MULTILEVEL, "Air temperature")
     assert (
         get_multilevel_sensor_scale_type(node.values.get(value_id))
         == TemperatureScale.CELSIUS

--- a/test/util/test_lock.py
+++ b/test/util/test_lock.py
@@ -65,22 +65,10 @@ async def test_set_usercode(lock_schlage_be469, mock_command, uuid4):
         "nodeId": 20,
         "messageId": uuid4,
         "valueId": {
-            "commandClassName": "User Code",
             "commandClass": 99,
             "endpoint": 0,
             "property": "userCode",
-            "propertyName": "userCode",
             "propertyKey": 1,
-            "propertyKeyName": "1",
-            "metadata": {
-                "type": "string",
-                "readable": True,
-                "writeable": True,
-                "minLength": 4,
-                "maxLength": 10,
-                "label": "User Code (1)",
-            },
-            "value": "**********",
         },
         "value": "1234",
     }
@@ -116,25 +104,10 @@ async def test_clear_usercode(lock_schlage_be469, mock_command, uuid4):
         "nodeId": 20,
         "messageId": uuid4,
         "valueId": {
-            "commandClassName": "User Code",
             "commandClass": 99,
             "endpoint": 0,
             "property": "userIdStatus",
-            "propertyName": "userIdStatus",
             "propertyKey": 1,
-            "propertyKeyName": "1",
-            "metadata": {
-                "type": "number",
-                "readable": True,
-                "writeable": True,
-                "label": "User ID status (1)",
-                "states": {
-                    "0": "Available",
-                    "1": "Enabled",
-                    "2": "Disabled",
-                },
-            },
-            "value": 1,
         },
         "value": 0,
     }

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -64,7 +64,12 @@ async def test_configuration_parameter_values(
     assert ack_commands_2[0] == {
         "command": "node.set_value",
         "nodeId": node_2.node_id,
-        "valueId": value.data,
+        "valueId": {
+            "commandClass": 112,
+            "endpoint": 0,
+            "property": 8,
+            "propertyKey": 255,
+        },
         "value": 190,
         "messageId": uuid4,
     }
@@ -78,7 +83,12 @@ async def test_configuration_parameter_values(
     assert ack_commands_2[1] == {
         "command": "node.set_value",
         "nodeId": node_2.node_id,
-        "valueId": value.data,
+        "valueId": {
+            "commandClass": 112,
+            "endpoint": 0,
+            "property": 8,
+            "propertyKey": 255,
+        },
         "value": 170,
         "messageId": uuid4,
     }
@@ -115,7 +125,11 @@ async def test_configuration_parameter_values(
     assert ack_commands[2] == {
         "command": "node.set_value",
         "nodeId": node.node_id,
-        "valueId": value.data,
+        "valueId": {
+            "commandClass": 112,
+            "endpoint": 0,
+            "property": 1,
+        },
         "value": 4,
         "messageId": uuid4,
     }

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__package__)
 
 
-def get_value_id_dict_from_value_data(value_data: ValueDataType) -> Dict[str, Any]:
+def _get_value_id_dict_from_value_data(value_data: ValueDataType) -> Dict[str, Any]:
     """Return a value ID dict from ValueDataType."""
     data = {
         "commandClass": value_data["commandClass"],
@@ -451,7 +451,7 @@ class Node(EventBase):
             raise UnwriteableValue
 
         cmd_args = {
-            "valueId": get_value_id_dict_from_value_data(val.data),
+            "valueId": _get_value_id_dict_from_value_data(val.data),
             "value": new_value,
         }
         if options:
@@ -520,7 +520,7 @@ class Node(EventBase):
         # the value object needs to be send to the server
         data = await self.async_send_command(
             "get_value_metadata",
-            valueId=get_value_id_dict_from_value_data(val.data),
+            valueId=_get_value_id_dict_from_value_data(val.data),
             wait_for_result=True,
         )
         return ValueMetadata(cast(MetaDataType, data))
@@ -564,7 +564,7 @@ class Node(EventBase):
             val = self.values[val]
         await self.async_send_command(
             "poll_value",
-            valueId=get_value_id_dict_from_value_data(val.data),
+            valueId=_get_value_id_dict_from_value_data(val.data),
             require_schema=1,
         )
 

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -66,9 +66,8 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__package__)
 
 
-def get_value_id_dict_from_value(val: Union[Value, ValueDataType]) -> Dict[str, Any]:
-    """Return a value ID dict from Value."""
-    value_data = val.data if isinstance(val, Value) else val
+def get_value_id_dict_from_value(value_data: ValueDataType) -> Dict[str, Any]:
+    """Return a value ID dict from ValueDataType."""
     data = {
         "commandClass": value_data["commandClass"],
         "property": value_data["property"],
@@ -452,7 +451,7 @@ class Node(EventBase):
             raise UnwriteableValue
 
         cmd_args = {
-            "valueId": get_value_id_dict_from_value(val),
+            "valueId": get_value_id_dict_from_value(val.data),
             "value": new_value,
         }
         if options:
@@ -521,7 +520,7 @@ class Node(EventBase):
         # the value object needs to be send to the server
         data = await self.async_send_command(
             "get_value_metadata",
-            valueId=get_value_id_dict_from_value(val),
+            valueId=get_value_id_dict_from_value(val.data),
             wait_for_result=True,
         )
         return ValueMetadata(cast(MetaDataType, data))
@@ -564,7 +563,7 @@ class Node(EventBase):
         if not isinstance(val, Value):
             val = self.values[val]
         await self.async_send_command(
-            "poll_value", valueId=get_value_id_dict_from_value(val), require_schema=1
+            "poll_value", valueId=get_value_id_dict_from_value(val.data), require_schema=1
         )
 
     async def async_ping(self) -> bool:

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__package__)
 
 
-def get_value_id_dict_from_value(val: Union[Value, Dict[str, Any]]) -> Dict[str, Any]:
+def get_value_id_dict_from_value(val: Union[Value, ValueDataType]) -> Dict[str, Any]:
     """Return a value ID dict from Value."""
     value_data = val.data if isinstance(val, Value) else val
     data = {

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__package__)
 
 
-def get_value_id_dict_from_value(value_data: ValueDataType) -> Dict[str, Any]:
+def get_value_id_dict_from_value_data(value_data: ValueDataType) -> Dict[str, Any]:
     """Return a value ID dict from ValueDataType."""
     data = {
         "commandClass": value_data["commandClass"],
@@ -451,7 +451,7 @@ class Node(EventBase):
             raise UnwriteableValue
 
         cmd_args = {
-            "valueId": get_value_id_dict_from_value(val.data),
+            "valueId": get_value_id_dict_from_value_data(val.data),
             "value": new_value,
         }
         if options:
@@ -520,7 +520,7 @@ class Node(EventBase):
         # the value object needs to be send to the server
         data = await self.async_send_command(
             "get_value_metadata",
-            valueId=get_value_id_dict_from_value(val.data),
+            valueId=get_value_id_dict_from_value_data(val.data),
             wait_for_result=True,
         )
         return ValueMetadata(cast(MetaDataType, data))
@@ -563,7 +563,9 @@ class Node(EventBase):
         if not isinstance(val, Value):
             val = self.values[val]
         await self.async_send_command(
-            "poll_value", valueId=get_value_id_dict_from_value(val.data), require_schema=1
+            "poll_value",
+            valueId=get_value_id_dict_from_value_data(val.data),
+            require_schema=1,
         )
 
     async def async_ping(self) -> bool:

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -46,7 +46,7 @@ from ..value import (
     ValueDataType,
     ValueMetadata,
     ValueNotification,
-    _get_value_id_from_dict,
+    _get_value_id_str_from_dict,
     _init_value,
 )
 from .data_model import NodeDataType
@@ -64,6 +64,22 @@ if TYPE_CHECKING:
 
 
 _LOGGER = logging.getLogger(__package__)
+
+
+def get_value_id_dict_from_value(val: Union[Value, Dict[str, Any]]) -> Dict[str, Any]:
+    """Return a value ID dict from Value."""
+    value_data = val.data if isinstance(val, Value) else val
+    data = {
+        "commandClass": value_data["commandClass"],
+        "property": value_data["property"],
+    }
+
+    if (endpoint := value_data.get("endpoint")) is not None:
+        data["endpoint"] = endpoint
+    if (property_key := value_data.get("propertyKey")) is not None:
+        data["propertyKey"] = property_key
+
+    return data
 
 
 class Node(EventBase):
@@ -322,7 +338,7 @@ class Node(EventBase):
         self._statistics = NodeStatistics(self.client, self.data.get("statistics"))
 
         # Remove stale values
-        value_ids = (_get_value_id_from_dict(self, val) for val in data["values"])
+        value_ids = (_get_value_id_str_from_dict(self, val) for val in data["values"])
         self.values = {
             value_id: val
             for value_id, val in self.values.items()
@@ -332,7 +348,7 @@ class Node(EventBase):
         # Populate new values
         for val in data["values"]:
             try:
-                if (value_id := _get_value_id_from_dict(self, val)) in self.values:
+                if (value_id := _get_value_id_str_from_dict(self, val)) in self.values:
                     self.values[value_id].update(val)
                 else:
                     self.values[value_id] = _init_value(self, val)
@@ -436,7 +452,7 @@ class Node(EventBase):
             raise UnwriteableValue
 
         cmd_args = {
-            "valueId": val.data,
+            "valueId": get_value_id_dict_from_value(val),
             "value": new_value,
         }
         if options:
@@ -504,7 +520,9 @@ class Node(EventBase):
             val = self.values[val]
         # the value object needs to be send to the server
         data = await self.async_send_command(
-            "get_value_metadata", valueId=val.data, wait_for_result=True
+            "get_value_metadata",
+            valueId=get_value_id_dict_from_value(val),
+            wait_for_result=True,
         )
         return ValueMetadata(cast(MetaDataType, data))
 
@@ -545,7 +563,9 @@ class Node(EventBase):
         # a value may be specified as value_id or the value itself
         if not isinstance(val, Value):
             val = self.values[val]
-        await self.async_send_command("poll_value", valueId=val.data, require_schema=1)
+        await self.async_send_command(
+            "poll_value", valueId=get_value_id_dict_from_value(val), require_schema=1
+        )
 
     async def async_ping(self) -> bool:
         """Send ping command to Node."""
@@ -787,13 +807,13 @@ class Node(EventBase):
         return next(
             idx
             for idx in range(len(values))
-            if _get_value_id_from_dict(self, values[idx]) == value_id
+            if _get_value_id_str_from_dict(self, values[idx]) == value_id
         )
 
     def handle_value_updated(self, event: Event) -> None:
         """Process a node value updated event."""
         evt_val_data: ValueDataType = event.data["args"]
-        value_id = _get_value_id_from_dict(self, evt_val_data)
+        value_id = _get_value_id_str_from_dict(self, evt_val_data)
         value = self.values.get(value_id)
         if value is None:
             value = _init_value(self, evt_val_data)
@@ -813,7 +833,7 @@ class Node(EventBase):
 
     def handle_value_removed(self, event: Event) -> None:
         """Process a node value removed event."""
-        value_id = _get_value_id_from_dict(self, event.data["args"])
+        value_id = _get_value_id_str_from_dict(self, event.data["args"])
         event.data["value"] = self.values.pop(value_id)
         self.data["values"].pop(self.value_data_idx(value_id))
 
@@ -822,7 +842,7 @@ class Node(EventBase):
         # if value is found, use value data as base and update what is provided
         # in the event, otherwise use the event data
         event_data = event.data["args"]
-        if value := self.values.get(_get_value_id_from_dict(self, event_data)):
+        if value := self.values.get(_get_value_id_str_from_dict(self, event_data)):
             value_notification = ValueNotification(
                 self, cast(ValueDataType, dict(value.data))
             )

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -63,9 +63,9 @@ def _init_value(
     return Value(node, val)
 
 
-def _get_value_id_from_dict(node: "Node", val: ValueDataType) -> str:
-    """Return ID of value from ValueDataType dict."""
-    return get_value_id(
+def _get_value_id_str_from_dict(node: "Node", val: ValueDataType) -> str:
+    """Return string ID of value from ValueDataType dict."""
+    return get_value_id_str(
         node,
         val["commandClass"],
         val["property"],
@@ -74,14 +74,14 @@ def _get_value_id_from_dict(node: "Node", val: ValueDataType) -> str:
     )
 
 
-def get_value_id(
+def get_value_id_str(
     node: "Node",
     command_class: int,
     property_: Union[str, int],
     endpoint: Optional[int] = None,
     property_key: Optional[Union[str, int]] = None,
 ) -> str:
-    """Return ID of value."""
+    """Return string ID of value."""
     # If endpoint is not provided, assume root endpoint
     endpoint_ = endpoint or 0
     value_id = f"{node.node_id}-{command_class}-{endpoint_}-{property_}"
@@ -196,7 +196,7 @@ class Value:
     @property
     def value_id(self) -> str:
         """Return value ID."""
-        return _get_value_id_from_dict(self.node, self.data)
+        return _get_value_id_str_from_dict(self.node, self.data)
 
     @property
     def metadata(self) -> ValueMetadata:

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -13,13 +13,13 @@ from ..const.command_class.lock import (
 )
 from ..exceptions import NotFoundError
 from ..model.node import Node
-from ..model.value import Value, get_value_id
+from ..model.value import Value, get_value_id_str
 
 
 def get_code_slot_value(node: Node, code_slot: int, property_name: str) -> Value:
     """Get a code slot value."""
     value = node.values.get(
-        get_value_id(
+        get_value_id_str(
             node,
             CommandClass.USER_CODE,
             property_name,

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, cast
 from ..client import Client
 from ..const import TARGET_VALUE_PROPERTY, CommandClass
 from ..exceptions import NotFoundError
-from ..model.node import Node, get_value_id_dict_from_value_data
+from ..model.node import Node, _get_value_id_dict_from_value_data
 from ..model.value import ValueDataType, _get_value_id_str_from_dict
 
 
@@ -60,7 +60,7 @@ async def async_multicast_set_value(
         client,
         "set_value",
         nodes,
-        valueId=get_value_id_dict_from_value_data(value_data),
+        valueId=_get_value_id_dict_from_value_data(value_data),
         value=new_value,
         options=options,
         require_schema=5,

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, cast
 from ..client import Client
 from ..const import TARGET_VALUE_PROPERTY, CommandClass
 from ..exceptions import NotFoundError
-from ..model.node import Node, get_value_id_dict_from_value
+from ..model.node import Node, get_value_id_dict_from_value_data
 from ..model.value import ValueDataType, _get_value_id_str_from_dict
 
 
@@ -60,7 +60,7 @@ async def async_multicast_set_value(
         client,
         "set_value",
         nodes,
-        valueId=get_value_id_dict_from_value(value_data),
+        valueId=get_value_id_dict_from_value_data(value_data),
         value=new_value,
         options=options,
         require_schema=5,

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -4,8 +4,8 @@ from typing import Any, List, Optional, cast
 from ..client import Client
 from ..const import TARGET_VALUE_PROPERTY, CommandClass
 from ..exceptions import NotFoundError
-from ..model.node import Node
-from ..model.value import ValueDataType, _get_value_id_from_dict
+from ..model.node import Node, get_value_id_dict_from_value
+from ..model.value import ValueDataType, _get_value_id_str_from_dict
 
 
 async def _async_send_command(
@@ -45,7 +45,7 @@ async def async_multicast_set_value(
             and value_data["property"] == TARGET_VALUE_PROPERTY
         ):
             break
-        value_id = _get_value_id_from_dict(node, value_data)
+        value_id = _get_value_id_str_from_dict(node, value_data)
         # Check that the value exists on the node
         if value_id not in node.values:
             raise NotFoundError(f"Node {node} doesn't have value {value_id}")
@@ -60,7 +60,7 @@ async def async_multicast_set_value(
         client,
         "set_value",
         nodes,
-        valueId=value_data,
+        valueId=get_value_id_dict_from_value(value_data),
         value=new_value,
         options=options,
         require_schema=5,

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -100,7 +100,10 @@ async def async_bulk_set_partial_config_parameters(
     if not partial_param_values:
         # If we find a value with this property_, we know this value isn't split
         # into partial params
-        if get_value_id_str(node, CommandClass.CONFIGURATION, property_) in config_values:
+        if (
+            get_value_id_str(node, CommandClass.CONFIGURATION, property_)
+            in config_values
+        ):
             # If the new value is provided as a dict, we don't have enough information
             # to set the parameter.
             if isinstance(new_value, dict):

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -12,7 +12,7 @@ from ..exceptions import (
     ValueTypeError,
 )
 from ..model.node import Node
-from ..model.value import ConfigurationValue, get_value_id
+from ..model.value import ConfigurationValue, get_value_id_str
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ async def async_set_config_parameter(
                 f"{property_or_property_name} could not be found"
             ) from None
     else:
-        value_id = get_value_id(
+        value_id = get_value_id_str(
             node,
             CommandClass.CONFIGURATION,
             property_or_property_name,
@@ -100,7 +100,7 @@ async def async_bulk_set_partial_config_parameters(
     if not partial_param_values:
         # If we find a value with this property_, we know this value isn't split
         # into partial params
-        if get_value_id(node, CommandClass.CONFIGURATION, property_) in config_values:
+        if get_value_id_str(node, CommandClass.CONFIGURATION, property_) in config_values:
             # If the new value is provided as a dict, we don't have enough information
             # to set the parameter.
             if isinstance(new_value, dict):
@@ -258,7 +258,7 @@ def _get_int_from_partials_dict(
         # If the dict key is a property key, we can generate the value ID to find the
         # partial value
         if isinstance(property_key_or_name, int):
-            value_id = get_value_id(
+            value_id = get_value_id_str(
                 node,
                 CommandClass.CONFIGURATION,
                 property_,


### PR DESCRIPTION
The reason https://github.com/home-assistant-libs/zwave-js-server-python/pull/480 became an issue is because we were previously sending the full value data, including metadata and the value of the value, to the driver. The driver would store this data in the value DB and then send it back but the interface expects just the four properties (cc, endpoint, property, property_key). In this PR we filter the data down to only send the dict value.

Note that I changed `get_value_id` to `get_value_id_str` to distinguish between the dict value ID and the string value ID - this will have to be updated in core when we bump the dependency to include this PR