### PR TITLE
Bump zwave-js-server to 0.43.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.43.0"
+VERSION = "0.43.1"
 
 
 setup(


### PR DESCRIPTION
To release https://github.com/home-assistant-libs/zwave-js-server-python/pull/521