### PR TITLE
Use dataclasses where it makes sense to simplify code

### DIFF
--- a/zwave_js_server/model/controller/firmware.py
+++ b/zwave_js_server/model/controller/firmware.py
@@ -1,7 +1,7 @@
 """Provide a model for Z-Wave controller firmware."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import TypedDict
 
@@ -59,27 +59,20 @@ class ControllerFirmwareUpdateProgressDataType(TypedDict):
     progress: float
 
 
+@dataclass
 class ControllerFirmwareUpdateProgress:
     """Model for a controller firmware update progress data."""
 
-    def __init__(self, data: ControllerFirmwareUpdateProgressDataType) -> None:
-        """Initialize."""
-        self.data = data
+    data: ControllerFirmwareUpdateProgressDataType
+    sent_fragments: int = field(init=False)
+    total_fragments: int = field(init=False)
+    progress: float = field(init=False)
 
-    @property
-    def sent_fragments(self) -> int:
-        """Return the number of fragments sent to the device so far."""
-        return self.data["sentFragments"]
-
-    @property
-    def total_fragments(self) -> int:
-        """Return the total number of fragments that need to be sent to the device."""
-        return self.data["totalFragments"]
-
-    @property
-    def progress(self) -> float:
-        """Return progress."""
-        return float(self.data["progress"])
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        self.sent_fragments = self.data["sentFragments"]
+        self.total_fragments = self.data["totalFragments"]
+        self.progress = float(self.data["progress"])
 
 
 class ControllerFirmwareUpdateResultDataType(TypedDict):
@@ -89,19 +82,15 @@ class ControllerFirmwareUpdateResultDataType(TypedDict):
     success: bool
 
 
+@dataclass
 class ControllerFirmwareUpdateResult:
     """Model for controller firmware update result data."""
 
-    def __init__(self, data: ControllerFirmwareUpdateResultDataType) -> None:
-        """Initialize."""
-        self.data = data
+    data: ControllerFirmwareUpdateResultDataType
+    status: ControllerFirmwareUpdateStatus = field(init=False)
+    success: bool = field(init=False)
 
-    @property
-    def status(self) -> ControllerFirmwareUpdateStatus:
-        """Return the firmware update status."""
-        return ControllerFirmwareUpdateStatus(self.data["status"])
-
-    @property
-    def success(self) -> bool:
-        """Return whether the firmware update was successful."""
-        return self.data["success"]
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        self.status = ControllerFirmwareUpdateStatus(self.data["status"])
+        self.success = self.data["success"]

--- a/zwave_js_server/model/controller/statistics.py
+++ b/zwave_js_server/model/controller/statistics.py
@@ -1,7 +1,7 @@
 """Provide a model for the Z-Wave JS controller's statistics."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypedDict
 
 from ..statistics import RouteStatistics, RouteStatisticsDataType
@@ -59,12 +59,24 @@ class ControllerStatisticsDataType(TypedDict):
     timeoutCallback: int
 
 
+@dataclass
 class ControllerStatistics:
     """Represent a controller statistics update."""
 
