### PR TITLE
Bump lib to 0.46.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.45.2"
+VERSION = "0.46.0"
 
 
 setup(


### PR DESCRIPTION
To be released alongside zwave-js-server 1.26.0