### PR TITLE
Bump the lib to 0.51.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.51.2"
+VERSION = "0.51.3"
 
 
 setup(


### PR DESCRIPTION
Allows us to release https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/untagged-ef6c4cd1d1575de41b81