### PR TITLE
Fix typehint for Value Metadata states

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -81,14 +81,6 @@ def invalid_multilevel_sensor_type_state_fixture():
     return json.loads(load_fixture("invalid_multilevel_sensor_type_state.json"))
 
 
-@pytest.fixture(name="client_session")
-def client_session_fixture(ws_client):
-    """Mock an aiohttp client session."""
-    client_session = AsyncMock(spec_set=ClientSession)
-    client_session.ws_connect.side_effect = AsyncMock(return_value=ws_client)
-    return client_session
-
-
 @pytest.fixture(name="inovelli_switch_state", scope="session")
 def inovelli_switch_state_fixture():
     """Load the bad string meta data node state fixture data."""
@@ -105,6 +97,20 @@ def ring_keypad_state_fixture():
 def is_secure_unknown_state_fixture():
     """Load the isSecure = `unknown` node state fixture data."""
     return json.loads(load_fixture("is_secure_unknown_state.json"))
+
+
+@pytest.fixture(name="switch_enbrighten_zw3010_state", scope="session")
+def switch_enbrighten_zw3010_state_fixture():
+    """Load the enbrighten zw3010 switch node state fixture data."""
+    return json.loads(load_fixture("switch_enbrighten_zw3010_state.json"))
+
+
+@pytest.fixture(name="client_session")
+def client_session_fixture(ws_client):
+    """Mock an aiohttp client session."""
+    client_session = AsyncMock(spec_set=ClientSession)
+    client_session.ws_connect.side_effect = AsyncMock(return_value=ws_client)
+    return client_session
 
 
 def create_ws_message(result):
@@ -426,5 +432,13 @@ def invalid_multilevel_sensor_type_fixture(
 def is_secure_unknown_fixture(driver, is_secure_unknown_state):
     """Mock a node that has inSecure = `unknown`."""
     node = Node(driver.client, deepcopy(is_secure_unknown_state))
+    driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="switch_enbrighten_zw3010")
+def switch_enbrighten_zw3010_fixture(driver, switch_enbrighten_zw3010_state):
+    """Mock an Enbrighten ZW3010 switch node."""
+    node = Node(driver.client, deepcopy(switch_enbrighten_zw3010_state))
     driver.controller.nodes[node.node_id] = node
     return node

