### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4.7.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install wheel
         run: >-
           pip install wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.10"
           - "3.11"
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["test.*", "test"]),
     package_data={"zwave_js_server": ["py.typed"]},
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     install_requires=["aiohttp>3", "pydantic>=1.10.0"],
     entry_points={
         "console_scripts": ["zwave-js-server-python = zwave_js_server.__main__:main"]
@@ -33,7 +33,6 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Topic :: Home Automation",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Home Automation",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py310, py311, lint, mypy
+envlist = py311, lint, mypy
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.10: py310, lint, mypy
-  3.11: py311
+  3.11: py311, lint, mypy
 
 [testenv]
 commands =


### PR DESCRIPTION
HA has dropped Python 3.10 support so we should as well, it will also avoid us having to include a backport in https://github.com/home-assistant-libs/zwave-js-server-python/pull/705