### PR TITLE
Add support for zwave-js 11 (schema 29)

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -222,7 +222,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 28,
+        "maxSchemaVersion": 29,
     }
 
 

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1981,7 +1981,7 @@ async def test_node_removed(client, multisensor_6, multisensor_6_state):
             "source": "controller",
             "event": "node removed",
             "node": multisensor_6_state,
-            "replaced": False,
+            "reason": 0,
         },
     )
     client.driver.controller.receive_event(event)

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -683,7 +683,7 @@ async def test_begin_exclusion_unprovision(controller, uuid4, mock_command):
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.begin_exclusion",
-        "strategy": ExclusionStrategy.EXCLUDE_ONLY,
+        "options": {"strategy": ExclusionStrategy.EXCLUDE_ONLY},
         "messageId": uuid4,
     }
 

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1811,9 +1811,9 @@ async def test_begin_ota_firmware_update(multisensor_6, uuid4, mock_command):
     """Test get available firmware updates."""
     ack_commands = mock_command(
         {"command": "controller.firmware_update_ota"},
-        {"success": True},
+        {"result": {"status": 255, "success": True, "reInterview": False}},
     )
-    assert await multisensor_6.client.driver.controller.async_firmware_update_ota(
+    result = await multisensor_6.client.driver.controller.async_firmware_update_ota(
         multisensor_6,
         [
             NodeFirmwareUpdateFileInfo(
@@ -1821,6 +1821,9 @@ async def test_begin_ota_firmware_update(multisensor_6, uuid4, mock_command):
             )
         ],
     )
+    assert result.status == 255
+    assert result.success
+    assert not result.reinterview
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {

--- a/test/model/test_value.py
+++ b/test/model/test_value.py
@@ -1,9 +1,15 @@
 """Test value model."""
 from copy import deepcopy
 
-from zwave_js_server.const import ConfigurationValueType
+from zwave_js_server.const import ConfigurationValueType, SetValueStatus
 from zwave_js_server.model.node import Node
-from zwave_js_server.model.value import get_value_id_str
+from zwave_js_server.model.value import (
+    ConfigurationValue,
+    MetaDataType,
+    SetValueResult,
+    ValueDataType,
+    get_value_id_str,
+)
 
 
 def test_value_size(lock_schlage_be469):
@@ -67,3 +73,148 @@ def test_secret(lock_schlage_be469):
     node = lock_schlage_be469
     zwave_value = node.values["20-112-0-3"]
     assert zwave_value.metadata.stateful
+
+
+def test_configuration_value_type(inovelli_switch_state):
+    """Test configuration value types."""
+    value = ConfigurationValue(
+        inovelli_switch_state,
+        ValueDataType(
+            commandClass=112,
+            property=8,
+            propertyName="8",
+            endpoint=0,
+            metadata=MetaDataType(
+                type="boolean",
+                max=2,
+                min=0,
+                allowManualEntry=True,
+                statues={True: "On", False: "Off"},
+            ),
+        ),
+    )
+    assert value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
+
+    value = ConfigurationValue(
+        inovelli_switch_state,
+        ValueDataType(
+            commandClass=112,
+            property=8,
+            propertyName="8",
+            endpoint=0,
+            metadata=MetaDataType(
+                type="boolean",
+                max=1,
+                min=0,
+                allowManualEntry=False,
+                states={True: "On", False: "Off"},
+            ),
+        ),
+    )
+    assert value.configuration_value_type == ConfigurationValueType.ENUMERATED
+
+    value = ConfigurationValue(
+        inovelli_switch_state,
+        ValueDataType(
+            commandClass=112,
+            property=8,
+            propertyName="8",
+            endpoint=0,
+            metadata=MetaDataType(
+                type="boolean",
+                max=1,
+                min=0,
+                allowManualEntry=False,
+            ),
+        ),
+    )
+    assert value.configuration_value_type == ConfigurationValueType.BOOLEAN
+
+    value = ConfigurationValue(
+        inovelli_switch_state,
+        ValueDataType(
+            commandClass=112,
+            property=8,
+            propertyName="8",
+            endpoint=0,
+            metadata=MetaDataType(
+                type="number",
+                max=2,
+                min=0,
+                allowManualEntry=True,
+                statues={0: "On", 1: "Off"},
+            ),
+        ),
+    )
+    assert value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
+
+    value = ConfigurationValue(
+        inovelli_switch_state,
+        ValueDataType(
+            commandClass=112,
+            property=8,
+            propertyName="8",
+            endpoint=0,
+            metadata=MetaDataType(
+                type="number",
+                max=1,
+                min=0,
+                allowManualEntry=False,
+                states={"1": "On", "0": "Off"},
+            ),
+        ),
+    )
+    assert value.configuration_value_type == ConfigurationValueType.ENUMERATED
+
+    value = ConfigurationValue(
+        inovelli_switch_state,
+        ValueDataType(
+            commandClass=112,
+            property=8,
+            propertyName="8",
+            endpoint=0,
+            metadata=MetaDataType(
+                type="number",
+                max=2,
+                min=0,
+                allowManualEntry=False,
+            ),
+        ),
+    )
+    assert value.configuration_value_type == ConfigurationValueType.RANGE
+
+    value = ConfigurationValue(
+        inovelli_switch_state,
+        ValueDataType(
+            commandClass=112,
+            property=8,
+            propertyName="8",
+            endpoint=0,
+            metadata=MetaDataType(
+                type="number",
+                allowManualEntry=False,
+            ),
+        ),
+    )
+    assert value.configuration_value_type == ConfigurationValueType.UNDEFINED
+
+
+def test_set_value_result_str():
+    """Test SetValueResult str."""
+    result = SetValueResult({"status": 255})
+    assert result.status == SetValueStatus.SUCCESS
+    assert str(result) == "Success"
+
+    result = SetValueResult({"status": 1, "remainingDuration": {"unit": "default"}})
+    assert result.status == SetValueStatus.WORKING
+    assert str(result) == "Working (default duration)"
+
+    result = SetValueResult(
+        {"status": 1, "remainingDuration": {"unit": "seconds", "value": 1}}
+    )
+    assert result.status == SetValueStatus.WORKING
+    assert str(result) == "Working (1 seconds)"
+
+    result = SetValueResult({"status": 3, "message": "test"})
+    assert result.status == SetValueStatus.ENDPOINT_NOT_FOUND
+    assert str(result) == "Endpoint Not Found: test"

--- a/test/model/test_value.py
+++ b/test/model/test_value.py
@@ -89,7 +89,7 @@ def test_configuration_value_type(inovelli_switch_state):
                 max=2,
                 min=0,
                 allowManualEntry=True,
-                statues={True: "On", False: "Off"},
+                states={True: "On", False: "Off"},
             ),
         ),
     )
