### PR TITLE
Fix bugs from #702

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp==3.8.4
-pydantic==2.0.3
+aiohttp==3.8.5
+pydantic>=1.10.0

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -366,8 +366,14 @@ class Node(EventBase):
         for value_id in stale_value_ids:
             self.values.pop(value_id)
 
-        # Updating existing values and populate new values
-        for value_id in new_value_ids - stale_value_ids:
+        # Updating existing values and populate new values. Preserve value order if
+        # initializing values for the node for the first time by using the key order
+        # which is deterministic
+        for value_id in (
+            new_value_ids - stale_value_ids
+            if stale_value_ids
+            else list(new_values_data)
+        ):
             val = new_values_data[value_id]
             try:
                 if value_id in self.values:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -266,10 +266,10 @@ class Value:
 
     def update(self, data: ValueDataType) -> None:
         """Update data."""
-        data.pop("prevValue", None)
         self.data.update(data)
-        if (new_value := self.data.pop("newValue", None)) is not None:
-            self.data["value"] = new_value
+        self.data.pop("prevValue", None)
+        if "newValue" in self.data:
+            self.data["value"] = self.data.pop("newValue")
 
         if "metadata" in data:
             self._metadata.update(data["metadata"])


### PR DESCRIPTION
Two changes:
1. To preserve ordering, `Node.update` should add values in the same order as the server on load
2. Fix issue with `Value.update` - when popping `prevValue`, we were removing it from the event data dictionary. We should preserve the event data as much as possible and instead remove it from a Value's data attribute