### PR TITLE
Bump lib to 0.53.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.51.3"
+VERSION = "0.52.0"
 
 
 setup(


### PR DESCRIPTION
Draft notes, the main two things are:
- support for Z-Wave JS 12.x
- Added server logging capabilities to the lib

https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/untagged-dffb232ec745575ee94b