### PR TITLE
Fix pydantic model and store firmware update progress on controller

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1822,6 +1822,7 @@ async def test_inclusion_aborted(controller):
 
 async def test_firmware_events(controller):
     """Test firmware events."""
+    assert controller.firmware_update_progress is None
     event = Event(
         type="firmware update progress",
         data={
@@ -1840,6 +1841,10 @@ async def test_firmware_events(controller):
     assert progress.sent_fragments == 1
     assert progress.total_fragments == 10
     assert progress.progress == 10.0
+    assert controller.firmware_update_progress
+    assert controller.firmware_update_progress.sent_fragments == 1
+    assert controller.firmware_update_progress.total_fragments == 10
+    assert controller.firmware_update_progress.progress == 10.0
 
     event = Event(
         type="firmware update finished",
@@ -1854,6 +1859,7 @@ async def test_firmware_events(controller):
     result = event.data["firmware_update_finished"]
     assert result.status == ControllerFirmwareUpdateStatus.OK
     assert result.success
+    assert controller.firmware_update_progress is None
 
 
 async def test_unknown_event(controller):

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1836,7 +1836,7 @@ async def test_firmware_events(controller):
         },
     )
 
-    controller.handle_firmware_update_progress(event)
+    controller.receive_event(event)
     progress = event.data["firmware_update_progress"]
     assert progress.sent_fragments == 1
     assert progress.total_fragments == 10
@@ -1855,7 +1855,7 @@ async def test_firmware_events(controller):
         },
     )
 
-    controller.handle_firmware_update_finished(event)
+    controller.receive_event(event)
     result = event.data["firmware_update_finished"]
     assert result.status == ControllerFirmwareUpdateStatus.OK
     assert result.success

--- a/zwave_js_server/model/controller/event_model.py
+++ b/zwave_js_server/model/controller/event_model.py
@@ -4,7 +4,10 @@ from typing import Dict, Literal, Type
 from ...const import TYPING_EXTENSION_FOR_TYPEDDICT_REQUIRED
 from ...event import BaseEventModel
 from ..node.data_model import FoundNodeDataType, NodeDataType
-from .firmware import ControllerFirmwareUpdateProgressDataType
+from .firmware import (
+    ControllerFirmwareUpdateProgressDataType,
+    ControllerFirmwareUpdateResultDataType,
+)
 from .inclusion_and_provisioning import InclusionGrantDataType
 from .statistics import ControllerStatisticsDataType
 
@@ -48,7 +51,7 @@ class FirmwareUpdateFinishedEventModel(BaseControllerEventModel):
     """Model for `firmware update finished` event data."""
 
     event: Literal["firmware update finished"]
-    result: int
+    result: ControllerFirmwareUpdateResultDataType
 
 
 class FirmwareUpdateProgressEventModel(BaseControllerEventModel):


### PR DESCRIPTION
like we do with the node firmware updates, we need to store progress on the controller so that users of the lib can check on the current status (e.g. if someone starts a controller firmware update, leaves the page, then comes back).

Also fixed a bug related to the pydantic model for the `firmware update finished` event