### PR TITLE
Bump zwave-js-server-python to 0.47.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.46.0"
+VERSION = "0.47.0"
 
 
 setup(


### PR DESCRIPTION
corresponds with https://github.com/zwave-js/zwave-js-server/pull/895