### PR TITLE
Bump lib to 0.45.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.45.1"
+VERSION = "0.45.2"
 
 
 setup(


### PR DESCRIPTION
This should be the last change needed for all the latest changes: https://github.com/home-assistant-libs/zwave-js-server-python/pull/567