--- a/test/fixtures/switch_enbrighten_zw3010_state.json
+++ b/test/fixtures/switch_enbrighten_zw3010_state.json
@@ -1,0 +1,978 @@
+{
+    "nodeId": 2,
+    "index": 0,
+    "installerIcon": 1540,
+    "userIcon": 1536,
+    "status": 4,
+    "ready": true,
+    "isListening": true,
+    "isRouting": true,
+    "isSecure": true,
+    "manufacturerId": 99,
+    "productId": 12853,
+    "productType": 18756,
+    "firmwareVersion": "5.54",
+    "zwavePlusVersion": 1,
+    "deviceConfig": {
+        "filename": "/data/db/devices/0x0063/46203_zw3010.json",
+        "isEmbedded": true,
+        "manufacturer": "GE/Enbrighten",
+        "manufacturerId": 99,
+        "label": "46203 / ZW3010",
+        "description": "In-Wall Paddle Dimmer, QFSW, 500S",
+        "devices": [
+            {
+                "productType": 18756,
+                "productId": 12853
+            }
+        ],
+        "firmwareVersion": {
+            "min": "0.0",
+            "max": "255.255"
+        },
+        "preferred": false,
+        "associations": {},
+        "paramInformation": {
+            "_map": {}
+        },
+        "compat": {
+            "treatBasicSetAsEvent": true
+        },
+        "metadata": {
+            "inclusion": "1. Follow the instructions for your Z-Wave certified controller to add a device to the Z-Wave network.\n2. Once the controller is ready to add your device, press and release the top or bottom of the wireless smart dimmer (rocker) to add it in the network.\nIf prompted by the controller to enter the S2 security code, refer to the QR code/security number on the back of the box, or the QR code label on the product",
+            "exclusion": "1. Follow the instructions for your Z-Wave certified controller to remove a device from the Z-Wave network.\n2. Once the controller is ready to remove your device, press and release the top or bottom of the wireless smart dimmer (rocker) to remove it from the network",
+            "reset": "Quickly press ON (top) button 3 times, then, immediately press the OFF (bottom) button 3 times. The LED will flash 5 times when completed successfully.\nNote: This should only be used in the event your network\u2019s primary controller is missing or otherwise inoperable",
+            "manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/4024/46203%20QSG%20v3%20(3).pdf"
+        }
+    },
+    "label": "46203 / ZW3010",
+    "interviewAttempts": 0,
+    "endpoints": [
+        {
+            "nodeId": 2,
+            "index": 0,
+            "installerIcon": 1540,
+            "userIcon": 1536,
+            "deviceClass": {
+                "basic": {
+                    "key": 4,
+                    "label": "Routing Slave"
+                },
+                "generic": {
+                    "key": 17,
+                    "label": "Multilevel Switch"
+                },
+                "specific": {
+                    "key": 1,
+                    "label": "Multilevel Power Switch"
+                },
+                "mandatorySupportedCCs": [
+                    32,
+                    38,
+                    39
+                ],
+                "mandatoryControlledCCs": []
+            },
+            "commandClasses": [
+                {
+                    "id": 32,
+                    "name": "Basic",
+                    "version": 1,
+                    "isSecure": false
+                },
+                {
+                    "id": 38,
+                    "name": "Multilevel Switch",
+                    "version": 4,
+                    "isSecure": true
+                },
+                {
+                    "id": 94,
+                    "name": "Z-Wave Plus Info",
+                    "version": 2,
+                    "isSecure": false
+                },
+                {
+                    "id": 85,
+                    "name": "Transport Service",
+                    "version": 2,
+                    "isSecure": false
+                },
+                {
+                    "id": 108,
+                    "name": "Supervision",
+                    "version": 1,
+                    "isSecure": false
+                },
+                {
+                    "id": 159,
+                    "name": "Security 2",
+                    "version": 1,
+                    "isSecure": true
+                },
+                {
+                    "id": 133,
+                    "name": "Association",
+                    "version": 2,
+                    "isSecure": true
+                },
+                {
+                    "id": 89,
+                    "name": "Association Group Information",
+                    "version": 1,
+                    "isSecure": true
+                },
+                {
+                    "id": 134,
+                    "name": "Version",
+                    "version": 3,
+                    "isSecure": true
+                },
+                {
+                    "id": 114,
+                    "name": "Manufacturer Specific",
+                    "version": 2,
+                    "isSecure": true
+                },
+                {
+                    "id": 90,
+                    "name": "Device Reset Locally",
+                    "version": 1,
+                    "isSecure": true
+                },
+                {
+                    "id": 115,
+                    "name": "Powerlevel",
+                    "version": 1,
+                    "isSecure": true
+                },
+                {
+                    "id": 91,
+                    "name": "Central Scene",
+                    "version": 3,
+                    "isSecure": true
+                },
+                {
+                    "id": 112,
+                    "name": "Configuration",
+                    "version": 4,
+                    "isSecure": true
+                },
+                {
+                    "id": 122,
+                    "name": "Firmware Update Meta Data",
+                    "version": 4,
+                    "isSecure": true
+                }
+            ]
+        }
+    ],
+    "values": [
+        {
+            "endpoint": 0,
+            "commandClass": 32,
+            "commandClassName": "Basic",
+            "property": "currentValue",
+            "propertyName": "currentValue",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Current value",
+                "min": 0,
+                "max": 99,
+                "stateful": true,
+                "secret": false
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 32,
+            "commandClassName": "Basic",
+            "property": "targetValue",
+            "propertyName": "targetValue",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "Target value",
+                "min": 0,
+                "max": 255,
+                "stateful": true,
+                "secret": false
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 32,
+            "commandClassName": "Basic",
+            "property": "duration",
+            "propertyName": "duration",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "duration",
+                "readable": true,
+                "writeable": false,
+                "label": "Remaining duration",
+                "stateful": true,
+                "secret": false
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 32,
+            "commandClassName": "Basic",
+            "property": "restorePrevious",
+            "propertyName": "restorePrevious",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "boolean",
+                "readable": false,
+                "writeable": true,
+                "label": "Restore previous value",
+                "states": {
+                    "true": "Restore"
+                },
+                "stateful": true,
+                "secret": false
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 32,
+            "commandClassName": "Basic",
+            "property": "event",
+            "propertyName": "event",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Event value",
+                "min": 0,
+                "max": 255,
+                "stateful": false,
+                "secret": false
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 38,
+            "commandClassName": "Multilevel Switch",
+            "property": "currentValue",
+            "propertyName": "currentValue",
+            "ccVersion": 0,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Current value",
+                "min": 0,
+                "max": 99,
+                "stateful": true,
+                "secret": false
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 38,
+            "commandClassName": "Multilevel Switch",
+            "property": "targetValue",
+            "propertyName": "targetValue",
+            "ccVersion": 0,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "Target value",
+                "valueChangeOptions": [
+                    "transitionDuration"
+                ],
+                "min": 0,
+                "max": 99,
+                "stateful": true,
+                "secret": false
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 38,
+            "commandClassName": "Multilevel Switch",
+            "property": "duration",
+            "propertyName": "duration",
+            "ccVersion": 0,
+            "metadata": {
+                "type": "duration",
+                "readable": true,
+                "writeable": false,
+                "label": "Remaining duration",
+                "stateful": true,
+                "secret": false
+            },
+            "value": {
+                "value": 0,
+                "unit": "seconds"
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 38,
+            "commandClassName": "Multilevel Switch",
+            "property": "Up",
+            "propertyName": "Up",
+            "ccVersion": 0,
+            "metadata": {
+                "type": "boolean",
+                "readable": false,
+                "writeable": true,
+                "label": "Perform a level change (Up)",
+                "ccSpecific": {
+                    "switchType": 2
+                },
+                "valueChangeOptions": [
+                    "transitionDuration"
+                ],
+                "stateful": true,
+                "secret": false
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 38,
+            "commandClassName": "Multilevel Switch",
+            "property": "Down",
+            "propertyName": "Down",
+            "ccVersion": 0,
+            "metadata": {
+                "type": "boolean",
+                "readable": false,
+                "writeable": true,
+                "label": "Perform a level change (Down)",
+                "ccSpecific": {
+                    "switchType": 2
+                },
+                "valueChangeOptions": [
+                    "transitionDuration"
+                ],
+                "stateful": true,
+                "secret": false
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 91,
+            "commandClassName": "Central Scene",
+            "property": "scene",
+            "propertyKey": "001",
+            "propertyName": "scene",
+            "propertyKeyName": "001",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Scene 001",
+                "min": 0,
+                "max": 255,
+                "states": {
+                    "0": "KeyPressed",
+                    "1": "KeyReleased",
+                    "2": "KeyHeldDown",
+                    "3": "KeyPressed2x",
+                    "4": "KeyPressed3x"
+                },
+                "stateful": true,
+                "secret": false
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 91,
+            "commandClassName": "Central Scene",
+            "property": "scene",
+            "propertyKey": "002",
+            "propertyName": "scene",
+            "propertyKeyName": "002",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Scene 002",
+                "min": 0,
+                "max": 255,
+                "states": {
+                    "0": "KeyPressed",
+                    "1": "KeyReleased",
+                    "2": "KeyHeldDown",
+                    "3": "KeyPressed2x",
+                    "4": "KeyPressed3x"
+                },
+                "stateful": true,
+                "secret": false
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 91,
+            "commandClassName": "Central Scene",
+            "property": "slowRefresh",
+            "propertyName": "slowRefresh",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "boolean",
+                "readable": true,
+                "writeable": true,
+                "description": "When this is true, KeyHeldDown notifications are sent every 55s. When this is false, the notifications are sent every 200ms.",
+                "label": "Send held down notifications at a slow rate",
+                "stateful": true,
+                "secret": false
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 3,
+            "propertyName": "LED Indicator",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "LED Indicator",
+                "default": 0,
+                "min": 0,
+                "max": 3,
+                "states": {
+                    "0": "On when load is off",
+                    "1": "On when load is on",
+                    "2": "Always off",
+                    "3": "Always on"
+                },
+                "valueSize": 1,
+                "format": 0,
+                "allowManualEntry": false,
+                "isFromConfig": true
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 4,
+            "propertyName": "Inverted Orientation",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "Inverted Orientation",
+                "default": 0,
+                "min": 0,
+                "max": 1,
+                "states": {
+                    "0": "Disable",
+                    "1": "Enable"
+                },
+                "valueSize": 1,
+                "format": 1,
+                "allowManualEntry": false,
+                "isFromConfig": true
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 6,
+            "propertyName": "Dim Rate",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "Dim Rate",
+                "default": 0,
+                "min": 0,
+                "max": 1,
+                "states": {
+                    "0": "Dim Quickly",
+                    "1": "Dim Slowly"
+                },
+                "valueSize": 1,
+                "format": 1,
+                "allowManualEntry": false,
+                "isFromConfig": true
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 16,
+            "propertyName": "Switch Mode",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "Switch Mode",
+                "default": 0,
+                "min": 0,
+                "max": 1,
+                "states": {
+                    "0": "Disable",
+                    "1": "Enable"
+                },
+                "valueSize": 1,
+                "format": 1,
+                "allowManualEntry": false,
+                "isFromConfig": true
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 19,
+            "propertyName": "Alternate Exclusion",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "description": "Press two times ON and two times OFF, LED will flash 5 times if successful",
+                "label": "Alternate Exclusion",
+                "default": 0,
+                "min": 0,
+                "max": 1,
+                "states": {
+                    "0": "Disable",
+                    "1": "Enable"
+                },
+                "valueSize": 1,
+                "format": 1,
+                "allowManualEntry": false,
+                "isFromConfig": true
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 30,
+            "propertyName": "Minimum Dimmer Threshold",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "Minimum Dimmer Threshold",
+                "default": 1,
+                "min": 1,
+                "max": 99,
+                "valueSize": 1,
+                "format": 1,
+                "allowManualEntry": true,
+                "isFromConfig": true
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 31,
+            "propertyName": "Maximum Dimmer Threshold",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "Maximum Dimmer Threshold",
+                "default": 99,
+                "min": 1,
+                "max": 99,
+                "valueSize": 1,
+                "format": 1,
+                "allowManualEntry": true,
+                "isFromConfig": true
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 32,
+            "propertyName": "Default Brightness Level",
+            "ccVersion": 4,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "label": "Default Brightness Level",
+                "default": 0,
+                "min": 0,
+                "max": 99,
+                "valueSize": 1,
+                "format": 1,
+                "allowManualEntry": true,
+                "isFromConfig": true
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 114,
+            "commandClassName": "Manufacturer Specific",
+            "property": "manufacturerId",
+            "propertyName": "manufacturerId",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Manufacturer ID",
+                "min": 0,
+                "max": 65535,
+                "stateful": true,
+                "secret": false
+            },
+            "value": 99
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 114,
+            "commandClassName": "Manufacturer Specific",
+            "property": "productType",
+            "propertyName": "productType",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Product type",
+                "min": 0,
+                "max": 65535,
+                "stateful": true,
+                "secret": false
+            },
+            "value": 18756
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 114,
+            "commandClassName": "Manufacturer Specific",
+            "property": "productId",
+            "propertyName": "productId",
+            "ccVersion": 2,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Product ID",
+                "min": 0,
+                "max": 65535,
+                "stateful": true,
+                "secret": false
+            },
+            "value": 12853
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "sdkVersion",
+            "propertyName": "sdkVersion",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "string",
+                "readable": true,
+                "writeable": false,
+                "label": "SDK version",
+                "stateful": true,
+                "secret": false
+            },
+            "value": "6.81.3"
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "applicationFrameworkAPIVersion",
+            "propertyName": "applicationFrameworkAPIVersion",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "string",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave application framework API version",
+                "stateful": true,
+                "secret": false
+            },
+            "value": "4.1.2"
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "applicationFrameworkBuildNumber",
+            "propertyName": "applicationFrameworkBuildNumber",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "string",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave application framework API build number",
+                "stateful": true,
+                "secret": false
+            },
+            "value": 52445
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "hostInterfaceVersion",
+            "propertyName": "hostInterfaceVersion",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "string",
+                "readable": true,
+                "writeable": false,
+                "label": "Serial API version",
+                "stateful": true,
+                "secret": false
+            },
+            "value": "unused"
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "hostInterfaceBuildNumber",
+            "propertyName": "hostInterfaceBuildNumber",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "string",
+                "readable": true,
+                "writeable": false,
+                "label": "Serial API build number",
+                "stateful": true,
+                "secret": false
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "zWaveProtocolVersion",
+            "propertyName": "zWaveProtocolVersion",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "string",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave protocol version",
+                "stateful": true,
+                "secret": false
+            },
+            "value": "6.4.0"
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "zWaveProtocolBuildNumber",
+            "propertyName": "zWaveProtocolBuildNumber",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "string",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave protocol build number",
+                "stateful": true,
+                "secret": false
+            },
+            "value": 91
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "applicationVersion",
+            "propertyName": "applicationVersion",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "string",
+                "readable": true,
+                "writeable": false,
+                "label": "Application version",
+                "stateful": true,
+                "secret": false
+            },
+            "value": "4.1.2"
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "applicationBuildNumber",
+            "propertyName": "applicationBuildNumber",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "string",
+                "readable": true,
+                "writeable": false,
+                "label": "Application build number",
+                "stateful": true,
+                "secret": false
+            },
+            "value": 52445
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "libraryType",
+            "propertyName": "libraryType",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Library type",
+                "states": {
+                    "0": "Unknown",
+                    "1": "Static Controller",
+                    "2": "Controller",
+                    "3": "Enhanced Slave",
+                    "4": "Slave",
+                    "5": "Installer",
+                    "6": "Routing Slave",
+                    "7": "Bridge Controller",
+                    "8": "Device under Test",
+                    "9": "N/A",
+                    "10": "AV Remote",
+                    "11": "AV Device"
+                },
+                "stateful": true,
+                "secret": false
+            },
+            "value": 3
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "protocolVersion",
+            "propertyName": "protocolVersion",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "string",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave protocol version",
+                "stateful": true,
+                "secret": false
+            },
+            "value": "6.4"
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "firmwareVersions",
+            "propertyName": "firmwareVersions",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "string[]",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave chip firmware versions",
+                "stateful": true,
+                "secret": false
+            },
+            "value": [
+                "5.54"
+            ]
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "hardwareVersion",
+            "propertyName": "hardwareVersion",
+            "ccVersion": 3,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave chip hardware version",
+                "stateful": true,
+                "secret": false
+            },
+            "value": 255
+        }
+    ],
+    "isFrequentListening": false,
+    "maxDataRate": 100000,
+    "supportedDataRates": [
+        40000,
+        100000
+    ],
+    "protocolVersion": 3,
+    "supportsBeaming": true,
+    "supportsSecurity": false,
+    "nodeType": 1,
+    "zwavePlusNodeType": 0,
+    "zwavePlusRoleType": 5,
+    "deviceClass": {
+        "basic": {
+            "key": 4,
+            "label": "Routing Slave"
+        },
+        "generic": {
+            "key": 17,
+            "label": "Multilevel Switch"
+        },
+        "specific": {
+            "key": 1,
+            "label": "Multilevel Power Switch"
+        },
+        "mandatorySupportedCCs": [
+            32,
+            38,
+            39
+        ],
+        "mandatoryControlledCCs": []
+    },
+    "interviewStage": "Complete",
+    "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x0063:0x4944:0x3235:5.54",
+    "statistics": {
+        "commandsTX": 6,
+        "commandsRX": 4,
+        "commandsDroppedRX": 1,
+        "commandsDroppedTX": 0,
+        "timeoutResponse": 1,
+        "rtt": 190.2,
+        "rssi": -79,
+        "lwr": {
+            "protocolDataRate": 3,
+            "repeaters": [
+                72
+            ],
+            "rssi": -78,
+            "repeaterRSSI": [
+                -83
+            ]
+        }
+    },
+    "highestSecurityClass": 1,
+    "isControllerNode": false,
+    "keepAwake": false
+}

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -516,6 +516,35 @@ def test_node_inclusion(multisensor_6_state):
     assert len(node.values) > 0
 
 
