### PR TITLE
Add missing firmware enum and update docstrings

### DIFF
--- a/zwave_js_server/model/controller/firmware.py
+++ b/zwave_js_server/model/controller/firmware.py
@@ -6,7 +6,7 @@ from typing import TypedDict
 class ControllerFirmwareUpdateStatus(IntEnum):
     """Enum with all controller firmware update status values.
 
-    https://zwave-js.github.io/node-zwave-js/#/api/node?id=status
+    https://zwave-js.github.io/node-zwave-js/#/api/controller?id=quotfirmware-update-finishedquot
     """
 
     ERROR_TIMEOUT = 0
@@ -14,6 +14,8 @@ class ControllerFirmwareUpdateStatus(IntEnum):
     ERROR_RETRY_LIMIT_REACHED = 1
     # The update was aborted by the bootloader
     ERROR_ABORTED = 2
+    # This controller does not support firmware updates
+    ERROR_NOT_SUPPORTED = 3
     OK = 255
 
 

--- a/zwave_js_server/model/node/firmware.py
+++ b/zwave_js_server/model/node/firmware.py
@@ -86,7 +86,7 @@ class NodeFirmwareUpdateCapabilities:
 class NodeFirmwareUpdateStatus(IntEnum):
     """Enum with all node firmware update status values.
 
-    https://zwave-js.github.io/node-zwave-js/#/api/node?id=status
+    https://zwave-js.github.io/node-zwave-js/#/api/node?id=quotfirmware-update-finishedquot
     """
 
     ERROR_TIMEOUT = -1


### PR DESCRIPTION
We were missing a status value that was added when 500 series controllers became supported. Additionally the docstrings linked to the wrong part of the API docs