### PR TITLE
Cancel waiting for a response when node goes to dead/asleep

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -327,7 +327,7 @@ async def test_set_value_node_status_change(multisensor_6_state):
     async def async_send_command(
         message: dict[str, Any], require_schema: int | None = None
     ) -> dict:
-        """Return a mock response."""
+        """Send a mock command that never returns."""
         block_event = asyncio.Event()
         await block_event.wait()
 

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -466,7 +466,8 @@ class Node(EventBase):
             kwargs["require_schema"] = require_schema
 
         if wait_for_result or (
-            wait_for_result is None and self.status != NodeStatus.ASLEEP
+            wait_for_result is None
+            and self.status not in (NodeStatus.ASLEEP, NodeStatus.DEAD)
         ):
             result_task = asyncio.create_task(
                 self.client.async_send_command(message, **kwargs)
@@ -907,7 +908,7 @@ class Node(EventBase):
     def handle_wake_up(self, event: Event) -> None:
         """Process a node wake up event."""
         # pylint: disable=unused-argument
-        self._status_event.release()
+        self._status_event.clear()
         self.data["status"] = NodeStatus.AWAKE
 
     def handle_sleep(self, event: Event) -> None:
@@ -925,7 +926,7 @@ class Node(EventBase):
     def handle_alive(self, event: Event) -> None:
         """Process a node alive event."""
         # pylint: disable=unused-argument
-        self._status_event.release()
+        self._status_event.clear()
         self.data["status"] = NodeStatus.ALIVE
 
     def handle_interview_started(self, event: Event) -> None:

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -478,7 +478,7 @@ class Node(EventBase):
             if not self._status_lock.locked() and not result_task.done():
                 result_task.cancel()
                 return None
-            return await result_task.result()
+            return result_task.result()
 
         await self.client.async_send_command_no_wait(message, **kwargs)
         return None

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -475,9 +475,7 @@ class Node(EventBase):
             result_task = asyncio.create_task(
                 self.client.async_send_command(message, **kwargs)
             )
-            status_task = asyncio.create_task(
-                self._status_event.wait()
-            )
+            status_task = asyncio.create_task(self._status_event.wait())
             await asyncio.wait(
                 [result_task, status_task],
                 return_when=asyncio.FIRST_COMPLETED,

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -475,11 +475,13 @@ class Node(EventBase):
                 [result_task, self._status_event.wait()],
                 return_when=asyncio.FIRST_COMPLETED,
             )
-            if self._status_event.is_set() and not result_task.done():
+            try:
+                if self._status_event.is_set() and not result_task.done():
+                    result_task.cancel()
+                    return None
+                return result_task.result()
+            finally:
                 self._status_event.clear()
-                result_task.cancel()
-                return None
-            return result_task.result()
 
         await self.client.async_send_command_no_wait(message, **kwargs)
         return None

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -475,10 +475,14 @@ class Node(EventBase):
             result_task = asyncio.create_task(
                 self.client.async_send_command(message, **kwargs)
             )
+            status_task = asyncio.create_task(
+                self._status_event.wait()
+            )
             await asyncio.wait(
-                [result_task, self._status_event.wait()],
+                [result_task, status_task],
                 return_when=asyncio.FIRST_COMPLETED,
             )
+            status_task.cancel()
             if self._status_event.is_set() and not result_task.done():
                 result_task.cancel()
                 return None

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -468,9 +468,9 @@ class Node(EventBase):
         if wait_for_result:
             result = await self.client.async_send_command(message, **kwargs)
             return result
-        if (
-            wait_for_result is None
-            and self.status not in (NodeStatus.ASLEEP, NodeStatus.DEAD)
+        if wait_for_result is None and self.status not in (
+            NodeStatus.ASLEEP,
+            NodeStatus.DEAD,
         ):
             result_task = asyncio.create_task(
                 self.client.async_send_command(message, **kwargs)

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -476,6 +476,7 @@ class Node(EventBase):
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if self._status_event.is_set() and not result_task.done():
+                self._status_event.clear()
                 result_task.cancel()
                 return None
             return result_task.result()
@@ -904,25 +905,25 @@ class Node(EventBase):
     def handle_wake_up(self, event: Event) -> None:
         """Process a node wake up event."""
         # pylint: disable=unused-argument
-        self._status_event.set()
+        self._status_event.release()
         self.data["status"] = NodeStatus.AWAKE
 
     def handle_sleep(self, event: Event) -> None:
         """Process a node sleep event."""
         # pylint: disable=unused-argument
-        self._status_event.release()
+        self._status_event.set()
         self.data["status"] = NodeStatus.ASLEEP
 
     def handle_dead(self, event: Event) -> None:
         """Process a node dead event."""
         # pylint: disable=unused-argument
-        self._status_event.release()
+        self._status_event.set()
         self.data["status"] = NodeStatus.DEAD
 
     def handle_alive(self, event: Event) -> None:
         """Process a node alive event."""
         # pylint: disable=unused-argument
-        self._status_event.set()
+        self._status_event.release()
         self.data["status"] = NodeStatus.ALIVE
 
     def handle_interview_started(self, event: Event) -> None:

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -476,13 +476,10 @@ class Node(EventBase):
                 [result_task, self._status_event.wait()],
                 return_when=asyncio.FIRST_COMPLETED,
             )
-            try:
-                if self._status_event.is_set() and not result_task.done():
-                    result_task.cancel()
-                    return None
-                return result_task.result()
-            finally:
-                self._status_event.clear()
+            if self._status_event.is_set() and not result_task.done():
+                result_task.cancel()
+                return None
+            return result_task.result()
 
         await self.client.async_send_command_no_wait(message, **kwargs)
         return None

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -465,7 +465,10 @@ class Node(EventBase):
         if require_schema is not None:
             kwargs["require_schema"] = require_schema
 
-        if wait_for_result or (
+        if wait_for_result:
+            result = await self.client.async_send_command(message, **kwargs)
+            return result
+        if (
             wait_for_result is None
             and self.status not in (NodeStatus.ASLEEP, NodeStatus.DEAD)
         ):


### PR DESCRIPTION
We should not wait for a response when we send a command and the node that we are sending a command for moves to a status that means we won't get a response in a reasonable time