-    def __init__(self, data: ControllerStatisticsDataType | None = None) -> None:
-        """Initialize controller statistics."""
-        self.data = data or ControllerStatisticsDataType(
+    data: ControllerStatisticsDataType | None = None
+    messages_tx: int = field(init=False)
+    messages_rx: int = field(init=False)
+    messages_dropped_rx: int = field(init=False)
+    messages_dropped_tx: int = field(init=False)
+    nak: int = field(init=False)
+    can: int = field(init=False)
+    timeout_ack: int = field(init=False)
+    timeout_response: int = field(init=False)
+    timeout_callback: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        data = self.data or ControllerStatisticsDataType(
             CAN=0,
             messagesDroppedRX=0,
             messagesDroppedTX=0,
@@ -75,52 +87,12 @@ class ControllerStatistics:
             timeoutCallback=0,
             timeoutResponse=0,
         )
-
-    @property
-    def messages_tx(self) -> int:
-        """Return number of messages successfully sent to controller."""
-        return self.data["messagesTX"]
-
-    @property
-    def messages_rx(self) -> int:
-        """Return number of messages received by controller."""
-        return self.data["messagesRX"]
-
-    @property
-    def messages_dropped_rx(self) -> int:
-        """Return number of messages from controller that were dropped by host."""
-        return self.data["messagesDroppedRX"]
-
-    @property
-    def messages_dropped_tx(self) -> int:
-        """
-        Return number of outgoing messages that were dropped.
-
-        These messages could not be sent.
-        """
-        return self.data["messagesDroppedTX"]
-
-    @property
-    def nak(self) -> int:
-        """Return number of messages that controller did not accept."""
-        return self.data["NAK"]
-
-    @property
-    def can(self) -> int:
-        """Return number of collisions while sending a message to controller."""
-        return self.data["CAN"]
-
-    @property
-    def timeout_ack(self) -> int:
-        """Return number of transmission attempts without an ACK from controller."""
-        return self.data["timeoutACK"]
-
-    @property
-    def timeout_response(self) -> int:
-        """Return number of transmission attempts where controller response timed out."""
-        return self.data["timeoutResponse"]
-
-    @property
-    def timeout_callback(self) -> int:
-        """Return number of transmission attempts where controller callback timed out."""
-        return self.data["timeoutCallback"]
+        self.messages_tx = data["messagesTX"]
+        self.messages_rx = data["messagesRX"]
+        self.messages_dropped_rx = data["messagesDroppedRX"]
+        self.messages_dropped_tx = data["messagesDroppedTX"]
+        self.nak = data["NAK"]
+        self.can = data["CAN"]
+        self.timeout_ack = data["timeoutACK"]
+        self.timeout_response = data["timeoutResponse"]
+        self.timeout_callback = data["timeoutCallback"]

--- a/zwave_js_server/model/controller/statistics.py
+++ b/zwave_js_server/model/controller/statistics.py
@@ -21,27 +21,17 @@ class ControllerLifelineRoutesDataType(TypedDict):
 class ControllerLifelineRoutes:
     """Represent controller lifeline routes."""
 
-    def __init__(
-        self, client: "Client", data: ControllerLifelineRoutesDataType
-    ) -> None:
-        """Initialize controller lifeline routes."""
-        self.data = data
-        self._lwr = None
+    client: "Client"
+    data: ControllerLifelineRoutesDataType
+    lwr: RouteStatistics | None = field(init=False, default=None)
+    nlwr: RouteStatistics | None = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        """Post initialize."""
         if lwr := self.data.get("lwr"):
-            self._lwr = RouteStatistics(client, lwr)
-        self._nlwr = None
+            self.lwr = RouteStatistics(self.client, lwr)
         if nlwr := self.data.get("nlwr"):
-            self._nlwr = RouteStatistics(client, nlwr)
-
-    @property
-    def lwr(self) -> RouteStatistics | None:
-        """Return the last working route from the controller to this node."""
-        return self._lwr
-
-    @property
-    def nlwr(self) -> RouteStatistics | None:
-        """Return the next to last working route from the controller to this node."""
-        return self._nlwr
+            self.nlwr = RouteStatistics(self.client, nlwr)
 
 
 class ControllerStatisticsDataType(TypedDict):

--- a/zwave_js_server/model/log_message.py
+++ b/zwave_js_server/model/log_message.py
@@ -38,7 +38,7 @@ class LogMessageContext:
     )
     internal: bool | None = field(init=False)
     endpoint: int | None = field(init=False)
-    command_class: CommandClass | None = field(init=False)
+    command_class: CommandClass | None = field(init=False, default=None)
     property_: int | str | None = field(init=False)
     property_key: int | str | None = field(init=False)
 
@@ -52,11 +52,8 @@ class LogMessageContext:
         self.change = self.data.get("change")
         self.internal = self.data.get("internal")
         self.endpoint = self.data.get("endpoint")
-        self.command_class = (
-            CommandClass(self.data["commandClass"])
-            if "commandClass" in self.data
-            else None
-        )
+        if (command_class := self.data.get("commandClass")) is not None:
+            self.command_class = CommandClass(command_class)
         self.property_ = self.data.get("property")
         self.property_key = self.data.get("propertyKey")
 

