### PR TITLE
Update get_available_firmware_updates to default include prereleases

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1871,7 +1871,7 @@ async def test_get_available_firmware_updates(multisensor_6, uuid4, mock_command
         "command": "controller.get_available_firmware_updates",
         "nodeId": multisensor_6.node_id,
         "apiKey": "test",
-        "includePrereleases": False,
+        "includePrereleases": True,
         "messageId": uuid4,
     }
 

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -788,7 +788,7 @@ class Controller(EventBase):
         return cast(bool, data["progress"])
 
     async def async_get_available_firmware_updates(
-        self, node: Node, api_key: str, include_prereleases: bool = False
+        self, node: Node, api_key: str, include_prereleases: bool = True
     ) -> list[NodeFirmwareUpdateInfo]:
         """Send getAvailableFirmwareUpdates command to Controller."""
         data = await self.client.async_send_command(


### PR DESCRIPTION
## Breaking change

`Controller.async_get_available_firmware_updates` now sets `includePrereleases` to `True` by default

## Description

According to https://github.com/zwave-js/node-zwave-js/blob/506f1eabe57d0c24eb4bfbd37bd2706656cfdb1b/packages/zwave-js/src/lib/controller/FirmwareUpdateService.ts#L198 when we set `includePrereleases` to `False`, we use v1 of the API. This PR changes the default behavior to set `includePrereleases` to `True`. Users of the lib can still set `includePrereleases` to `False` if they want to.