### PR TITLE
Add convenience conversion functions for firmware classes

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -31,7 +31,10 @@ from zwave_js_server.exceptions import (
 )
 from zwave_js_server.model import endpoint as endpoint_pkg
 from zwave_js_server.model import node as node_pkg
-from zwave_js_server.model.node.firmware import NodeFirmwareUpdateStatus
+from zwave_js_server.model.node.firmware import (
+    NodeFirmwareUpdateStatus,
+    NodeFirmwareUpdateInfo,
+)
 from zwave_js_server.model.node.health_check import (
     LifelineHealthCheckResultDataType,
     RouteHealthCheckResultDataType,
@@ -40,6 +43,24 @@ from zwave_js_server.model.node.statistics import NodeStatistics
 from zwave_js_server.model.value import ConfigurationValue, get_value_id_str
 
 from .. import load_fixture
+
+FIRMWARE_UPDATE_INFO = {
+    "version": "1.0.0",
+    "changelog": "changelog",
+    "files": [{"target": 0, "url": "http://example.com", "integrity": "test"}],
+}
+
+
+def test_firmware():
+    """Test NodeFirmwareUpdateInfo."""
+    firmware_update_info = NodeFirmwareUpdateInfo.from_dict(FIRMWARE_UPDATE_INFO)
+    assert firmware_update_info.version == "1.0.0"
+    assert firmware_update_info.changelog == "changelog"
+    assert len(firmware_update_info.files) == 1
+    assert firmware_update_info.files[0].target == 0
+    assert firmware_update_info.files[0].url == "http://example.com"
+    assert firmware_update_info.files[0].integrity == "test"
+    assert firmware_update_info.to_dict() == FIRMWARE_UPDATE_INFO
 
 
 def test_from_state(client):

--- a/zwave_js_server/model/node/firmware.py
+++ b/zwave_js_server/model/node/firmware.py
@@ -229,6 +229,13 @@ class NodeFirmwareUpdateFileInfo:
     url: str
     integrity: str
 
+    @classmethod
+    def from_dict(
+        cls, data: NodeFirmwareUpdateFileInfoDataType
+    ) -> "NodeFirmwareUpdateFileInfo":
+        """Initialize from dict."""
+        return cls(**data)
+
     def to_dict(self) -> NodeFirmwareUpdateFileInfoDataType:
         """Return dict representation of the object."""
         return cast(NodeFirmwareUpdateFileInfoDataType, asdict(self))
@@ -258,5 +265,18 @@ class NodeFirmwareUpdateInfo:
         return cls(
             version=data["version"],
             changelog=data["changelog"],
-            files=[NodeFirmwareUpdateFileInfo(**file) for file in data["files"]],
+            files=[
+                NodeFirmwareUpdateFileInfo.from_dict(file) for file in data["files"]
+            ],
+        )
+
+    def to_dict(self) -> NodeFirmwareUpdateInfoDataType:
+        """Return dict representation of the object."""
+        return cast(
+            NodeFirmwareUpdateInfoDataType,
+            {
+                "version": self.version,
+                "changelog": self.changelog,
+                "files": [file.to_dict() for file in self.files],
+            },
         )


### PR DESCRIPTION
we are using `asdict` in https://github.com/home-assistant/core/pull/89737 which works because of the keys we use, but to be consistent with everything else, adding these functions will make it easier for downstream systems to not have to know these details