--- a/zwave_js_server/model/log_message.py
+++ b/zwave_js_server/model/log_message.py
@@ -1,6 +1,7 @@
 """Provide a model for a log message event."""
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Literal, TypedDict
 
 from ..const import CommandClass
@@ -22,71 +23,42 @@ class LogMessageContextDataType(TypedDict, total=False):
     propertyKey: int | str
 
 
+@dataclass
 class LogMessageContext:
     """Represent log message context information."""
 
-    def __init__(self, data: LogMessageContextDataType) -> None:
-        """Initialize log message context."""
-        self.data = data
+    data: LogMessageContextDataType
+    source: Literal["config", "serial", "controller", "driver"] = field(init=False)
+    type: Literal["controller", "value", "node"] | None = field(init=False)
+    node_id: int | None = field(init=False)
+    header: str | None = field(init=False)
+    direction: Literal["inbound", "outbound", "none"] | None = field(init=False)
+    change: Literal["added", "removed", "updated", "notification"] | None = field(
+        init=False
+    )
+    internal: bool | None = field(init=False)
+    endpoint: int | None = field(init=False)
+    command_class: CommandClass | None = field(init=False)
+    property_: int | str | None = field(init=False)
+    property_key: int | str | None = field(init=False)
 
-    @property
-    def source(self) -> Literal["config", "serial", "controller", "driver"]:
-        """Return the log message source."""
-        return self.data["source"]
-
-    @property
-    def type(self) -> Literal["controller", "value", "node"] | None:
-        """Return the object type for the log message if applicable."""
-        return self.data.get("type")
-
-    @property
-    def node_id(self) -> int | None:
-        """Return the Node ID for the log message if applicable."""
-        return self.data.get("nodeId")
-
-    @property
-    def header(self) -> str | None:
-        """Return the header for the log message if applicable."""
-        return self.data.get("header")
-
-    @property
-    def direction(self) -> Literal["inbound", "outbound", "none"] | None:
-        """Return the direction for the log message if applicable."""
-        return self.data.get("direction")
-
-    @property
-    def change(
-        self,
-    ) -> Literal["added", "removed", "updated", "notification"] | None:
-        """Return the change type for the log message if applicable."""
-        return self.data.get("change")
-
-    @property
-    def internal(self) -> bool | None:
-        """Return the internal flag for the log message if applicable."""
-        return self.data.get("internal")
-
-    @property
-    def endpoint(self) -> int | None:
-        """Return the Node/Value endpoint for the log message if applicable."""
-        return self.data.get("endpoint")
-
-    @property
-    def command_class(self) -> CommandClass | None:
-        """Return the Value command class for the log message if applicable."""
-        if command_class := self.data.get("commandClass"):
-            return CommandClass(command_class)
-        return None
-
-    @property
-    def property_(self) -> int | str | None:
-        """Return the Value property for the log message if applicable."""
-        return self.data.get("property")
-
-    @property
-    def property_key(self) -> int | str | None:
-        """Return the Value property key for the log message if applicable."""
-        return self.data.get("propertyKey")
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        self.source = self.data["source"]
+        self.type = self.data.get("type")
+        self.node_id = self.data.get("nodeId")
+        self.header = self.data.get("header")
+        self.direction = self.data.get("direction")
+        self.change = self.data.get("change")
+        self.internal = self.data.get("internal")
+        self.endpoint = self.data.get("endpoint")
+        self.command_class = (
+            CommandClass(self.data["commandClass"])
+            if "commandClass" in self.data
+            else None
+        )
+        self.property_ = self.data.get("property")
+        self.property_key = self.data.get("propertyKey")
 
 
 class LogMessageDataType(TypedDict, total=False):
@@ -107,75 +79,43 @@ class LogMessageDataType(TypedDict, total=False):
     label: str
 
 
+def _process_message(message: str | list[str]) -> list[str]:
+    """Process a message and always return a list."""
+    if isinstance(message, str):
+        return str(message).splitlines()
+
+    # We will assume each item in the array is on a separate line so we can
+    # remove trailing line breaks
+    return [message.rstrip("\n") for message in message]
+
+
+@dataclass
 class LogMessage:
     """Represent a log message."""
 
