### PR TITLE
`async_get_state` cmds return state instead of updating it

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1398,8 +1398,9 @@ async def test_get_state(controller, controller_state, uuid4, mock_command):
         {"state": new_state},
     )
     assert controller.inclusion_state == InclusionState.IDLE
-    assert await controller.async_get_state() is None
-    assert controller.inclusion_state == InclusionState.INCLUDING
+    assert await controller.async_get_state() == new_state
+    # Verify state hasn't changed
+    assert controller.inclusion_state == InclusionState.IDLE
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1586,8 +1586,9 @@ async def test_get_state(
 
     # Verify new values
     assert await node.async_get_state() == new_state
-    assert node.endpoints[0].installer_icon == 1
-    assert node.values[value_id].value == 0
+    # Verify original values are still the same
+    assert node.endpoints[0].installer_icon != 1
+    assert node.values[value_id].value != 0
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1585,7 +1585,7 @@ async def test_get_state(
     )
 
     # Verify new values
-    assert await node.async_get_state() is None
+    assert await node.async_get_state() == new_state
     assert node.endpoints[0].installer_icon == 1
     assert node.values[value_id].value == 0
 

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -620,12 +620,12 @@ class Controller(EventBase):
         )
         return cast(Optional[bool], data.get("supported"))
 
-    async def async_get_state(self) -> None:
+    async def async_get_state(self) -> ControllerDataType:
         """Get controller state."""
         data = await self.client.async_send_command(
             {"command": "controller.get_state"}, require_schema=14
         )
-        self.update(data["state"])
+        return cast(ControllerDataType, data["state"])
 
     async def async_backup_nvm_raw(self) -> bytes:
         """Send backupNVMRaw command to Controller."""

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -660,14 +660,12 @@ class Node(EventBase):
         assert data
         return RouteHealthCheckSummary(data["summary"])
 
-    async def async_get_state(self, update_internal_state: bool = True) -> NodeDataType:
+    async def async_get_state(self) -> NodeDataType:
         """Get node state."""
         data = await self.async_send_command(
             "get_state", require_schema=14, wait_for_result=True
         )
         assert data
-        if update_internal_state:
-            self.update(data["state"])
         return cast(NodeDataType, data["state"])
 
     async def async_set_name(

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -660,7 +660,7 @@ class Node(EventBase):
         assert data
         return RouteHealthCheckSummary(data["summary"])
 
-    async def async_get_state(self, update_internal_state: bool = True) -> None:
+    async def async_get_state(self, update_internal_state: bool = True) -> NodeDataType:
         """Get node state."""
         data = await self.async_send_command(
             "get_state", require_schema=14, wait_for_result=True
@@ -668,6 +668,7 @@ class Node(EventBase):
         assert data
         if update_internal_state:
             self.update(data["state"])
+        return cast(NodeDataType, data["state"])
 
     async def async_set_name(
         self, name: str, update_cc: bool = True, wait_for_result: Optional[bool] = None

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -660,13 +660,14 @@ class Node(EventBase):
         assert data
         return RouteHealthCheckSummary(data["summary"])
 
-    async def async_get_state(self) -> None:
+    async def async_get_state(self, update_internal_state: bool = True) -> None:
         """Get node state."""
         data = await self.async_send_command(
             "get_state", require_schema=14, wait_for_result=True
         )
         assert data
-        self.update(data["state"])
+        if update_internal_state:
+            self.update(data["state"])
 
     async def async_set_name(
         self, name: str, update_cc: bool = True, wait_for_result: Optional[bool] = None


### PR DESCRIPTION
It occurred to me while troubleshooting an issue that it would be nice to get both the lib state and driver state in the device diagnostics dump (config entry gets the driver state, we may want to consider adding the lib state). We have the async_get_state command but currently it just updates the internal state. With this new flag, an application like HA could call this command to retrieve the state without updating the internal state for diagnostics purposes