### PR TITLE
Fix bug in CommandClassInfo model

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -147,7 +147,10 @@ async def test_command_classes(is_secure_unknown):
     """Test command_classes property on endpoint."""
     assert len(is_secure_unknown.endpoints[0].command_classes) == 17
     assert is_secure_unknown.endpoints[0].command_classes[0].id == 38
-    assert is_secure_unknown.endpoints[0].command_classes[0].command_class == CommandClass.SWITCH_MULTILEVEL
+    assert (
+        is_secure_unknown.endpoints[0].command_classes[0].command_class
+        == CommandClass.SWITCH_MULTILEVEL
+    )
 
 
 async def test_device_config(

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -143,6 +143,13 @@ async def test_highest_security_value(lock_schlage_be469, ring_keypad):
     assert ring_keypad.highest_security_class is None
 
 
+async def test_command_classes(is_secure_unknown):
+    """Test command_classes property on endpoint."""
+    assert len(is_secure_unknown.endpoints[0].command_classes) == 17
+    assert is_secure_unknown.endpoints[0].command_classes[0].id == 38
+    assert is_secure_unknown.endpoints[0].command_classes[0].command_class == CommandClass.SWITCH_MULTILEVEL
+
+
 async def test_device_config(
     wallmote_central_scene, climate_radio_thermostat_ct100_plus
 ):

--- a/zwave_js_server/model/command_class.py
+++ b/zwave_js_server/model/command_class.py
@@ -27,9 +27,14 @@ class CommandClassInfo:
         self.data = data
 
     @property
-    def id(self) -> CommandClass:
+    def id(self) -> int:
         """Return CommandClass ID."""
-        return CommandClass(self.data["id"])
+        return self.data["id"]
+
+    @property
+    def command_class(self) -> CommandClass:
+        """Return CommandClass."""
+        return CommandClass(self.id)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
from https://github.com/home-assistant/core/issues/90551 I noticed that we are converting id to a `CommandClass` in the property which doesn't make sense so added a separate property to do it