### PR TITLE
Add support for config parameters not on endpoint 0

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -33,8 +33,8 @@ from zwave_js_server.exceptions import (
 from zwave_js_server.model import endpoint as endpoint_pkg
 from zwave_js_server.model import node as node_pkg
 from zwave_js_server.model.node.firmware import (
-    NodeFirmwareUpdateStatus,
     NodeFirmwareUpdateInfo,
+    NodeFirmwareUpdateStatus,
 )
 from zwave_js_server.model.node.health_check import (
     LifelineHealthCheckResultDataType,

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -35,7 +35,10 @@ async def test_configuration_parameter_values(
     # Put all config parameters on endpoint we are testing
     for state in (node_state, node_2_state):
         for value in state["values"]:
-            if value["commandClass"] == CommandClass.CONFIGURATION:
+            if (
+                value["commandClass"] == CommandClass.CONFIGURATION
+                and value["endpoint"] == 0
+            ):
                 value["endpoint"] = endpoint
 
     node: Node = Node(client, node_state)
@@ -164,7 +167,10 @@ async def test_bulk_set_partial_config_parameters(
     node_state = copy.deepcopy(multisensor_6_state)
     # Put all config parameters on endpoint we are testing
     for value in node_state["values"]:
-        if value["commandClass"] == CommandClass.CONFIGURATION:
+        if (
+            value["commandClass"] == CommandClass.CONFIGURATION
+            and value["endpoint"] == 0
+        ):
             value["endpoint"] = endpoint
     node: Node = Node(client, node_state)
     ack_commands = mock_command(
@@ -293,7 +299,10 @@ async def test_bulk_set_with_full_and_partial_parameters(
     node_state = copy.deepcopy(partial_and_full_parameter_state)
     # Put all config parameters on endpoint we are testing
     for value in node_state["values"]:
-        if value["commandClass"] == CommandClass.CONFIGURATION:
+        if (
+            value["commandClass"] == CommandClass.CONFIGURATION
+            and value["endpoint"] == 0
+        ):
             value["endpoint"] = endpoint
     node: Node = Node(client, node_state)
     ack_commands = mock_command(
@@ -326,7 +335,10 @@ async def test_failures(endpoint, client, multisensor_6_state, mock_command):
     node_state = copy.deepcopy(multisensor_6_state)
     # Put all config parameters on endpoint we are testing
     for value in node_state["values"]:
-        if value["commandClass"] == CommandClass.CONFIGURATION:
+        if (
+            value["commandClass"] == CommandClass.CONFIGURATION
+            and value["endpoint"] == 0
+        ):
             value["endpoint"] = endpoint
     node: Node = Node(client, node_state)
     # We need the node to be alive so we wait for a response
@@ -352,7 +364,10 @@ async def test_returned_values(endpoint, client, multisensor_6_state, mock_comma
     node_state = copy.deepcopy(multisensor_6_state)
     # Put all config parameters on endpoint we are testing
     for value in node_state["values"]:
-        if value["commandClass"] == CommandClass.CONFIGURATION:
+        if (
+            value["commandClass"] == CommandClass.CONFIGURATION
+            and value["endpoint"] == 0
+        ):
             value["endpoint"] = endpoint
     node: Node = Node(client, node_state)
     # We need the node to be alive so we wait for a response

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -1,4 +1,5 @@
 """Test node utility functions."""
+import copy
 from unittest.mock import patch
 
 import pytest
@@ -19,12 +20,26 @@ from zwave_js_server.util.node import (
 )
 
 
+@pytest.mark.parametrize("endpoint", [0, 1])
 async def test_configuration_parameter_values(
-    climate_radio_thermostat_ct100_plus, inovelli_switch, uuid4, mock_command
+    endpoint,
+    client,
+    climate_radio_thermostat_ct100_plus_state,
+    inovelli_switch_state,
+    uuid4,
+    mock_command,
 ):
     """Test node methods to get and set configuration parameter values."""
-    node: Node = climate_radio_thermostat_ct100_plus
-    node_2: Node = inovelli_switch
+    node_state = copy.deepcopy(climate_radio_thermostat_ct100_plus_state)
+    node_2_state = copy.deepcopy(inovelli_switch_state)
+    # Put all config parameters on endpoint we are testing
+    for state in (node_state, node_2_state):
+        for value in state["values"]:
+            if value["commandClass"] == CommandClass.CONFIGURATION:
+                value["endpoint"] = endpoint
+
+    node: Node = Node(client, node_state)
+    node_2: Node = Node(client, node_2_state)
     ack_commands = mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
         {"success": True},
@@ -43,11 +58,11 @@ async def test_configuration_parameter_values(
 
     # Test setting a configuration parameter that has no metadata
     with pytest.raises(NotImplementedError):
-        await async_set_config_parameter(node, 1, 2)
+        await async_set_config_parameter(node, 1, 2, endpoint=endpoint)
 
     # Test setting a manual entry configuration parameter with an invalid value
     with pytest.raises(InvalidNewValue):
-        await async_set_config_parameter(node_2, "Purple", 8, 255)
+        await async_set_config_parameter(node_2, "Purple", 8, 255, endpoint=endpoint)
 
     # Test setting a manual entry configuration parameter with a valid value
     ack_commands_2 = mock_command(
@@ -55,18 +70,20 @@ async def test_configuration_parameter_values(
         {"success": True},
     )
 
-    zwave_value, cmd_status = await async_set_config_parameter(node_2, 190, 8, 255)
+    zwave_value, cmd_status = await async_set_config_parameter(
+        node_2, 190, 8, 255, endpoint=endpoint
+    )
     assert isinstance(zwave_value, ConfigurationValue)
     assert cmd_status == CommandStatus.ACCEPTED
 
-    value = node_2.values["31-112-0-8-255"]
+    value = node_2.values[f"31-112-{endpoint}-8-255"]
     assert len(ack_commands_2) == 1
     assert ack_commands_2[0] == {
         "command": "node.set_value",
         "nodeId": node_2.node_id,
         "valueId": {
             "commandClass": 112,
-            "endpoint": 0,
+            "endpoint": endpoint,
             "property": 8,
             "propertyKey": 255,
         },
@@ -74,18 +91,20 @@ async def test_configuration_parameter_values(
         "messageId": uuid4,
     }
 
-    zwave_value, cmd_status = await async_set_config_parameter(node_2, "Blue", 8, 255)
+    zwave_value, cmd_status = await async_set_config_parameter(
+        node_2, "Blue", 8, 255, endpoint=endpoint
+    )
     assert isinstance(zwave_value, ConfigurationValue)
     assert cmd_status == CommandStatus.ACCEPTED
 
-    value = node_2.values["31-112-0-8-255"]
+    value = node_2.values[f"31-112-{endpoint}-8-255"]
     assert len(ack_commands_2) == 2
     assert ack_commands_2[1] == {
         "command": "node.set_value",
         "nodeId": node_2.node_id,
         "valueId": {
             "commandClass": 112,
-            "endpoint": 0,
+            "endpoint": endpoint,
             "property": 8,
             "propertyKey": 255,
         },
@@ -95,39 +114,41 @@ async def test_configuration_parameter_values(
 
     # Test setting an enumerated configuration parameter with an invalid value
     with pytest.raises(InvalidNewValue):
-        await async_set_config_parameter(node, 5, 1)
+        await async_set_config_parameter(node, 5, 1, endpoint=endpoint)
 
     # Test setting a range configuration parameter with an out of bounds value
     with pytest.raises(InvalidNewValue):
-        await async_set_config_parameter(node, 200, 10)
+        await async_set_config_parameter(node, 200, 10, endpoint=endpoint)
 
     # Test configuration parameter not found when using an invalid property name
     with pytest.raises(NotFoundError):
-        await async_set_config_parameter(node, 5, "fake configuration parameter name")
+        await async_set_config_parameter(
+            node, 5, "fake configuration parameter name", endpoint=endpoint
+        )
 
     # Test using an invalid state label to set a value
     with pytest.raises(InvalidNewValue):
-        await async_set_config_parameter(node, "fake state label", 1)
+        await async_set_config_parameter(node, "fake state label", 1, endpoint=endpoint)
 
     # Test configuration parameter not found when property key is invalid
     with pytest.raises(NotFoundError):
-        await async_set_config_parameter(node, 1, 1, property_key=1)
+        await async_set_config_parameter(node, 1, 1, property_key=1, endpoint=endpoint)
 
     # Test setting a configuration parameter by state label and property name
     zwave_value, cmd_status = await async_set_config_parameter(
-        node, "2.0\u00b0 F", "Temperature Reporting Threshold"
+        node, "2.0\u00b0 F", "Temperature Reporting Threshold", endpoint=endpoint
     )
     assert isinstance(zwave_value, ConfigurationValue)
     assert cmd_status == CommandStatus.ACCEPTED
 
-    value = node.values["13-112-0-1"]
+    value = node.values[f"13-112-{endpoint}-1"]
     assert len(ack_commands) == 3
     assert ack_commands[2] == {
         "command": "node.set_value",
         "nodeId": node.node_id,
         "valueId": {
             "commandClass": 112,
-            "endpoint": 0,
+            "endpoint": endpoint,
             "property": 1,
         },
         "value": 4,
@@ -135,14 +156,24 @@ async def test_configuration_parameter_values(
     }
 
 
-async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_command):
+@pytest.mark.parametrize("endpoint", [0, 1])
+async def test_bulk_set_partial_config_parameters(
+    endpoint, client, multisensor_6_state, uuid4, mock_command
+):
     """Test bulk setting partial config parameters."""
-    node: Node = multisensor_6
+    node_state = copy.deepcopy(multisensor_6_state)
+    # Put all config parameters on endpoint we are testing
+    for value in node_state["values"]:
+        if value["commandClass"] == CommandClass.CONFIGURATION:
+            value["endpoint"] = endpoint
+    node: Node = Node(client, node_state)
     ack_commands = mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
         {"success": True},
     )
-    cmd_status = await async_bulk_set_partial_config_parameters(node, 101, 241)
+    cmd_status = await async_bulk_set_partial_config_parameters(
+        node, 101, 241, endpoint=endpoint
+    )
     assert cmd_status == CommandStatus.QUEUED
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
@@ -150,6 +181,7 @@ async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_com
         "nodeId": node.node_id,
         "valueId": {
             "commandClass": CommandClass.CONFIGURATION.value,
+            "endpoint": endpoint,
             "property": 101,
         },
         "value": 241,
@@ -157,7 +189,7 @@ async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_com
     }
 
     cmd_status = await async_bulk_set_partial_config_parameters(
-        node, 101, {128: 1, 64: 1, 32: 1, 16: 1, 1: 1}
+        node, 101, {128: 1, 64: 1, 32: 1, 16: 1, 1: 1}, endpoint=endpoint
     )
     assert cmd_status == CommandStatus.QUEUED
     assert len(ack_commands) == 2
@@ -166,6 +198,7 @@ async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_com
         "nodeId": node.node_id,
         "valueId": {
             "commandClass": CommandClass.CONFIGURATION.value,
+            "endpoint": endpoint,
             "property": 101,
         },
         "value": 241,
@@ -174,7 +207,7 @@ async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_com
 
     # Only set some values so we use cached values for the rest
     cmd_status = await async_bulk_set_partial_config_parameters(
-        node, 101, {64: 1, 32: 1, 16: 1, 1: 1}
+        node, 101, {64: 1, 32: 1, 16: 1, 1: 1}, endpoint=endpoint
     )
     assert cmd_status == CommandStatus.QUEUED
     assert len(ack_commands) == 3
@@ -183,6 +216,7 @@ async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_com
         "nodeId": node.node_id,
         "valueId": {
             "commandClass": CommandClass.CONFIGURATION.value,
+            "endpoint": endpoint,
             "property": 101,
         },
         "value": 241,
@@ -199,6 +233,7 @@ async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_com
             "Group 1: Send ultraviolet reports": 1,
             "Group 1: Send battery reports": 1,
         },
+        endpoint=endpoint,
     )
     assert cmd_status == CommandStatus.QUEUED
     assert len(ack_commands) == 4
@@ -207,6 +242,7 @@ async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_com
         "nodeId": node.node_id,
         "valueId": {
             "commandClass": CommandClass.CONFIGURATION.value,
+            "endpoint": endpoint,
             "property": 101,
         },
         "value": 241,
@@ -215,49 +251,59 @@ async def test_bulk_set_partial_config_parameters(multisensor_6, uuid4, mock_com
 
     # Use an invalid property
     with pytest.raises(NotFoundError):
-        await async_bulk_set_partial_config_parameters(node, 999, 99)
+        await async_bulk_set_partial_config_parameters(node, 999, 99, endpoint=endpoint)
 
     # use an invalid bitmask
     with pytest.raises(NotFoundError):
         await async_bulk_set_partial_config_parameters(
-            node, 101, {128: 1, 64: 1, 32: 1, 16: 1, 2: 1}
+            node, 101, {128: 1, 64: 1, 32: 1, 16: 1, 2: 1}, endpoint=endpoint
         )
 
     # use an invalid property name
     with pytest.raises(NotFoundError):
         await async_bulk_set_partial_config_parameters(
-            node, 101, {"Invalid property name": 1}
+            node, 101, {"Invalid property name": 1}, endpoint=endpoint
         )
 
     # use an invalid bitmask
     with pytest.raises(BulkSetConfigParameterFailed):
         await async_bulk_set_partial_config_parameters(
-            node, 101, {128: 1, 64: 1, 32: 1, 16: 1, 1: 99999}
+            node, 101, {128: 1, 64: 1, 32: 1, 16: 1, 1: 99999}, endpoint=endpoint
         )
 
     # Try to bulkset a property that isn't broken into partials with a dictionary
     with pytest.raises(ValueTypeError):
-        await async_bulk_set_partial_config_parameters(node, 252, {1: 1})
+        await async_bulk_set_partial_config_parameters(
+            node, 252, {1: 1}, endpoint=endpoint
+        )
 
     # Try to bulkset a property that isn't broken into partials, it should fall back to
     # async_set_config_parameter
     with patch("zwave_js_server.util.node.async_set_config_parameter") as mock_cmd:
         mock_cmd.return_value = (None, None)
-        await async_bulk_set_partial_config_parameters(node, 252, 1)
+        await async_bulk_set_partial_config_parameters(node, 252, 1, endpoint=endpoint)
         mock_cmd.assert_called_once()
 
 
+@pytest.mark.parametrize("endpoint", [0, 1])
 async def test_bulk_set_with_full_and_partial_parameters(
-    partial_and_full_parameter, uuid4, mock_command
+    endpoint, client, partial_and_full_parameter_state, uuid4, mock_command
 ):
     """Test bulk setting config parameters when state has full and partial values."""
-    node: Node = partial_and_full_parameter
+    node_state = copy.deepcopy(partial_and_full_parameter_state)
+    # Put all config parameters on endpoint we are testing
+    for value in node_state["values"]:
+        if value["commandClass"] == CommandClass.CONFIGURATION:
+            value["endpoint"] = endpoint
+    node: Node = Node(client, node_state)
     ack_commands = mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
         {"success": True},
     )
 
-    cmd_status = await async_bulk_set_partial_config_parameters(node, 8, 34867929)
+    cmd_status = await async_bulk_set_partial_config_parameters(
+        node, 8, 34867929, endpoint=endpoint
+    )
 
     assert cmd_status == CommandStatus.ACCEPTED
     assert len(ack_commands) == 1
@@ -266,6 +312,7 @@ async def test_bulk_set_with_full_and_partial_parameters(
         "nodeId": node.node_id,
         "valueId": {
             "commandClass": CommandClass.CONFIGURATION.value,
+            "endpoint": endpoint,
             "property": 8,
         },
         "value": 34867929,
@@ -273,9 +320,15 @@ async def test_bulk_set_with_full_and_partial_parameters(
     }
 
 
-async def test_failures(multisensor_6, mock_command):
+@pytest.mark.parametrize("endpoint", [0, 1])
+async def test_failures(endpoint, client, multisensor_6_state, mock_command):
     """Test setting config parameter failures."""
-    node: Node = multisensor_6
+    node_state = copy.deepcopy(multisensor_6_state)
+    # Put all config parameters on endpoint we are testing
+    for value in node_state["values"]:
+        if value["commandClass"] == CommandClass.CONFIGURATION:
+            value["endpoint"] = endpoint
+    node: Node = Node(client, node_state)
     # We need the node to be alive so we wait for a response
     node.handle_alive(node)
 
@@ -286,16 +339,22 @@ async def test_failures(multisensor_6, mock_command):
 
     with pytest.raises(SetValueFailed):
         await async_bulk_set_partial_config_parameters(
-            node, 101, {64: 1, 32: 1, 16: 1, 1: 1}
+            node, 101, {64: 1, 32: 1, 16: 1, 1: 1}, endpoint=endpoint
         )
 
     with pytest.raises(SetValueFailed):
-        await async_set_config_parameter(node, 1, 101, 64)
+        await async_set_config_parameter(node, 1, 101, 64, endpoint=endpoint)
 
 
-async def test_returned_values(multisensor_6, mock_command):
+@pytest.mark.parametrize("endpoint", [0, 1])
+async def test_returned_values(endpoint, client, multisensor_6_state, mock_command):
     """Test returned values from setting config parameters."""
-    node: Node = multisensor_6
+    node_state = copy.deepcopy(multisensor_6_state)
+    # Put all config parameters on endpoint we are testing
+    for value in node_state["values"]:
+        if value["commandClass"] == CommandClass.CONFIGURATION:
+            value["endpoint"] = endpoint
+    node: Node = Node(client, node_state)
     # We need the node to be alive so we wait for a response
     node.handle_alive(node)
 
@@ -305,10 +364,12 @@ async def test_returned_values(multisensor_6, mock_command):
     )
 
     cmd_status = await async_bulk_set_partial_config_parameters(
-        node, 101, {64: 1, 32: 1, 16: 1, 1: 1}
+        node, 101, {64: 1, 32: 1, 16: 1, 1: 1}, endpoint=endpoint
     )
     assert cmd_status == CommandStatus.ACCEPTED
 
-    zwave_value, cmd_status = await async_set_config_parameter(node, 1, 101, 64)
+    zwave_value, cmd_status = await async_set_config_parameter(
+        node, 1, 101, 64, endpoint=endpoint
+    )
     assert isinstance(zwave_value, ConfigurationValue)
     assert cmd_status == CommandStatus.ACCEPTED

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -1,8 +1,8 @@
 """Provide a model for the Z-Wave JS node."""
 from __future__ import annotations
 
-from datetime import datetime
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 
 from ...const import (

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -142,7 +142,7 @@ async def async_bulk_set_partial_config_parameters(
     # If new_value is a dictionary, we need to calculate the full value to send
     if isinstance(new_value, dict):
         new_value = _get_int_from_partials_dict(
-            node, partial_param_values, property_, new_value
+            node, partial_param_values, property_, new_value, endpoint=endpoint
         )
     else:
         _validate_raw_int(partial_param_values, new_value)
@@ -151,6 +151,7 @@ async def async_bulk_set_partial_config_parameters(
         "set_value",
         valueId={
             "commandClass": CommandClass.CONFIGURATION.value,
+            "endpoint": endpoint,
             "property": property_,
         },
         value=new_value,

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -31,6 +31,7 @@ async def async_set_config_parameter(
     new_value: int | str,
     property_or_property_name: int | str,
     property_key: int | str | None = None,
+    endpoint: int = 0,
 ) -> tuple[ConfigurationValue, CommandStatus]:
     """
     Set a value for a config parameter on this node.
@@ -48,18 +49,20 @@ async def async_set_config_parameter(
                 config_value
                 for config_value in config_values.values()
                 if config_value.property_name == property_or_property_name
+                and config_value.endpoint == endpoint
             )
         except StopIteration:
             raise NotFoundError(
                 "Configuration parameter with parameter name "
-                f"{property_or_property_name} could not be found"
+                f"{property_or_property_name} on node {node} endpoint {endpoint} "
+                "could not be found"
             ) from None
     else:
         value_id = get_value_id_str(
             node,
             CommandClass.CONFIGURATION,
             property_or_property_name,
-            endpoint=0,
+            endpoint=endpoint,
             property_key=property_key,
         )
 
@@ -87,21 +90,28 @@ async def async_set_config_parameter(
 
 
 async def async_bulk_set_partial_config_parameters(
-    node: Node, property_: int, new_value: int | dict[int | str, int | str]
+    node: Node,
+    property_: int,
+    new_value: int | dict[int | str, int | str],
+    endpoint: int = 0,
 ) -> CommandStatus:
     """Bulk set partial configuration values on this node."""
     config_values = node.get_configuration_values()
     partial_param_values = {
         value_id: value
         for value_id, value in config_values.items()
-        if value.property_ == property_ and value.property_key is not None
+        if value.property_ == property_
+        and value.endpoint == endpoint
+        and value.property_key is not None
     }
 
     if not partial_param_values:
         # If we find a value with this property_, we know this value isn't split
         # into partial params
         if (
-            get_value_id_str(node, CommandClass.CONFIGURATION, property_)
+            get_value_id_str(
+                node, CommandClass.CONFIGURATION, property_, endpoint=endpoint
+            )
             in config_values
         ):
             # If the new value is provided as a dict, we don't have enough information
@@ -109,7 +119,7 @@ async def async_bulk_set_partial_config_parameters(
             if isinstance(new_value, dict):
                 raise ValueTypeError(
                     f"Configuration parameter {property_} for node {node.node_id} "
-                    "does not have partials"
+                    f"endpoint {endpoint} does not have partials"
                 )
             # If the new value is provided as an int, we may as well try to set it
             # using the standard utility function
@@ -117,13 +127,16 @@ async def async_bulk_set_partial_config_parameters(
                 "Falling back to async_set_config_parameter because no partials "
                 "were found"
             )
-            _, cmd_status = await async_set_config_parameter(node, new_value, property_)
+            _, cmd_status = await async_set_config_parameter(
+                node, new_value, property_, endpoint=endpoint
+            )
             return cmd_status
 
         # Otherwise if we can't find any values with this property, this config
         # parameter does not exist
         raise NotFoundError(
-            f"Configuration parameter {property_} for node {node.node_id} not found"
+            f"Configuration parameter {property_} for node {node.node_id} endpoint "
+            f"{endpoint} not found"
         )
 
     # If new_value is a dictionary, we need to calculate the full value to send
@@ -239,7 +252,7 @@ def _bulk_set_validate_and_transform_new_value(
         return _validate_and_transform_new_value(zwave_value, new_partial_value)
     except (InvalidNewValue, NotImplementedError) as err:
         raise BulkSetConfigParameterFailed(
-            f"Config parameter {zwave_value.property_} failed validation on partial "
+            f"Config parameter {zwave_value.value_id} failed validation on partial "
             f"parameter {property_key}"
         ) from err
 
@@ -249,6 +262,7 @@ def _get_int_from_partials_dict(
     partial_param_values: dict[str, ConfigurationValue],
     property_: int,
     new_value: dict[int | str, int | str],
+    endpoint: int = 0,
 ) -> int:
     """Take an input dict for a set of partial values and compute the raw int value."""
     int_value = 0
@@ -264,11 +278,13 @@ def _get_int_from_partials_dict(
                 CommandClass.CONFIGURATION,
                 property_,
                 property_key=property_key_or_name,
+                endpoint=endpoint,
             )
             if value_id not in partial_param_values:
                 raise NotFoundError(
                     f"Bitmask {property_key_or_name} ({hex(property_key_or_name)}) "
-                    f"not found for parameter {property_}"
+                    f"not found for parameter {property_} on node {node} endpoint "
+                    f"{endpoint}"
                 )
             zwave_value = partial_param_values[value_id]
         # If the dict key is a property name, we have to find the value from the list
@@ -279,11 +295,13 @@ def _get_int_from_partials_dict(
                     value
                     for value in partial_param_values.values()
                     if value.property_name == property_key_or_name
+                    and value.endpoint == endpoint
                 )
             except StopIteration:
                 raise NotFoundError(
                     f"Partial parameter with label '{property_key_or_name}'"
-                    f"not found for parameter {property_}"
+                    f"not found for parameter {property_} on node {node} endpoint "
+                    f"{endpoint}"
                 ) from None
 
         provided_partial_values.append(zwave_value)


### PR DESCRIPTION
The util functions were built with the assumption that config parameters would always be on endpoint 0. That is no longer the case so we need to update the utility functions accordingly