-    def __init__(self, data: LogMessageDataType):
-        """Initialize log message."""
-        self.data = data
+    data: LogMessageDataType
+    message: list[str] = field(init=False)
+    formatted_message: list[str] = field(init=False)
+    direction: str = field(init=False)
+    level: str = field(init=False)
+    context: LogMessageContext = field(init=False)
+    primary_tags: str | None = field(init=False)
+    secondary_tags: str | None = field(init=False)
+    secondary_tag_padding: int | None = field(init=False)
+    multiline: bool | None = field(init=False)
+    timestamp: str | None = field(init=False)
+    label: str | None = field(init=False)
 
-    def _process_message(
-        self, field_name: Literal["message", "formattedMessage"]
-    ) -> list[str]:
-        """Process a message and always return a list."""
-        if isinstance(self.data[field_name], str):
-            return str(self.data[field_name]).splitlines()
-
-        # We will assume each item in the array is on a separate line so we can
-        # remove trailing line breaks
-        return [message.rstrip("\n") for message in self.data[field_name]]
-
-    @property
-    def message(self) -> list[str]:
-        """Return message."""
-        return self._process_message("message")
-
-    @property
-    def formatted_message(self) -> list[str]:
-        """Return fully formatted message."""
-        return self._process_message("formattedMessage")
-
-    @property
-    def direction(self) -> str:
-        """Return direction."""
-        return self.data["direction"]
-
-    @property
-    def level(self) -> str:
-        """Return level."""
-        return self.data["level"]
-
-    @property
-    def primary_tags(self) -> str | None:
-        """Return primary tags."""
-        return self.data.get("primaryTags")
-
-    @property
-    def secondary_tags(self) -> str | None:
-        """Return secondary tags."""
-        return self.data.get("secondaryTags")
-
-    @property
-    def secondary_tag_padding(self) -> int | None:
-        """Return secondary tag padding."""
-        return self.data.get("secondaryTagPadding")
-
-    @property
-    def multiline(self) -> bool | None:
-        """Return whether message is multiline."""
-        return self.data.get("multiline")
-
-    @property
-    def timestamp(self) -> str | None:
-        """Return timestamp."""
-        return self.data.get("timestamp")
-
-    @property
-    def label(self) -> str | None:
-        """Return label."""
-        return self.data.get("label")
-
-    @property
-    def context(self) -> LogMessageContext:
-        """Return context."""
-        return LogMessageContext(self.data["context"])
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        self.message = _process_message(self.data["message"])
+        self.formatted_message = _process_message(self.data["formattedMessage"])
+        self.direction = self.data["direction"]
+        self.level = self.data["level"]
+        self.context = LogMessageContext(self.data["context"])
+        self.primary_tags = self.data.get("primaryTags")
+        self.secondary_tags = self.data.get("secondaryTags")
+        self.secondary_tag_padding = self.data.get("secondaryTagPadding")
+        self.multiline = self.data.get("multiline")
+        self.timestamp = self.data.get("timestamp")
+        self.label = self.data.get("label")

--- a/zwave_js_server/model/node/firmware.py
+++ b/zwave_js_server/model/node/firmware.py
@@ -1,7 +1,7 @@
 """Provide a model for Z-Wave firmware."""
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from enum import IntEnum
 from typing import TYPE_CHECKING, TypedDict, cast
 
@@ -61,17 +61,16 @@ class NodeFirmwareUpdateCapabilitiesDict(TypedDict, total=False):
     supports_activation: bool | None
 
 
+@dataclass
 class NodeFirmwareUpdateCapabilities:
     """Model for firmware update capabilities."""
 
-    def __init__(self, data: NodeFirmwareUpdateCapabilitiesDataType) -> None:
-        """Initialize class."""
-        self.data = data
+    data: NodeFirmwareUpdateCapabilitiesDataType
+    firmware_upgradable: bool = field(init=False)
 
-    @property
-    def firmware_upgradable(self) -> bool:
-        """Return whether firmware is upgradable."""
-        return self.data["firmwareUpgradable"]
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        self.firmware_upgradable = self.data["firmwareUpgradable"]
 
     @property
     def firmware_targets(self) -> list[int]:
