### PR TITLE
Add Fan and Dry as valid thermostat modes

### DIFF
--- a/zwave_js_server/const/command_class/thermostat.py
+++ b/zwave_js_server/const/command_class/thermostat.py
@@ -88,6 +88,8 @@ THERMOSTAT_MODES = [
     ThermostatMode.COOL,
     ThermostatMode.AUTO,
     ThermostatMode.AUTO_CHANGE_OVER,
+    ThermostatMode.FAN,
+    ThermostatMode.DRY,
 ]
 
 THERMOSTAT_MODE_SETPOINT_MAP: dict[int, list[ThermostatSetpointType]] = {


### PR DESCRIPTION
According to the [docs](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes) and [code](https://github.com/home-assistant/core/blob/acb7b1fe3be1bffa8da12240e08a92c3da4a3ef7/homeassistant/components/climate/const.py#L8), the 'fan' and 'dry' modes are valid HVAC modes. 

I have a Z-Wave thermostat that is wrongly reporting the 'dry' and 'fan' modes as presets, which is wrong and causes issues with frontend cards and weird behaviors when changing the modes from the wall controller. 

I've checked other climate integrations and they do set the 'dry' and 'fan' as HVAC modes properly.

As additional context, this is what the Z-Wave node reports:

```
[...]
2023-06-28T12:40:51.013Z CNTRLR   [Node 011] Interviewing Thermostat Mode...
2023-06-28T12:40:51.013Z CNTRLR » [Node 011] querying supported thermostat modes...
2023-06-28T12:40:51.022Z DRIVER » [Node 011] [REQ] [SendData]
                                  │ transmit options: 0x25
                                  │ callback id:      76
                                  └─[ThermostatModeCCSupportedGet]
2023-06-28T12:40:51.030Z DRIVER « [RES] [SendData]
                                    was sent: true
2023-06-28T12:40:51.046Z DRIVER « [REQ] [SendData]
                                    callback id:     76
                                    transmit status: OK
2023-06-28T12:40:51.060Z DRIVER « [Node 011] [REQ] [ApplicationCommand]
                                  └─[ThermostatModeCCSupportedReport]
                                      supported modes:
                                      · Off
                                      · Heat
                                      · Cool
                                      · Fan
                                      · Dry
                                      · Auto changeover
2023-06-28T12:40:51.066Z CNTRLR « [Node 011] received supported thermostat modes:
                                  · Off
                                  · Heat
                                  · Cool
                                  · Fan
                                  · Dry
                                  · Auto changeover
[...]
```

And this is what I get in Home Assistant:

```yaml
hvac_modes:
  - 'off'
  - heat
  - cool
  - heat_cool
min_temp: 7
max_temp: 35
fan_modes:
  - Low
  - High
  - Auto medium
  - Medium
preset_modes:
  - none
  - Fan  <--- this should be in hvac_modes
  - Dry  <--- this should be in hvac_modes
current_temperature: 28.9
temperature: null
target_temp_high: null
target_temp_low: null
fan_mode: Low
preset_mode: none
icon: mdi:snowflake
friendly_name: Downstairs Air Conditioner
supported_features: 27
```