### PR TITLE
Drop python 3.8 support

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4.2.0
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install wheel
         run: >-
           pip install wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["test.*", "test"]),
     package_data={"zwave_js_server": ["py.typed"]},
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=["aiohttp>3", "pydantic>=1.9.0"],
     entry_points={
         "console_scripts": ["zwave-js-server-python = zwave_js_server.__main__:main"]
@@ -32,7 +32,6 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Topic :: Home Automation",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py38, py39, py310, lint, mypy
+envlist = py39, py310, lint, mypy
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.8: py38, lint, mypy
-  3.9: py39
+  3.9: py39, lint, mypy
   3.10: py310
 
 [testenv]


### PR DESCRIPTION
The minimum for HA is now python 3.9 so I think we can drop 3.8 support.