+def test_node_ready_event(switch_enbrighten_zw3010_state):
+    """Emulate a node ready event."""
+    # when a node node is added, it has minimal info first
+    node = node_pkg.Node(
+        None, {"nodeId": 2, "status": 1, "ready": False, "values": [], "endpoints": []}
+    )
+    assert node.node_id == 2
+    assert node.status == 1
+    assert not node.ready
+    assert len(node.values) == 0
+    assert node.device_config.manufacturer is None
+
+    # the ready event contains a full (and complete) dump of the node, including values
+    event = Event(
+        "ready",
+        {
+            "event": "ready",
+            "source": "node",
+            "nodeId": node.node_id,
+            "nodeState": switch_enbrighten_zw3010_state,
+            "result": [],
+        },
+    )
+    # This will fail if the schema is invalid
+    node.receive_event(event)
+
+    assert len(node.values) > 0
+
+
 async def test_node_status_events(multisensor_6):
     """Test Node status events."""
     node = multisensor_6

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -22,7 +22,7 @@ class MetaDataType(TypedDict, total=False):
     min: int | None
     max: int | None
     unit: str
-    states: dict[str | bool, str]
+    states: dict[str, str]
     ccSpecific: dict[str, Any]
     valueChangeOptions: list[str]
     allowManualEntry: bool

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -22,7 +22,7 @@ class MetaDataType(TypedDict, total=False):
     min: int
     max: int
     unit: str
-    states: dict[int, str]
+    states: dict[str, str]
     ccSpecific: dict[str, Any]
     valueChangeOptions: list[str]
     allowManualEntry: bool

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -19,10 +19,10 @@ class MetaDataType(TypedDict, total=False):
     writeable: bool  # required
     description: str
     label: str
-    min: int
-    max: int
+    min: int | None
+    max: int | None
     unit: str
-    states: dict[str, str]
+    states: dict[str | bool, str]
     ccSpecific: dict[str, Any]
     valueChangeOptions: list[str]
     allowManualEntry: bool


### PR DESCRIPTION
The below issues are happening because of this PR: https://github.com/zwave-js/node-zwave-js/pull/5792

Even though the original state keys are numeric, they are represented as strings so we should fix that typehint as well

Fixes https://github.com/home-assistant/core/issues/93252
Fixes https://github.com/home-assistant/core/issues/93299