### PR TITLE
Improve InvalidServerVersion exception and corresponding message

### DIFF
--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -92,8 +92,7 @@ class Client:
         """Send a command and get a response."""
         if require_schema is not None and require_schema > self.schema_version:
             raise InvalidServerVersion(
-                self.version.server_version,
-                self.version.max_schema_version,
+                self.version,
                 require_schema,
                 "Command not available due to incompatible server version. Update the Z-Wave "
                 f"JS Server to a version that supports at least api schema {require_schema}.",
@@ -113,8 +112,7 @@ class Client:
         """Send a command without waiting for the response."""
         if require_schema is not None and require_schema > self.schema_version:
             raise InvalidServerVersion(
-                self.version.server_version,
-                self.version.max_schema_version,
+                self.version,
                 require_schema,
                 "Command not available due to incompatible server version. Update the Z-Wave "
                 f"JS Server to a version that supports at least api schema {require_schema}.",
@@ -152,8 +150,7 @@ class Client:
         ):
             await self._client.close()
             raise InvalidServerVersion(
-                self.version.server_version,
-                self.version.max_schema_version,
+                self.version,
                 MIN_SERVER_SCHEMA_VERSION,
                 f"Z-Wave JS Server version ({self.version.server_version}) is "
                 "incompatible. Update the Z-Wave JS Server to a version that supports "

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -95,7 +95,7 @@ class Client:
                 self.version.server_version,
                 require_schema,
                 "Command not available due to incompatible server version. Update the Z-Wave "
-                f"JS Server to a version that supports at least api schema {require_schema}."
+                f"JS Server to a version that supports at least api schema {require_schema}.",
             )
         future: "asyncio.Future[dict]" = self._loop.create_future()
         message_id = message["messageId"] = uuid.uuid4().hex
@@ -115,7 +115,7 @@ class Client:
                 self.version.server_version,
                 require_schema,
                 "Command not available due to incompatible server version. Update the Z-Wave "
-                f"JS Server to a version that supports at least api schema {require_schema}."
+                f"JS Server to a version that supports at least api schema {require_schema}.",
             )
         message["messageId"] = uuid.uuid4().hex
         await self._send_json_message(message)

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -92,6 +92,8 @@ class Client:
         """Send a command and get a response."""
         if require_schema is not None and require_schema > self.schema_version:
             raise InvalidServerVersion(
+                self.version.server_version,
+                require_schema,
                 "Command not available due to incompatible server version. Update the Z-Wave "
                 f"JS Server to a version that supports at least api schema {require_schema}."
             )
@@ -110,6 +112,8 @@ class Client:
         """Send a command without waiting for the response."""
         if require_schema is not None and require_schema > self.schema_version:
             raise InvalidServerVersion(
+                self.version.server_version,
+                require_schema,
                 "Command not available due to incompatible server version. Update the Z-Wave "
                 f"JS Server to a version that supports at least api schema {require_schema}."
             )
