### PR TITLE
Handle non existing result futures on pop

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -161,9 +161,11 @@ async def ws_client_fixture(
         """Return a websocket message."""
         await asyncio.sleep(0)
 
-        message = messages.popleft()
-        if not messages:
+        try:
+            message = messages.popleft()
+        except IndexError:
             ws_client.closed = True
+            return WSMessage(WSMsgType.CLOSED, None, None)
 
         return message
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -474,5 +474,5 @@ async def test_pop_future_none(client_session, url, driver_ready):
 
     await driver_ready.wait()
 
-    with pytest.raises(NotConnected):
+    with pytest.raises(asyncio.CancelledError):
         await client.async_send_command({"command": "some_command"})

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -472,5 +472,7 @@ async def test_pop_future_none(client_session, url, driver_ready):
 
     asyncio.create_task(client.listen(driver_ready))
 
-    with pytest.raises(asyncio.CancelledError):
+    await driver_ready.wait()
+
+    with pytest.raises(NotConnected):
         await client.async_send_command({"command": "some_command"})

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -461,3 +461,16 @@ async def test_additional_user_agent_components(client_session, url):
                 },
             }
         )
+
+
+async def test_pop_future_none(client_session, url, driver_ready):
+    """Test when a future has been cleared from futures dict, popping still works."""
+    client = Client(url, client_session)
+    await client.connect()
+
+    assert client.connected
+
+    asyncio.create_task(client.listen(driver_ready))
+
+    with pytest.raises(asyncio.CancelledError):
+        await client.async_send_command({"command": "some_command"})

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -72,4 +72,4 @@ def test_connect(client_session, url, ws_client):
         main()
 
     assert sys_exit.value.code == 0
-    assert ws_client.receive.call_count == 4
+    assert ws_client.receive.call_count == 5

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -115,7 +115,7 @@ class Client:
         try:
             return await future
         finally:
-            self._result_futures.pop(message_id)
+            self._result_futures.pop(message_id, None)
 
     async def async_send_command_no_wait(
         self, message: dict[str, Any], require_schema: int | None = None


### PR DESCRIPTION
I'm not sure how to test this... My only thought at the moment is to patch `self._result_futures` with a dict subclass instance that overrides adding an item to the dict to not do it. But that seems like a bad hack, so open to other suggestions