@@ -143,38 +142,25 @@ class NodeFirmwareUpdateProgressDataType(TypedDict):
     progress: float
 
 
+@dataclass
 class NodeFirmwareUpdateProgress:
     """Model for a node firmware update progress data."""
 
-    def __init__(self, node: "Node", data: NodeFirmwareUpdateProgressDataType) -> None:
-        """Initialize."""
-        self.data = data
-        self.node = node
+    node: "Node"
+    data: NodeFirmwareUpdateProgressDataType
+    current_file: int = field(init=False)
+    total_files: int = field(init=False)
+    sent_fragments: int = field(init=False)
+    total_fragments: int = field(init=False)
+    progress: float = field(init=False)
 
-    @property
-    def current_file(self) -> int:
-        """Return current file."""
-        return self.data["currentFile"]
-
-    @property
-    def total_files(self) -> int:
-        """Return total files."""
-        return self.data["totalFiles"]
-
-    @property
-    def sent_fragments(self) -> int:
-        """Return the number of fragments sent to the device so far."""
-        return self.data["sentFragments"]
-
-    @property
-    def total_fragments(self) -> int:
-        """Return the total number of fragments that need to be sent to the device."""
-        return self.data["totalFragments"]
-
-    @property
-    def progress(self) -> float:
-        """Return progress."""
-        return float(self.data["progress"])
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        self.current_file = self.data["currentFile"]
+        self.total_files = self.data["totalFiles"]
+        self.sent_fragments = self.data["sentFragments"]
+        self.total_fragments = self.data["totalFragments"]
+        self.progress = float(self.data["progress"])
 
 
 class NodeFirmwareUpdateResultDataType(TypedDict, total=False):
@@ -186,33 +172,23 @@ class NodeFirmwareUpdateResultDataType(TypedDict, total=False):
     reInterview: bool  # required
 
 
+@dataclass
 class NodeFirmwareUpdateResult:
     """Model for node firmware update result data."""
 
-    def __init__(self, node: "Node", data: NodeFirmwareUpdateResultDataType) -> None:
-        """Initialize."""
-        self.data = data
-        self.node = node
+    node: "Node"
+    data: NodeFirmwareUpdateResultDataType
+    status: NodeFirmwareUpdateStatus = field(init=False)
+    success: bool = field(init=False)
+    wait_time: int | None = field(init=False)
+    reinterview: bool = field(init=False)
 
-    @property
-    def status(self) -> NodeFirmwareUpdateStatus:
-        """Return the firmware update status."""
-        return NodeFirmwareUpdateStatus(self.data["status"])
-
-    @property
-    def success(self) -> bool:
-        """Return whether the firmware update was successful."""
-        return self.data["success"]
-
-    @property
-    def wait_time(self) -> int | None:
-        """Return the wait time in seconds before the device is functional again."""
-        return self.data.get("waitTime")
-
-    @property
-    def reinterview(self) -> bool:
-        """Return whether the node will be re-interviewed."""
-        return self.data["reInterview"]
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        self.status = NodeFirmwareUpdateStatus(self.data["status"])
+        self.success = self.data["success"]
+        self.wait_time = self.data.get("waitTime")
+        self.reinterview = self.data["reInterview"]
 
 
 class NodeFirmwareUpdateFileInfoDataType(TypedDict):

--- a/zwave_js_server/model/node/health_check.py
+++ b/zwave_js_server/model/node/health_check.py
@@ -37,7 +37,7 @@ class LifelineHealthCheckResult:
     num_neighbors: int = field(init=False)
     failed_pings_node: int = field(init=False)
     route_changes: int | None = field(init=False)
-    min_power_level: PowerLevel | None = field(init=False)
+    min_power_level: PowerLevel | None = field(init=False, default=None)
     failed_pings_controller: int | None = field(init=False)
     snr_margin: int | None = field(init=False)
 
@@ -47,11 +47,8 @@ class LifelineHealthCheckResult:
         self.num_neighbors = self.data["numNeighbors"]
         self.failed_pings_node = self.data["failedPingsNode"]
         self.route_changes = self.data.get("routeChanges")
