### PR TITLE
Add support for dsk inclusion option

### DIFF
--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -218,6 +218,7 @@ class Controller(EventBase):
         provisioning: Optional[
             Union[str, ProvisioningEntry, QRProvisioningInformation]
         ] = None,
+        dsk: Optional[str] = None,
     ) -> bool:
         """Send beginInclusion command to Controller."""
         # Most functionality was introduced in Schema 8
@@ -237,6 +238,11 @@ class Controller(EventBase):
             if inclusion_strategy != InclusionStrategy.SECURITY_S2:
                 raise ValueError(
                     "`provisioning` option is only supported with inclusion_strategy=SECURITY_S2"
+                )
+
+            if dsk is not None:
+                raise ValueError(
+                    "Only one of `provisioning` and `dsk` can be provided"
                 )
             # Provisioning option was introduced in Schema 11
             require_schema = 11
@@ -264,6 +270,15 @@ class Controller(EventBase):
             # QRProvisioningInformation that is not a Smart Start QR code
             else:
                 options["provisioning"] = provisioning.to_dict()
+
+        if dsk is not None:
+            if inclusion_strategy != InclusionStrategy.SECURITY_S2:
+                raise ValueError(
+                    "`dsk` option is only supported with inclusion_strategy=SECURITY_S2"
+                )
+
+            require_schema = 25
+            options["dsk"] = dsk
 
         data = await self.client.async_send_command(
             {

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -241,9 +241,7 @@ class Controller(EventBase):
                 )
 
             if dsk is not None:
-                raise ValueError(
-                    "Only one of `provisioning` and `dsk` can be provided"
-                )
+                raise ValueError("Only one of `provisioning` and `dsk` can be provided")
             # Provisioning option was introduced in Schema 11
             require_schema = 11
             # String is assumed to be the QR code string so we can pass as is


### PR DESCRIPTION
Guess I bumped the release too quickly, I missed that there is a new inclusion option for providing the DSK with S2 inclusion. This is related to the addition of this command: https://github.com/home-assistant-libs/zwave-js-server-python/blob/master/zwave_js_server/model/utils.py#L26

TODO: 
- [x] add tests