### PR TITLE
Filter out logging events from debug logs

### DIFF
--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -459,7 +459,10 @@ class Client:
         except ValueError as err:
             raise InvalidMessage("Received invalid JSON.") from err
 
-        if LOGGER.isEnabledFor(logging.DEBUG):
+        if LOGGER.isEnabledFor(logging.DEBUG) and not (
+            data.get("type") == "event"
+            and data.get("event", {}).get("event") == "logging"
+        ):
             LOGGER.debug("Received message:\n%s\n", pprint.pformat(msg))
 
         return data

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -460,7 +460,8 @@ class Client:
             raise InvalidMessage("Received invalid JSON.") from err
 
         if LOGGER.isEnabledFor(logging.DEBUG) and not (
-            data.get("type") == "event"
+            self.server_logging_enabled
+            and data.get("type") == "event"
             and data.get("event", {}).get("event") == "logging"
         ):
             LOGGER.debug("Received message:\n%s\n", pprint.pformat(msg))

--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -511,7 +511,9 @@ class Client:
             )
             return
 
-        if self._record_messages:
+        if self._record_messages and not (
+            self.server_logging_enabled and msg["event"]["event"] == "logging"
+        ):
             self._recorded_events.append(
                 {
                     "record_type": "event",

--- a/zwave_js_server/model/node/firmware.py
+++ b/zwave_js_server/model/node/firmware.py
@@ -297,7 +297,7 @@ class NodeFirmwareUpdateInfo:
         return cls(
             version=data["version"],
             changelog=data["changelog"],
-            channel=data.get("channel", "stable"),
+            channel=data["channel"],
             files=[
                 NodeFirmwareUpdateFileInfo.from_dict(file) for file in data["files"]
             ],

--- a/zwave_js_server/model/node/firmware.py
+++ b/zwave_js_server/model/node/firmware.py
@@ -265,7 +265,7 @@ class NodeFirmwareUpdateDeviceID:
         return cast(NodeFirmwareUpdateDeviceIDDataType, data)
 
 
-class NodeFirmwareUpdateInfoDataType(TypedDict):
+class NodeFirmwareUpdateInfoDataType(TypedDict, total=False):
     """Represent a firmware update info data dict type."""
 
     version: str
@@ -297,7 +297,7 @@ class NodeFirmwareUpdateInfo:
         return cls(
             version=data["version"],
             changelog=data["changelog"],
-            channel=data["channel"],
+            channel=data.get("channel", "stable"),
             files=[
                 NodeFirmwareUpdateFileInfo.from_dict(file) for file in data["files"]
             ],


### PR DESCRIPTION
When server logging is enabled, we should not include the `Received message` logging statement for logging events because it's not formatted well and we'll get the formatted version immediately after anyway.