### PR TITLE
Improve logic for determining config value boolean type

### DIFF
--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from ..const import VALUE_UNKNOWN, CommandClass, ConfigurationValueType, SetValueStatus
@@ -11,6 +12,15 @@ from .duration import Duration, DurationDataType
 
 if TYPE_CHECKING:
     from .node import Node
+
+
+class ValueType(StrEnum):
+    """Enum with all value types."""
+
+    ANY = "any"
+    BOOLEAN = "boolean"
+    NUMBER = "number"
+    STRING = "string"
 
 
 class MetaDataType(TypedDict, total=False):
@@ -301,8 +311,11 @@ class ConfigurationValue(Value):
         max_ = self.metadata.max
         states = self.metadata.states
         allow_manual_entry = self.metadata.allow_manual_entry
+        type_ = self.metadata.type
 
-        if max_ == 1 and min_ == 0 and not states:
+        if (
+            (max_ == 1 and min_ == 0) or type_ == ValueType.BOOLEAN
+        ) and not states:
             return ConfigurationValueType.BOOLEAN
 
         if (

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -313,9 +313,7 @@ class ConfigurationValue(Value):
         allow_manual_entry = self.metadata.allow_manual_entry
         type_ = self.metadata.type
 
-        if (
-            (max_ == 1 and min_ == 0) or type_ == ValueType.BOOLEAN
-        ) and not states:
+        if ((max_ == 1 and min_ == 0) or type_ == ValueType.BOOLEAN) and not states:
             return ConfigurationValueType.BOOLEAN
 
         if (

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -313,7 +313,7 @@ class ConfigurationValue(Value):
         allow_manual_entry = self.metadata.allow_manual_entry
         type_ = self.metadata.type
 
-        if ((max_ == 1 and min_ == 0) or type_ == ValueType.BOOLEAN) and not states:
+        if (max_ == 1 and min_ == 0 or type_ == ValueType.BOOLEAN) and not states:
             return ConfigurationValueType.BOOLEAN
 
         if (


### PR DESCRIPTION
I realized from https://github.com/home-assistant/core/pull/94760#discussion_r1287923508 that our check here isn't correct as values that are boolean do not have mins and maxes.