### PR TITLE
Bump zwave-js-server-python to 0.49.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.48.1"
+VERSION = "0.49.0"
 
 
 setup(


### PR DESCRIPTION
We need to release https://github.com/home-assistant-libs/zwave-js-server-python/pull/676 for a PR I am about to submit in HA core that I'd like to get in ahead of the beta, but per another conversation, we are bumping minor because of the change to support config parameters that are not on endpoint 0. We may have to do a patch bump in the future to raise the schema version so that we can push users onto v11.