-        self.min_power_level = (
-            PowerLevel(self.data["minPowerlevel"])
-            if "minPowerlevel" in self.data
-            else None
-        )
+        if (min_power_level := self.data.get("minPowerlevel")) is not None:
+            self.min_power_level = PowerLevel(min_power_level)
         self.failed_pings_controller = self.data.get("failedPingsController")
         self.snr_margin = self.data.get("snrMargin")
 
@@ -101,8 +98,8 @@ class RouteHealthCheckResult:
     rating: int = field(init=False)
     failed_pings_to_target: int | None = field(init=False)
     failed_pings_to_source: int | None = field(init=False)
-    min_power_level_source: PowerLevel | None = field(init=False)
-    min_power_level_target: PowerLevel | None = field(init=False)
+    min_power_level_source: PowerLevel | None = field(init=False, default=None)
+    min_power_level_target: PowerLevel | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         """Post initialize."""
@@ -110,16 +107,10 @@ class RouteHealthCheckResult:
         self.rating = self.data["rating"]
         self.failed_pings_to_target = self.data.get("failedPingsToTarget")
         self.failed_pings_to_source = self.data.get("failedPingsToSource")
-        self.min_power_level_source = (
-            PowerLevel(self.data["minPowerlevelSource"])
-            if "minPowerlevelSource" in self.data
-            else None
-        )
-        self.min_power_level_target = (
-            PowerLevel(self.data["minPowerlevelTarget"])
-            if "minPowerlevelTarget" in self.data
-            else None
-        )
+        if (min_power_level_source := self.data.get("minPowerlevelSource")) is not None:
+            self.min_power_level_source = PowerLevel(min_power_level_source)
+        if (min_power_level_target := self.data.get("minPowerlevelTarget")) is not None:
+            self.min_power_level_target = PowerLevel(min_power_level_target)
 
 
 @dataclass

