### PR TITLE
Bump zwave-js-server-python to 0.47.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.47.0"
+VERSION = "0.47.1"
 
 
 setup(


### PR DESCRIPTION
to release https://github.com/home-assistant-libs/zwave-js-server-python/pull/624