@@ -142,7 +142,7 @@ def test_configuration_value_type(inovelli_switch_state):
                 max=2,
                 min=0,
                 allowManualEntry=True,
-                statues={0: "On", 1: "Off"},
+                states={0: "On", 1: "Off"},
             ),
         ),
     )

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -339,6 +339,7 @@ async def test_command_error_handling(client, mock_command):
 
 async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
     """Test recording messages."""
+    # pylint: disable=protected-access
     client = wallmote_central_scene.client
     assert not client.recording_messages
     assert not client._recorded_commands
@@ -437,6 +438,7 @@ async def test_record_messages(wallmote_central_scene, mock_command, uuid4):
 
 async def test_additional_user_agent_components(client_session, url):
     """Test additionalUserAgentComponents parameter."""
+    # pylint: disable=protected-access
     client = Client(
         url, client_session, additional_user_agent_components={"foo": "bar"}
     )
@@ -452,7 +454,7 @@ async def test_additional_user_agent_components(client_session, url):
             {
                 "command": "initialize",
                 "messageId": "initialize",
-                "schemaVersion": 28,
+                "schemaVersion": 29,
                 "additionalUserAgentComponents": {
                     "zwave-js-server-python": __version__,
                     "foo": "bar",

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -105,7 +105,7 @@ async def test_dump_additional_user_agent_components(
         {
             "command": "initialize",
             "messageId": "initialize",
-            "schemaVersion": 28,
+            "schemaVersion": 29,
             "additionalUserAgentComponents": {
                 "zwave-js-server-python": __version__,
                 "foo": "bar",

--- a/test/test_firmware.py
+++ b/test/test_firmware.py
@@ -2,8 +2,14 @@
 from unittest.mock import patch
 
 from zwave_js_server.firmware import controller_firmware_update_otw, update_firmware
-from zwave_js_server.model.controller.firmware import ControllerFirmwareUpdateData
-from zwave_js_server.model.node.firmware import NodeFirmwareUpdateData
+from zwave_js_server.model.controller.firmware import (
+    ControllerFirmwareUpdateData,
+    ControllerFirmwareUpdateStatus,
+)
+from zwave_js_server.model.node.firmware import (
+    NodeFirmwareUpdateData,
+    NodeFirmwareUpdateStatus,
+)
 
 
 async def test_update_firmware_guess_format(url, client_session, multisensor_6):
@@ -16,10 +22,15 @@ async def test_update_firmware_guess_format(url, client_session, multisensor_6):
         "zwave_js_server.firmware.Client.disconnect"
     ) as disconnect_mock:
         node = multisensor_6
-        cmd_mock.return_value = {"success": True}
-        assert await update_firmware(
+        cmd_mock.return_value = {
+            "result": {"status": 255, "success": True, "reInterview": False}
+        }
+        result = await update_firmware(
             url, node, [NodeFirmwareUpdateData("test", bytes(10))], client_session
         )
+        assert result.status == NodeFirmwareUpdateStatus.OK_RESTART_PENDING
+        assert result.success
+        assert not result.reinterview
 
         connect_mock.assert_called_once()
         initialize_mock.assert_called_once()
@@ -51,13 +62,18 @@ async def test_update_firmware_known_format_and_target(
         "zwave_js_server.firmware.Client.disconnect"
     ) as disconnect_mock:
         node = multisensor_6
-        cmd_mock.return_value = {"success": True}
-        assert await update_firmware(
+        cmd_mock.return_value = {
+            "result": {"status": 255, "success": True, "reInterview": False}
+        }
+        result = await update_firmware(
             url=url,
             node=node,
             updates=[NodeFirmwareUpdateData("test", bytes(10), "test", 1)],
             session=client_session,
         )
+        assert result.status == NodeFirmwareUpdateStatus.OK_RESTART_PENDING
+        assert result.success
+        assert not result.reinterview
 
         connect_mock.assert_called_once()
         initialize_mock.assert_called_once()
@@ -88,10 +104,12 @@ async def test_controller_firmware_update_otw_guess_format(url, client_session):
     ) as cmd_mock, patch(
         "zwave_js_server.firmware.Client.disconnect"
     ) as disconnect_mock:
-        cmd_mock.return_value = {"success": True}
-        assert await controller_firmware_update_otw(
+        cmd_mock.return_value = {"result": {"status": 255, "success": True}}
+        result = await controller_firmware_update_otw(
             url, ControllerFirmwareUpdateData("test", bytes(10)), client_session
         )
+        assert result.status == ControllerFirmwareUpdateStatus.OK
+        assert result.success
 
         connect_mock.assert_called_once()
         initialize_mock.assert_called_once()
@@ -117,12 +135,14 @@ async def test_controller_firmware_update_otw_known_format_and_target(
     ) as cmd_mock, patch(
         "zwave_js_server.firmware.Client.disconnect"
     ) as disconnect_mock:
-        cmd_mock.return_value = {"success": True}
-        assert await controller_firmware_update_otw(
+        cmd_mock.return_value = {"result": {"status": 255, "success": True}}
+        result = await controller_firmware_update_otw(
             url=url,
             firmware_file=ControllerFirmwareUpdateData("test", bytes(10), "test"),
             session=client_session,
         )
+        assert result.status == ControllerFirmwareUpdateStatus.OK
+        assert result.success
 
         connect_mock.assert_called_once()
         initialize_mock.assert_called_once()

--- a/test/test_firmware.py
+++ b/test/test_firmware.py
@@ -45,7 +45,7 @@ async def test_update_firmware_guess_format(url, client_session, multisensor_6):
                     }
                 ],
             },
-            require_schema=24,
+            require_schema=29,
         )
         disconnect_mock.assert_called_once()
 
@@ -90,7 +90,7 @@ async def test_update_firmware_known_format_and_target(
                     }
                 ],
             },
-            require_schema=24,
+            require_schema=29,
         )
         disconnect_mock.assert_called_once()
 