@@ -146,9 +150,11 @@ class Client:
         ):
             await self._client.close()
             raise InvalidServerVersion(
-                f"Z-Wave JS Server version is incompatible: {self.version.server_version} "
-                "a version is required that supports at least "
-                f"api schema {MIN_SERVER_SCHEMA_VERSION}"
+                self.version.server_version,
+                MIN_SERVER_SCHEMA_VERSION,
+                f"Z-Wave JS Server version ({self.version.server_version}) is "
+                "incompatible. Update the Z-Wave JS Server to a version that supports "
+                f"at least api schema {MIN_SERVER_SCHEMA_VERSION}",
             )
         # store the (highest possible) schema version we're going to use/request
         # this is a bit future proof as we might decide to use a pinned version at some point

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -93,6 +93,7 @@ class Client:
         if require_schema is not None and require_schema > self.schema_version:
             raise InvalidServerVersion(
                 self.version.server_version,
+                self.version.max_schema_version,
                 require_schema,
                 "Command not available due to incompatible server version. Update the Z-Wave "
                 f"JS Server to a version that supports at least api schema {require_schema}.",
@@ -113,6 +114,7 @@ class Client:
         if require_schema is not None and require_schema > self.schema_version:
             raise InvalidServerVersion(
                 self.version.server_version,
+                self.version.max_schema_version,
                 require_schema,
                 "Command not available due to incompatible server version. Update the Z-Wave "
                 f"JS Server to a version that supports at least api schema {require_schema}.",
@@ -151,6 +153,7 @@ class Client:
             await self._client.close()
             raise InvalidServerVersion(
                 self.version.server_version,
+                self.version.max_schema_version,
                 MIN_SERVER_SCHEMA_VERSION,
                 f"Z-Wave JS Server version ({self.version.server_version}) is "
                 "incompatible. Update the Z-Wave JS Server to a version that supports "

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -64,11 +64,16 @@ class InvalidServerVersion(BaseZwaveJSServerError):
     """Exception raised when connected to server with incompatible version."""
 
     def __init__(
-        self, current_version: int, required_version: int, message: str
+        self,
+        server_version: str,
+        server_max_schema_version: int,
+        required_schema_version: int,
+        message: str,
     ) -> None:
         """Initialize an invalid server version error."""
-        self.current_version = current_version
-        self.required_version = required_version
+        self.server_version = server_version
+        self.server_max_schema_version = server_max_schema_version
+        self.required_schema_version = required_schema_version
         super().__init__(message)
 
 

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -63,7 +63,9 @@ class InvalidMessage(BaseZwaveJSServerError):
 class InvalidServerVersion(BaseZwaveJSServerError):
     """Exception raised when connected to server with incompatible version."""
 
-    def __init__(self, current_version: int, required_version: int, message: str) -> None:
+    def __init__(
+        self, current_version: int, required_version: int, message: str
+    ) -> None:
         """Initialize an invalid server version error."""
         self.current_version = current_version
         self.required_version = required_version

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -6,6 +6,7 @@ from .const import RssiError
 if TYPE_CHECKING:
     from .const import CommandClass
     from .model.value import Value
+    from .model.version import VersionInfo
 
 
 class BaseZwaveJSServerError(Exception):
@@ -64,15 +65,11 @@ class InvalidServerVersion(BaseZwaveJSServerError):
     """Exception raised when connected to server with incompatible version."""
 
     def __init__(
-        self,
-        server_version: str,
-        server_max_schema_version: int,
-        required_schema_version: int,
-        message: str,
+        self, version_info: "VersionInfo", required_schema_version: int, message: str
     ) -> None:
         """Initialize an invalid server version error."""
-        self.server_version = server_version
-        self.server_max_schema_version = server_max_schema_version
+        self.server_version = version_info.server_version
+        self.server_max_schema_version = version_info.max_schema_version
         self.required_schema_version = required_schema_version
         super().__init__(message)
 

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -63,6 +63,12 @@ class InvalidMessage(BaseZwaveJSServerError):
 class InvalidServerVersion(BaseZwaveJSServerError):
     """Exception raised when connected to server with incompatible version."""
 
+    def __init__(self, current_version: int, required_version: int, message: str) -> None:
+        """Initialize a invalid server version error."""
+        self.current_version = current_version
+        self.required_version = required_version
+        super().__init__(message)
+
 
 class FailedCommand(BaseZwaveJSServerError):
     """When a command has failed."""

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -65,7 +65,10 @@ class InvalidServerVersion(BaseZwaveJSServerError):
     """Exception raised when connected to server with incompatible version."""
 
     def __init__(
-        self, version_info: Optional["VersionInfo"], required_schema_version: int, message: str
+        self,
+        version_info: Optional["VersionInfo"],
+        required_schema_version: int,
+        message: str,
     ) -> None:
         """Initialize an invalid server version error."""
         assert version_info

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -64,7 +64,7 @@ class InvalidServerVersion(BaseZwaveJSServerError):
     """Exception raised when connected to server with incompatible version."""
 
     def __init__(self, current_version: int, required_version: int, message: str) -> None:
-        """Initialize a invalid server version error."""
+        """Initialize an invalid server version error."""
         self.current_version = current_version
         self.required_version = required_version
         super().__init__(message)

--- a/zwave_js_server/exceptions.py
+++ b/zwave_js_server/exceptions.py
@@ -65,9 +65,10 @@ class InvalidServerVersion(BaseZwaveJSServerError):
     """Exception raised when connected to server with incompatible version."""
 
     def __init__(
-        self, version_info: "VersionInfo", required_schema_version: int, message: str
+        self, version_info: Optional["VersionInfo"], required_schema_version: int, message: str
     ) -> None:
         """Initialize an invalid server version error."""
+        assert version_info
         self.server_version = version_info.server_version
         self.server_max_schema_version = version_info.max_schema_version
         self.required_schema_version = required_schema_version


### PR DESCRIPTION
We have no structured way to get the current version and required versions right now so I added that. I also think our connection error message was a little vague so I updated it to match the async_send_command require_schema exception message which seems more clear to me.