--- a/zwave_js_server/model/node/health_check.py
+++ b/zwave_js_server/model/node/health_check.py
@@ -1,7 +1,7 @@
 """Provide a model for the Z-Wave JS node's health checks and power tests."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TypedDict
 
 from ...const import PowerLevel
@@ -28,69 +28,48 @@ class LifelineHealthCheckSummaryDataType(TypedDict):
     rating: int
 
 
+@dataclass
 class LifelineHealthCheckResult:
     """Represent a lifeline health check result."""
 
-    def __init__(self, data: LifelineHealthCheckResultDataType) -> None:
-        """Initialize lifeline health check result."""
-        self.data = data
+    data: LifelineHealthCheckResultDataType
+    latency: int = field(init=False)
+    num_neighbors: int = field(init=False)
+    failed_pings_node: int = field(init=False)
+    route_changes: int | None = field(init=False)
+    min_power_level: PowerLevel | None = field(init=False)
+    failed_pings_controller: int | None = field(init=False)
+    snr_margin: int | None = field(init=False)
 
-    @property
-    def latency(self) -> int:
-        """Return latency."""
-        return self.data["latency"]
-
-    @property
-    def num_neighbors(self) -> int:
-        """Return number of neighbors."""
-        return self.data["numNeighbors"]
-
-    @property
-    def failed_pings_node(self) -> int:
-        """Return number of failed pings to node."""
-        return self.data["failedPingsNode"]
-
-    @property
-    def route_changes(self) -> int | None:
-        """Return number of route changes."""
-        return self.data.get("routeChanges")
-
-    @property
-    def min_power_level(self) -> PowerLevel | None:
-        """Return minimum power level."""
-        power_level = self.data.get("minPowerlevel")
-        if power_level is not None:
-            return PowerLevel(power_level)
-        return None
-
-    @property
-    def failed_pings_controller(self) -> int | None:
-        """Return number of failed pings to controller."""
-        return self.data.get("failedPingsController")
-
-    @property
-    def snr_margin(self) -> int | None:
-        """Return SNR margin."""
-        return self.data.get("snrMargin")
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        self.latency = self.data["latency"]
+        self.num_neighbors = self.data["numNeighbors"]
+        self.failed_pings_node = self.data["failedPingsNode"]
+        self.route_changes = self.data.get("routeChanges")
+        self.min_power_level = (
+            PowerLevel(self.data["minPowerlevel"])
+            if "minPowerlevel" in self.data
+            else None
+        )
+        self.failed_pings_controller = self.data.get("failedPingsController")
+        self.snr_margin = self.data.get("snrMargin")
 
 
+@dataclass
 class LifelineHealthCheckSummary:
     """Represent a lifeline health check summary update."""
 
-    def __init__(self, data: LifelineHealthCheckSummaryDataType) -> None:
-        """Initialize lifeline health check summary."""
-        self._rating = data["rating"]
-        self._results = [LifelineHealthCheckResult(r) for r in data.get("results", [])]
+    data: LifelineHealthCheckSummaryDataType
+    rating: int = field(init=False)
+    results: list[LifelineHealthCheckResult] = field(init=False)
 
-    @property
-    def rating(self) -> int:
-        """Return rating."""
-        return self._rating
-
-    @property
-    def results(self) -> list[LifelineHealthCheckResult]:
-        """Return lifeline health check results."""
-        return self._results
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        self.rating = self.data["rating"]
+        self.results = [
+            LifelineHealthCheckResult(r) for r in self.data.get("results", [])
+        ]
 
 
 class RouteHealthCheckResultDataType(TypedDict, total=False):
@@ -113,67 +92,48 @@ class RouteHealthCheckSummaryDataType(TypedDict):
     rating: int
 
 
+@dataclass
 class RouteHealthCheckResult:
     """Represent a route health check result."""
 
-    def __init__(self, data: RouteHealthCheckResultDataType) -> None:
-        """Initialize route health check result."""
-        self.data = data
+    data: RouteHealthCheckResultDataType
+    num_neighbors: int = field(init=False)
+    rating: int = field(init=False)
+    failed_pings_to_target: int | None = field(init=False)
+    failed_pings_to_source: int | None = field(init=False)
+    min_power_level_source: PowerLevel | None = field(init=False)
+    min_power_level_target: PowerLevel | None = field(init=False)
 
-    @property
-    def num_neighbors(self) -> int:
-        """Return number of neighbors."""
-        return self.data["numNeighbors"]
-
-    @property
-    def rating(self) -> int:
-        """Return rating."""
-        return self.data["rating"]
-
-    @property
-    def failed_pings_to_target(self) -> int | None:
-        """Return number of failed pings to target."""
-        return self.data.get("failedPingsToTarget")
-
-    @property
-    def failed_pings_to_source(self) -> int | None:
-        """Return number of failed pings to source."""
-        return self.data.get("failedPingsToSource")
-
-    @property
-    def min_power_level_source(self) -> PowerLevel | None:
-        """Return minimum power level source."""
-        power_level = self.data.get("minPowerlevelSource")
-        if power_level is not None:
-            return PowerLevel(power_level)
-        return None
-
-    @property
-    def min_power_level_target(self) -> PowerLevel | None:
-        """Return minimum power level target."""
-        power_level = self.data.get("minPowerlevelTarget")
-        if power_level is not None:
-            return PowerLevel(power_level)
-        return None
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        self.num_neighbors = self.data["numNeighbors"]
+        self.rating = self.data["rating"]
+        self.failed_pings_to_target = self.data.get("failedPingsToTarget")
+        self.failed_pings_to_source = self.data.get("failedPingsToSource")
+        self.min_power_level_source = (
+            PowerLevel(self.data["minPowerlevelSource"])
+            if "minPowerlevelSource" in self.data
+            else None
+        )
+        self.min_power_level_target = (
+            PowerLevel(self.data["minPowerlevelTarget"])
+            if "minPowerlevelTarget" in self.data
+            else None
+        )
 
 
+@dataclass
 class RouteHealthCheckSummary:
     """Represent a route health check summary update."""
 
-    def __init__(self, data: RouteHealthCheckSummaryDataType) -> None:
-        """Initialize route health check summary."""
-        self._rating = data["rating"]
-        self._results = [RouteHealthCheckResult(r) for r in data.get("results", [])]
+    data: RouteHealthCheckSummaryDataType
+    rating: int = field(init=False)
+    results: list[RouteHealthCheckResult] = field(init=False)
 
-    @property
-    def rating(self) -> int:
-        """Return rating."""
-        return self._rating
-
-    @property
-    def results(self) -> list[RouteHealthCheckResult]:
-        """Return route health check results."""
-        return self._results
+    def __post_init__(self) -> None:
+        """Post initialize."""
+        self.rating = self.data["rating"]
+        self.results = [RouteHealthCheckResult(r) for r in self.data.get("results", [])]
 
 
 @dataclass

--- a/zwave_js_server/model/node/statistics.py
+++ b/zwave_js_server/model/node/statistics.py
@@ -40,8 +40,8 @@ class NodeStatistics:
     commands_dropped_tx: int = field(init=False)
     timeout_response: int = field(init=False)
     rtt: int | None = field(init=False)
-    lwr: RouteStatistics | None = field(init=False)
-    nlwr: RouteStatistics | None = field(init=False)
+    lwr: RouteStatistics | None = field(init=False, default=None)
+    nlwr: RouteStatistics | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         """Post initialize."""
@@ -58,22 +58,10 @@ class NodeStatistics:
         self.commands_dropped_tx = self.data["commandsDroppedTX"]
         self.timeout_response = self.data["timeoutResponse"]
         self.rtt = self.data.get("rtt")
-        self.lwr = (
-            RouteStatistics(self.client, self.data["lwr"])
-            if "lwr" in self.data
-            else None
-        )
-        self.nlwr = (
-            RouteStatistics(self.client, self.data["nlwr"])
-            if "nlwr" in self.data
-            else None
-        )
-        self._lwr = None
         if lwr := self.data.get("lwr"):
-            self._lwr = RouteStatistics(self.client, lwr)
-        self._nlwr = None
+            self.lwr = RouteStatistics(self.client, lwr)
         if nlwr := self.data.get("nlwr"):
-            self._nlwr = RouteStatistics(self.client, nlwr)
+            self.nlwr = RouteStatistics(self.client, nlwr)
 
     @property
     def rssi(self) -> int | None:

--- a/zwave_js_server/model/node/statistics.py
+++ b/zwave_js_server/model/node/statistics.py
@@ -45,22 +45,22 @@ class NodeStatistics:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.data = self.data or NodeStatisticsDataType(
+        data = self.data or NodeStatisticsDataType(
             commandsDroppedRX=0,
             commandsDroppedTX=0,
             commandsRX=0,
             commandsTX=0,
             timeoutResponse=0,
         )
-        self.commands_tx = self.data["commandsTX"]
-        self.commands_rx = self.data["commandsRX"]
-        self.commands_dropped_rx = self.data["commandsDroppedRX"]
-        self.commands_dropped_tx = self.data["commandsDroppedTX"]
-        self.timeout_response = self.data["timeoutResponse"]
-        self.rtt = self.data.get("rtt")
-        if lwr := self.data.get("lwr"):
+        self.commands_tx = data["commandsTX"]
+        self.commands_rx = data["commandsRX"]
+        self.commands_dropped_rx = data["commandsDroppedRX"]
+        self.commands_dropped_tx = data["commandsDroppedTX"]
+        self.timeout_response = data["timeoutResponse"]
+        self.rtt = data.get("rtt")
+        if lwr := data.get("lwr"):
             self.lwr = RouteStatistics(self.client, lwr)
-        if nlwr := self.data.get("nlwr"):
+        if nlwr := data.get("nlwr"):
             self.nlwr = RouteStatistics(self.client, nlwr)
 
     @property
@@ -71,7 +71,7 @@ class NodeStatistics:
         Consecutive non-error measurements are combined using an exponential moving
         average.
         """
-        if (rssi_ := self.data.get("rssi")) is None:
+        if not self.data or (rssi_ := self.data.get("rssi")) is None:
             return None
         if rssi_ in [item.value for item in RssiError]:
             raise RssiErrorReceived(RssiError(rssi_))


### PR DESCRIPTION
Per https://github.com/home-assistant-libs/zwave-js-server-python/pull/610#discussion_r1144675684 anything that is a onetime message that does not need to be updated can be a dataclass, removing a lot of boilerplate code in the process