@@ -119,7 +119,7 @@ async def test_controller_firmware_update_otw_guess_format(url, client_session):
                 "filename": "test",
                 "file": "AAAAAAAAAAAAAA==",
             },
-            require_schema=25,
+            require_schema=29,
         )
         disconnect_mock.assert_called_once()
 
@@ -153,6 +153,6 @@ async def test_controller_firmware_update_otw_known_format_and_target(
                 "file": "AAAAAAAAAAAAAA==",
                 "fileFormat": "test",
             },
-            require_schema=25,
+            require_schema=29,
         )
         disconnect_mock.assert_called_once()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -55,7 +55,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 28}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 29}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'initialize'}\n"
         "test_result\n"
     )

--- a/test/util/test_lock.py
+++ b/test/util/test_lock.py
@@ -54,7 +54,7 @@ async def test_set_usercode(lock_schlage_be469, mock_command, uuid4):
     node = lock_schlage_be469
     ack_commands = mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
-        {"success": True},
+        {"result": {"status": 255}},
     )
 
     # Test valid code
@@ -93,7 +93,7 @@ async def test_clear_usercode(lock_schlage_be469, mock_command, uuid4):
     node = lock_schlage_be469
     ack_commands = mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
-        {"success": True},
+        {"result": {"status": 255}},
     )
 
     # Test valid code

--- a/test/util/test_multicast.py
+++ b/test/util/test_multicast.py
@@ -1,5 +1,5 @@
 """Test node utility functions."""
