### PR TITLE
Update util.lock.get_usercode logic

### DIFF
--- a/test/util/test_lock.py
+++ b/test/util/test_lock.py
@@ -4,6 +4,7 @@ import pytest
 from zwave_js_server.const.command_class.lock import (
     ATTR_CODE_SLOT,
     ATTR_IN_USE,
+    ATTR_NAME,
     ATTR_USERCODE,
 )
 from zwave_js_server.exceptions import NotFoundError
@@ -134,6 +135,7 @@ async def test_get_usercode_from_node(lock_schlage_be469, mock_command, uuid4):
 
     # Test valid code
     assert await get_usercode_from_node(node, 1) == {
+        ATTR_NAME: "User Code (1)",
         ATTR_CODE_SLOT: 1,
         ATTR_IN_USE: True,
         ATTR_USERCODE: "**********",

--- a/test/util/test_lock.py
+++ b/test/util/test_lock.py
@@ -1,7 +1,11 @@
 """Test lock utility functions."""
 import pytest
 
-from zwave_js_server.const.command_class.lock import ATTR_IN_USE, ATTR_USERCODE
+from zwave_js_server.const.command_class.lock import (
+    ATTR_CODE_SLOT,
+    ATTR_IN_USE,
+    ATTR_USERCODE,
+)
 from zwave_js_server.exceptions import NotFoundError
 from zwave_js_server.util.lock import (
     clear_usercode,
@@ -29,14 +33,14 @@ def test_get_usercode(lock_schlage_be469):
     node = lock_schlage_be469
 
     # Test in use slot
-    user_code = get_usercode(node, 1)
-    assert all(char == "*" for char in user_code)
+    slot = get_usercode(node, 1)
+    assert all(char == "*" for char in slot[ATTR_USERCODE])
 
     # Test unused slot
-    assert get_usercode(node, 29) == ""
+    assert get_usercode(node, 29)[ATTR_USERCODE] == ""
 
     # Test unknown slot
-    assert get_usercode(node, 30) is None
+    assert get_usercode(node, 30)[ATTR_USERCODE] is None
 
     # Test invalid slot
     with pytest.raises(NotFoundError):
@@ -130,6 +134,7 @@ async def test_get_usercode_from_node(lock_schlage_be469, mock_command, uuid4):
 
     # Test valid code
     assert await get_usercode_from_node(node, 1) == {
+        ATTR_CODE_SLOT: 1,
         ATTR_IN_USE: True,
         ATTR_USERCODE: "**********",
     }

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -114,7 +114,7 @@ def get_usercode(node: Node, code_slot: int) -> CodeSlot:
     )
 
 
-async def get_usercode_from_node(node: Node, code_slot: int) -> dict[str, str | bool]:
+async def get_usercode_from_node(node: Node, code_slot: int) -> CodeSlot:
     """
     Fetch a usercode directly from a node.
 
@@ -122,14 +122,10 @@ async def get_usercode_from_node(node: Node, code_slot: int) -> dict[str, str | 
     This call will populate the ValueDB and trigger value update events from the
     driver.
     """
-    resp = await node.async_invoke_cc_api(
+    await node.async_invoke_cc_api(
         CommandClass.USER_CODE, "get", code_slot, wait_for_result=True
     )
-    return {
-        ATTR_CODE_SLOT: code_slot,
-        ATTR_IN_USE: resp["userIdStatus"] == CodeSlotStatus.ENABLED,
-        ATTR_USERCODE: resp["userCode"],
-    }
+    return get_usercode(node, code_slot)
 
 
 async def set_usercode(

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -91,10 +91,27 @@ def get_usercodes(node: Node) -> list[CodeSlot]:
     return _get_code_slots(node, True)
 
 
-def get_usercode(node: Node, code_slot: int) -> str | None:
+def get_usercode(node: Node, code_slot: int) -> CodeSlot:
     """Get usercode from slot X on the lock."""
     value = get_code_slot_value(node, code_slot, LOCK_USERCODE_PROPERTY)
-    return value.value
+    status_value = get_code_slot_value(node, code_slot, LOCK_USERCODE_STATUS_PROPERTY)
+
+    code_slot = int(value.property_key)  # type: ignore
+    in_use = (
+        None
+        if status_value.value is None
+        else status_value.value == CodeSlotStatus.ENABLED
+    )
+
+    return cast(
+        CodeSlot,
+        {
+            ATTR_CODE_SLOT: code_slot,
+            ATTR_NAME: value.metadata.label,
+            ATTR_IN_USE: in_use,
+            ATTR_USERCODE: value.value,
+        },
+    )
 
 
 async def get_usercode_from_node(node: Node, code_slot: int) -> dict[str, str | bool]:
@@ -109,6 +126,7 @@ async def get_usercode_from_node(node: Node, code_slot: int) -> dict[str, str | 
         CommandClass.USER_CODE, "get", code_slot, wait_for_result=True
     )
     return {
+        ATTR_CODE_SLOT: code_slot,
         ATTR_IN_USE: resp["userIdStatus"] == CodeSlotStatus.ENABLED,
         ATTR_USERCODE: resp["userCode"],
     }


### PR DESCRIPTION
To prep for adding services to get user codes using the new return capability for HA services, we are updating the `get_usercode` logic to return the same TypedDict we return elsewhere.

This is a breaking change but since the next release is a breaking one anyway, may as well squeeze this in