### PR TITLE
Allow upstream application to provide its user agent

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -211,7 +211,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 22,
+        "maxSchemaVersion": 23,
     }
 
 

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1599,7 +1599,7 @@ async def test_get_available_firmware_updates(multisensor_6, uuid4, mock_command
         },
     )
     updates = await multisensor_6.client.driver.controller.async_get_available_firmware_updates(
-        multisensor_6, "test"
+        multisensor_6, "test", {"test": "test"}
     )
 
     assert len(updates) == 1
@@ -1617,6 +1617,7 @@ async def test_get_available_firmware_updates(multisensor_6, uuid4, mock_command
         "command": "controller.get_available_firmware_updates",
         "nodeId": multisensor_6.node_id,
         "apiKey": "test",
+        "additionalUserAgentComponents": {"test": "test"},
         "messageId": uuid4,
     }
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -55,7 +55,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 22}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 23}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'api-schema-id'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -3,9 +3,9 @@ import sys
 from enum import Enum, IntEnum
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 22
+MIN_SERVER_SCHEMA_VERSION = 23
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 22
+MAX_SERVER_SCHEMA_VERSION = 23
 
 TYPING_EXTENSION_FOR_TYPEDDICT_REQUIRED = sys.version_info < (3, 9, 2)
 

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -713,17 +713,20 @@ class Controller(EventBase):
         return cast(bool, data["progress"])
 
     async def async_get_available_firmware_updates(
-        self, node: Node, api_key: str
+        self,
+        node: Node,
+        api_key: str,
+        additional_user_agent_components: Optional[Dict[str, str]] = None,
     ) -> List[FirmwareUpdateInfo]:
         """Send getAvailableFirmwareUpdates command to Controller."""
-        data = await self.client.async_send_command(
-            {
-                "command": "controller.get_available_firmware_updates",
-                "nodeId": node.node_id,
-                "apiKey": api_key,
-            },
-            require_schema=22,
-        )
+        payload = {
+            "command": "controller.get_available_firmware_updates",
+            "nodeId": node.node_id,
+            "apiKey": api_key,
+        }
+        if additional_user_agent_components:
+            payload["additionalUserAgentComponents"] = additional_user_agent_components
+        data = await self.client.async_send_command(payload, require_schema=23)
         assert data
         return [FirmwareUpdateInfo.from_dict(update) for update in data["updates"]]
 


### PR DESCRIPTION
Implements https://github.com/zwave-js/node-zwave-js/pull/5070 which hasn't been released yet and doesn't have server support but will soon