### PR TITLE
Bump zwave-js-server-python to 0.48.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.48.1"
+VERSION = "0.48.2"
 
 
 setup(


### PR DESCRIPTION
Because endpoint was added to the end of the function in https://github.com/home-assistant-libs/zwave-js-server-python/pull/668, the change is backwards compatible so this can be a patch release