-from zwave_js_server.const import CommandClass
+from zwave_js_server.const import CommandClass, SetValueStatus
 from zwave_js_server.util.multicast import (
     async_multicast_endpoint_get_cc_version,
     async_multicast_endpoint_invoke_cc_api,
@@ -141,12 +141,13 @@ async def test_set_value_broadcast(client, driver, uuid4, mock_command):
     """Test broadcast_node.set_value command."""
     ack_commands = mock_command(
         {"command": "broadcast_node.set_value"},
-        {"success": True},
+        {"result": {"status": 255}},
     )
 
-    assert await async_multicast_set_value(
+    result = await async_multicast_set_value(
         client, 1, {"commandClass": 1, "property": 1}
     )
+    assert result.status == SetValueStatus.SUCCESS
 
     assert ack_commands[0] == {
         "command": "broadcast_node.set_value",
@@ -165,12 +166,13 @@ async def test_set_value_multicast(
     node2 = inovelli_switch
     ack_commands = mock_command(
         {"command": "multicast_group.set_value"},
-        {"success": True},
+        {"result": {"status": 255}},
     )
 
-    assert await async_multicast_set_value(
+    result = await async_multicast_set_value(
         client, 1, {"commandClass": 112, "property": 1}, [node1, node2]
     )
+    assert result.status == SetValueStatus.SUCCESS
 
     assert ack_commands[0] == {
         "command": "multicast_group.set_value",
@@ -190,12 +192,13 @@ async def test_set_value_multicast_basic(
     node2 = inovelli_switch
     ack_commands = mock_command(
         {"command": "multicast_group.set_value"},
-        {"success": True},
+        {"result": {"status": 255}},
     )
 
-    assert await async_multicast_set_value(
+    result = await async_multicast_set_value(
         client, 1, {"commandClass": 32, "property": "targetValue"}, [node1, node2]
     )
+    assert result.status == SetValueStatus.SUCCESS
 
     assert ack_commands[0] == {
         "command": "multicast_group.set_value",
@@ -305,12 +308,13 @@ async def test_set_value_broadcast_missing_value(
     """Test multicast_group.set_value command with value missing from a node."""
     ack_commands = mock_command(
         {"command": "broadcast_node.set_value"},
-        {"success": True},
+        {"result": {"status": 255}},
     )
 
-    assert await async_multicast_set_value(
+    result = await async_multicast_set_value(
         client, 1, {"commandClass": 67, "property": "blah"}
     )
+    assert result.status == SetValueStatus.SUCCESS
 
     assert ack_commands[0] == {
         "command": "broadcast_node.set_value",

--- a/test/util/test_node.py
+++ b/test/util/test_node.py
@@ -45,7 +45,7 @@ async def test_configuration_parameter_values(
     node_2: Node = Node(client, node_2_state)
     ack_commands = mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
-        {"success": True},
+        {"result": {"status": 255}},
     )
 
     assert node.node_id == 13
@@ -70,7 +70,7 @@ async def test_configuration_parameter_values(
     # Test setting a manual entry configuration parameter with a valid value
     ack_commands_2 = mock_command(
         {"command": "node.set_value", "nodeId": node_2.node_id},
-        {"success": True},
+        {"result": {"status": 255}},
     )
 
     zwave_value, cmd_status = await async_set_config_parameter(
@@ -175,7 +175,7 @@ async def test_bulk_set_partial_config_parameters(
     node: Node = Node(client, node_state)
     ack_commands = mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
-        {"success": True},
+        {"result": {"status": 255}},
     )
     cmd_status = await async_bulk_set_partial_config_parameters(
         node, 101, 241, endpoint=endpoint
@@ -307,7 +307,7 @@ async def test_bulk_set_with_full_and_partial_parameters(
     node: Node = Node(client, node_state)
     ack_commands = mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
-        {"success": True},
+        {"result": {"status": 255}},
     )
 
     cmd_status = await async_bulk_set_partial_config_parameters(
@@ -346,7 +346,7 @@ async def test_failures(endpoint, client, multisensor_6_state, mock_command):
 
     mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
-        {"success": False},
+        {"result": {"status": 0}},
     )
 
     with pytest.raises(SetValueFailed):
@@ -375,7 +375,7 @@ async def test_returned_values(endpoint, client, multisensor_6_state, mock_comma
 
     mock_command(
         {"command": "node.set_value", "nodeId": node.node_id},
-        {"success": True},
+        {"result": {"status": 255}},
     )
 
     cmd_status = await async_bulk_set_partial_config_parameters(

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -8,9 +8,9 @@ PACKAGE_NAME = "zwave-js-server-python"
 __version__ = metadata.version(PACKAGE_NAME)
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 28
+MIN_SERVER_SCHEMA_VERSION = 29
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 28
+MAX_SERVER_SCHEMA_VERSION = 29
 
 VALUE_UNKNOWN = "unknown"
 
@@ -201,6 +201,7 @@ class NodeStatus(IntEnum):
 class ConfigurationValueType(str, Enum):
     """Enum for configuration value types."""
 
+    BOOLEAN = "boolean"
     ENUMERATED = "enumerated"
     MANUAL_ENTRY = "manual_entry"
     RANGE = "range"
@@ -362,3 +363,25 @@ class SecurityBootstrapFailure(IntEnum):
     S2_INCORRECT_PIN = 6
     S2_WRONG_SECURITY_LEVEL = 7
     UNKNOWN = 8
+
+
+class SetValueStatus(IntEnum):
+    """Enum for all known setValue statuses."""
+
+    # https://github.com/zwave-js/node-zwave-js/blob/v11-dev/packages/cc/src/lib/API.ts#L83
+    # The device reports no support for this command
+    NO_DEVICE_SUPPORT = 0
+    # The device has accepted the command and is working on it
+    WORKING = 1
+    # The device has rejected the command
+    FAIL = 2
+    # The endpoint specified in the value ID does not exist
+    ENDPOINT_NOT_FOUND = 3
+    # The given CC or its API is not implemented (yet) or it has no `setValue` implementation
+    NOT_IMPLEMENTED = 4
+    # The value to set (or a related value) is invalid
+    INVALID_VALUE = 5
+    # The command was sent successfully, but it is unknown whether it was executed
+    SUCCESS_UNSUPERVISED = 254
+    # The device has executed the command successfully
+    SUCCESS = 255

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -368,7 +368,7 @@ class SecurityBootstrapFailure(IntEnum):
 class SetValueStatus(IntEnum):
     """Enum for all known setValue statuses."""
 
-    # https://github.com/zwave-js/node-zwave-js/blob/v11-dev/packages/cc/src/lib/API.ts#L83
+    # https://github.com/zwave-js/node-zwave-js/blob/master/packages/cc/src/lib/API.ts#L83
     # The device reports no support for this command
     NO_DEVICE_SUPPORT = 0
     # The device has accepted the command and is working on it
@@ -385,3 +385,23 @@ class SetValueStatus(IntEnum):
     SUCCESS_UNSUPERVISED = 254
     # The device has executed the command successfully
     SUCCESS = 255
+
+
+class RemoveNodeReason(IntEnum):
+    """Enum for all known reasons why a node was removed."""
+
+    # https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/controller/Inclusion.ts#L266
+    # The node was excluded by the user or an inclusion controller
+    EXCLUDED = 0
+    # The node was excluded by an inclusion controller
+    PROXY_EXCLUDED = 1
+    # The node was removed using the "remove failed node" feature
+    REMOVE_FAILED = 2
+    # The node was replaced using the "replace failed node" feature
+    REPLACED = 3
+    # The node was replaced by an inclusion controller
+    PROXY_REPLACED = 4
+    # The node was reset locally and was auto-removed
+    RESET = 5
+    # SmartStart inclusion failed, and the node was auto-removed as a result.
+    SMART_START_FAILED = 6

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -387,6 +387,13 @@ class SetValueStatus(IntEnum):
     SUCCESS = 255
 
 
+SET_VALUE_SUCCESS = (
+    SetValueStatus.SUCCESS,
+    SetValueStatus.SUCCESS_UNSUPERVISED,
+    SetValueStatus.WORKING,
+)
+
+
 class RemoveNodeReason(IntEnum):
     """Enum for all known reasons why a node was removed."""
 

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -2,14 +2,16 @@
 from __future__ import annotations
 
 import asyncio
-from typing import cast
 
 import aiohttp
 
 from .client import Client
-from .model.controller.firmware import ControllerFirmwareUpdateData
+from .model.controller.firmware import (
+    ControllerFirmwareUpdateData,
+    ControllerFirmwareUpdateResult,
+)
 from .model.node import Node
-from .model.node.firmware import NodeFirmwareUpdateData
+from .model.node.firmware import NodeFirmwareUpdateData, NodeFirmwareUpdateResult
 
 
 async def update_firmware(
@@ -18,7 +20,7 @@ async def update_firmware(
     updates: list[NodeFirmwareUpdateData],
     session: aiohttp.ClientSession,
     additional_user_agent_components: dict[str, str] | None = None,
-) -> bool:
+) -> NodeFirmwareUpdateResult:
     """Send updateFirmware command to Node."""
     client = Client(
         url, session, additional_user_agent_components=additional_user_agent_components
@@ -39,7 +41,7 @@ async def update_firmware(
     if not receive_task.done():
         receive_task.cancel()
 
-    return cast(bool, data["success"])
+    return NodeFirmwareUpdateResult(node, data["result"])
 
 
 async def controller_firmware_update_otw(
@@ -47,7 +49,7 @@ async def controller_firmware_update_otw(
     firmware_file: ControllerFirmwareUpdateData,
     session: aiohttp.ClientSession,
     additional_user_agent_components: dict[str, str] | None = None,
-) -> bool:
+) -> ControllerFirmwareUpdateResult:
     """
     Send firmwareUpdateOTW command to Controller.
 
@@ -74,4 +76,4 @@ async def controller_firmware_update_otw(
     if not receive_task.done():
         receive_task.cancel()
 
-    return cast(bool, data["success"])
+    return ControllerFirmwareUpdateResult(data["result"])

--- a/zwave_js_server/firmware.py
+++ b/zwave_js_server/firmware.py
@@ -36,7 +36,7 @@ async def update_firmware(
         "updates": [update.to_dict() for update in updates],
     }
 
-    data = await client.async_send_command(cmd, require_schema=24)
+    data = await client.async_send_command(cmd, require_schema=29)
     await client.disconnect()
     if not receive_task.done():
         receive_task.cancel()
@@ -70,7 +70,7 @@ async def controller_firmware_update_otw(
             "command": "controller.firmware_update_otw",
             **firmware_file.to_dict(),
         },
-        require_schema=25,
+        require_schema=29,
     )
     await client.disconnect()
     if not receive_task.done():

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -375,7 +375,7 @@ class Controller(EventBase):
         self, strategy: ExclusionStrategy | None = None
     ) -> bool:
         """Send beginExclusion command to Controller."""
-        payload: dict[str, str | ExclusionStrategy] = {
+        payload: dict[str, str | dict[str, ExclusionStrategy]] = {
             "command": "controller.begin_exclusion"
         }
         if strategy is not None:

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -16,6 +16,7 @@ from ...const import (
     InclusionStrategy,
     NodeType,
     QRCodeVersion,
+    RemoveNodeReason,
     RFRegion,
     ZwaveFeature,
 )
@@ -868,6 +869,7 @@ class Controller(EventBase):
 
     def handle_node_removed(self, event: Event) -> None:
         """Process a node removed event."""
+        event.data["reason"] = RemoveNodeReason(event.data["reason"])
         event.data["node"] = self.nodes.pop(event.data["node"]["nodeId"])
         # Remove client from node since it's no longer connected to the controller
         event.data["node"].client = None

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -792,7 +792,7 @@ class Controller(EventBase):
                 "nodeId": node.node_id,
                 "updates": [update.to_dict() for update in updates],
             },
-            require_schema=24,
+            require_schema=29,
         )
         return NodeFirmwareUpdateResult(node, data["result"])
 

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -379,7 +379,7 @@ class Controller(EventBase):
             "command": "controller.begin_exclusion"
         }
         if strategy is not None:
-            payload["strategy"] = strategy
+            payload["options"] = {"strategy": strategy}
         data = await self.client.async_send_command(payload, require_schema=22)
         return cast(bool, data["success"])
 

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -869,7 +869,6 @@ class Controller(EventBase):
 
     def handle_node_removed(self, event: Event) -> None:
         """Process a node removed event."""
-        event.data["reason"] = RemoveNodeReason(event.data["reason"])
         event.data["node"] = self.nodes.pop(event.data["node"]["nodeId"])
         # Remove client from node since it's no longer connected to the controller
         event.data["node"].client = None

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -869,6 +869,7 @@ class Controller(EventBase):
 
     def handle_node_removed(self, event: Event) -> None:
         """Process a node removed event."""
+        event.data["reason"] = RemoveNodeReason(event.data["reason"])
         event.data["node"] = self.nodes.pop(event.data["node"]["nodeId"])
         # Remove client from node since it's no longer connected to the controller
         event.data["node"].client = None

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -23,6 +23,7 @@ from ...event import Event, EventBase
 from ...util.helpers import convert_base64_to_bytes, convert_bytes_to_base64
 from ..association import AssociationAddress, AssociationGroup
 from ..node import Node
+from ..node.firmware import NodeFirmwareUpdateResult
 from .data_model import ControllerDataType
 from .event_model import CONTROLLER_EVENT_MODEL_MAP
 from .firmware import ControllerFirmwareUpdateProgress, ControllerFirmwareUpdateResult
@@ -783,7 +784,7 @@ class Controller(EventBase):
 
     async def async_firmware_update_ota(
         self, node: Node, updates: list[NodeFirmwareUpdateFileInfo]
-    ) -> bool:
+    ) -> NodeFirmwareUpdateResult:
         """Send firmwareUpdateOTA command to Controller."""
         data = await self.client.async_send_command(
             {
@@ -793,7 +794,7 @@ class Controller(EventBase):
             },
             require_schema=24,
         )
-        return cast(bool, data["success"])
+        return NodeFirmwareUpdateResult(node, data["result"])
 
     async def async_is_firmware_update_in_progress(self) -> bool:
         """Send isFirmwareUpdateInProgress command to Controller."""

--- a/zwave_js_server/model/controller/event_model.py
+++ b/zwave_js_server/model/controller/event_model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Literal, TypedDict
 
+from ...const import RemoveNodeReason
 from ...event import BaseEventModel
 from ..node.data_model import FoundNodeDataType, NodeDataType
 from .firmware import (
@@ -124,7 +125,7 @@ class NodeRemovedEventModel(BaseControllerEventModel):
 
     event: Literal["node removed"]
     node: NodeDataType
-    reason: int
+    reason: RemoveNodeReason
 
 
 class NVMBackupAndConvertProgressEventModel(BaseControllerEventModel):

--- a/zwave_js_server/model/controller/event_model.py
+++ b/zwave_js_server/model/controller/event_model.py
@@ -124,7 +124,7 @@ class NodeRemovedEventModel(BaseControllerEventModel):
 
     event: Literal["node removed"]
     node: NodeDataType
-    replaced: bool
+    reason: int
 
 
 class NVMBackupAndConvertProgressEventModel(BaseControllerEventModel):

--- a/zwave_js_server/model/duration.py
+++ b/zwave_js_server/model/duration.py
@@ -1,0 +1,33 @@
+"""Provide a model for Z-Wave JS Duration."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, TypedDict
+
+
+class DurationDataType(TypedDict, total=False):
+    """Represent a Duration data dict type."""
+
+    # https://github.com/zwave-js/node-zwave-js/blob/v11-dev/packages/core/src/values/Duration.ts#L11
+    unit: Literal["seconds", "minutes", "unknown", "default"]  # required
+    value: int | float
+
+
+@dataclass
+class Duration:
+    """Duration class."""
+
+    data: DurationDataType
+    unit: Literal["seconds", "minutes", "unknown", "default"] = field(init=False)
+    value: int | float | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Post init."""
+        self.unit = self.data["unit"]
+        self.value = self.data.get("value")
+
+    def __repr__(self) -> str:
+        """Return the representationt."""
+        if self.value:
+            return f"{self.value} {self.unit}"
+        return f"{self.unit} duration"

--- a/zwave_js_server/model/duration.py
+++ b/zwave_js_server/model/duration.py
@@ -27,7 +27,7 @@ class Duration:
         self.value = self.data.get("value")
 
     def __repr__(self) -> str:
-        """Return the representationt."""
+        """Return the representation."""
         if self.value:
             return f"{self.value} {self.unit}"
         return f"{self.unit} duration"

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -489,7 +489,7 @@ class Node(EventBase):
 
         # the value object needs to be send to the server
         result = await self.async_send_command(
-            "set_value", **cmd_args, wait_for_result=wait_for_result
+            "set_value", **cmd_args, require_schema=29, wait_for_result=wait_for_result
         )
 
         if result is None:

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -37,6 +37,7 @@ from ..notification import (
 from ..value import (
     ConfigurationValue,
     MetaDataType,
+    SetValueResult,
     Value,
     ValueDataType,
     ValueMetadata,
@@ -456,7 +457,7 @@ class Node(EventBase):
         new_value: Any,
         options: dict | None = None,
         wait_for_result: bool | None = None,
-    ) -> bool | None:
+    ) -> SetValueResult | None:
         """Send setValue command to Node for given value (or value_id)."""
         # a value may be specified as value_id or the value itself
         if not isinstance(val, Value):
@@ -494,7 +495,7 @@ class Node(EventBase):
         if result is None:
             return None
 
-        return cast(bool, result["success"])
+        return SetValueResult(result["result"])
 
     async def async_refresh_info(self) -> None:
         """Send refreshInfo command to Node."""

--- a/zwave_js_server/model/node/event_model.py
+++ b/zwave_js_server/model/node/event_model.py
@@ -5,8 +5,7 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-from zwave_js_server.const import CommandClass
-
+from ...const import CommandClass
 from ...event import BaseEventModel
 from ..notification import (
     EntryControlNotificationArgsDataType,

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -298,27 +298,26 @@ class ConfigurationValue(Value):
     @property
     def configuration_value_type(self) -> ConfigurationValueType:
         """Return configuration value type."""
-        if self.metadata.type == "number":
-            if (
-                self.metadata.allow_manual_entry
-                and not self.metadata.max == self.metadata.min == 0
-            ):
-                return ConfigurationValueType.MANUAL_ENTRY
-            if self.metadata.states:
-                return ConfigurationValueType.ENUMERATED
-            if (
-                self.metadata.max is not None or self.metadata.min is not None
-            ) and not self.metadata.max == self.metadata.min == 0:
-                return ConfigurationValueType.RANGE
+        min_ = self.metadata.min
+        max_ = self.metadata.max
+        states = self.metadata.states
+        allow_manual_entry = self.metadata.allow_manual_entry
 
-        if self.metadata.type == "boolean":
-            if self.metadata.allow_manual_entry and not (
-                self.metadata.max == 1 and self.metadata.min == 0
-            ):
-                return ConfigurationValueType.MANUAL_ENTRY
-            if self.metadata.states:
-                return ConfigurationValueType.ENUMERATED
+        if max_ == 1 and min_ == 0 and not states:
             return ConfigurationValueType.BOOLEAN
+
+        if (
+            allow_manual_entry
+            and not max_ == min_ == 0
+            and not (max_ is None and min_ is None)
+        ):
+            return ConfigurationValueType.MANUAL_ENTRY
+
+        if states:
+            return ConfigurationValueType.ENUMERATED
+
+        if (max_ is not None or min_ is not None) and not max_ == min_ == 0:
+            return ConfigurationValueType.RANGE
 
         return ConfigurationValueType.UNDEFINED
 

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -351,7 +351,7 @@ class SetValueResult:
         self.message = self.data.get("message")
 
     def __repr__(self) -> str:
-        """Return the representationt."""
+        """Return the representation."""
         status = self.status.name.replace("_", " ").title()
         if self.status == SetValueStatus.WORKING:
             assert self.remaining_duration

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -114,7 +114,9 @@ async def get_usercode_from_node(node: Node, code_slot: int) -> dict[str, str | 
     }
 
 
-async def set_usercode(node: Node, code_slot: int, usercode: str) -> SetValueResult:
+async def set_usercode(
+    node: Node, code_slot: int, usercode: str
+) -> SetValueResult | None:
     """Set the usercode to index X on the lock."""
     value = get_code_slot_value(node, code_slot, LOCK_USERCODE_PROPERTY)
 
@@ -124,7 +126,7 @@ async def set_usercode(node: Node, code_slot: int, usercode: str) -> SetValueRes
     return await node.async_set_value(value, usercode)
 
 
-async def clear_usercode(node: Node, code_slot: int) -> SetValueResult:
+async def clear_usercode(node: Node, code_slot: int) -> SetValueResult | None:
     """Clear a code slot on the lock."""
     value = get_code_slot_value(node, code_slot, LOCK_USERCODE_STATUS_PROPERTY)
     return await node.async_set_value(value, CodeSlotStatus.AVAILABLE.value)

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -15,7 +15,7 @@ from ..const.command_class.lock import (
 )
 from ..exceptions import NotFoundError
 from ..model.node import Node
-from ..model.value import Value, get_value_id_str
+from ..model.value import SetValueResult, Value, get_value_id_str
 
 
 def get_code_slot_value(node: Node, code_slot: int, property_name: str) -> Value:
@@ -114,17 +114,17 @@ async def get_usercode_from_node(node: Node, code_slot: int) -> dict[str, str | 
     }
 
 
-async def set_usercode(node: Node, code_slot: int, usercode: str) -> None:
+async def set_usercode(node: Node, code_slot: int, usercode: str) -> SetValueResult:
     """Set the usercode to index X on the lock."""
     value = get_code_slot_value(node, code_slot, LOCK_USERCODE_PROPERTY)
 
     if len(str(usercode)) < 4:
         raise ValueError("User code must be at least 4 digits")
 
-    await node.async_set_value(value, usercode)
+    return await node.async_set_value(value, usercode)
 
 
-async def clear_usercode(node: Node, code_slot: int) -> None:
+async def clear_usercode(node: Node, code_slot: int) -> SetValueResult:
     """Clear a code slot on the lock."""
     value = get_code_slot_value(node, code_slot, LOCK_USERCODE_STATUS_PROPERTY)
-    await node.async_set_value(value, CodeSlotStatus.AVAILABLE.value)
+    return await node.async_set_value(value, CodeSlotStatus.AVAILABLE.value)

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -44,7 +44,7 @@ async def async_multicast_set_value(
         valueId=_get_value_id_dict_from_value_data(value_data),
         value=new_value,
         options=options,
-        require_schema=5,
+        require_schema=29,
     )
     return SetValueResult(result["result"])
 

--- a/zwave_js_server/util/multicast.py
+++ b/zwave_js_server/util/multicast.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 from ..client import Client
 from ..const import CommandClass
 from ..model.node import Node, _get_value_id_dict_from_value_data
-from ..model.value import ValueDataType
+from ..model.value import SetValueResult, ValueDataType
 
 
 async def _async_send_command(
@@ -35,7 +35,7 @@ async def async_multicast_set_value(
     value_data: ValueDataType,
     nodes: list[Node] | None = None,
     options: dict | None = None,
-) -> bool:
+) -> SetValueResult:
     """Send a multicast set_value command."""
     result = await _async_send_command(
         client,
@@ -46,7 +46,7 @@ async def async_multicast_set_value(
         options=options,
         require_schema=5,
     )
-    return cast(bool, result["success"])
+    return SetValueResult(result["result"])
 
 
 async def async_multicast_get_endpoint_count(

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -223,6 +223,7 @@ def _validate_and_transform_new_value(
     max_ = zwave_value.metadata.max
     min_ = zwave_value.metadata.min
     check_ = zwave_value.configuration_value_type in (
+        ConfigurationValueType.BOOLEAN,
         ConfigurationValueType.RANGE,
         ConfigurationValueType.MANUAL_ENTRY,
     )

--- a/zwave_js_server/util/node.py
+++ b/zwave_js_server/util/node.py
@@ -155,6 +155,7 @@ async def async_bulk_set_partial_config_parameters(
             "property": property_,
         },
         value=new_value,
+        require_schema=29,
     )
 
     # If we didn't wait for a response, we assume the command has been queued


### PR DESCRIPTION
See https://github.com/zwave-js/zwave-js-server/pull/956 for more details

In addition to what's listed there, we added support for the boolean configuration value type. This is a breaking change as it introduces a new `ConfigurationValueType` boolean which changes the `ConfigurationValueType` for existing cases.