### PR TITLE
Remove TypedDicts and Clients from dataclass repr

### DIFF
--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -459,7 +459,7 @@ class DateAndTimeDataType(TypedDict, total=False):
 class DateAndTime:
     """Represent a date and time."""
 
-    data: DateAndTimeDataType
+    data: DateAndTimeDataType = field(repr=False)
     hour: int | None = field(init=False)
     minute: int | None = field(init=False)
     weekday: Weekday | None = field(default=None, init=False)

--- a/zwave_js_server/model/controller/firmware.py
+++ b/zwave_js_server/model/controller/firmware.py
@@ -63,7 +63,7 @@ class ControllerFirmwareUpdateProgressDataType(TypedDict):
 class ControllerFirmwareUpdateProgress:
     """Model for a controller firmware update progress data."""
 
-    data: ControllerFirmwareUpdateProgressDataType
+    data: ControllerFirmwareUpdateProgressDataType = field(repr=False)
     sent_fragments: int = field(init=False)
     total_fragments: int = field(init=False)
     progress: float = field(init=False)
@@ -86,7 +86,7 @@ class ControllerFirmwareUpdateResultDataType(TypedDict):
 class ControllerFirmwareUpdateResult:
     """Model for controller firmware update result data."""
 
-    data: ControllerFirmwareUpdateResultDataType
+    data: ControllerFirmwareUpdateResultDataType = field(repr=False)
     status: ControllerFirmwareUpdateStatus = field(init=False)
     success: bool = field(init=False)
 

--- a/zwave_js_server/model/controller/statistics.py
+++ b/zwave_js_server/model/controller/statistics.py
@@ -22,8 +22,8 @@ class ControllerLifelineRoutesDataType(TypedDict):
 class ControllerLifelineRoutes:
     """Represent controller lifeline routes."""
 
-    client: "Client"
-    data: ControllerLifelineRoutesDataType
+    client: "Client" = field(repr=False)
+    data: ControllerLifelineRoutesDataType = field(repr=False)
     lwr: RouteStatistics | None = field(init=False, default=None)
     nlwr: RouteStatistics | None = field(init=False, default=None)
 
@@ -74,7 +74,7 @@ class ControllerStatisticsDataType(TypedDict, total=False):
 class ChannelRSSI:
     """Represent a channel RSSI."""
 
-    data: ChannelRSSIDataType
+    data: ChannelRSSIDataType = field(repr=False)
     average: int = field(init=False)
     current: int = field(init=False)
 
@@ -88,7 +88,7 @@ class ChannelRSSI:
 class BackgroundRSSI:
     """Represent a background RSSI update."""
 
-    data: BackgroundRSSIDataType
+    data: BackgroundRSSIDataType = field(repr=False)
     timestamp: int = field(init=False)
     channel_0: ChannelRSSI = field(init=False)
     channel_1: ChannelRSSI = field(init=False)
@@ -109,7 +109,7 @@ class BackgroundRSSI:
 class ControllerStatistics:
     """Represent a controller statistics update."""
 
-    data: ControllerStatisticsDataType
+    data: ControllerStatisticsDataType = field(repr=False)
     messages_tx: int = field(init=False)
     messages_rx: int = field(init=False)
     messages_dropped_rx: int = field(init=False)

--- a/zwave_js_server/model/duration.py
+++ b/zwave_js_server/model/duration.py
@@ -17,7 +17,7 @@ class DurationDataType(TypedDict, total=False):
 class Duration:
     """Duration class."""
 
-    data: DurationDataType | Literal["unknown", "default"]
+    data: DurationDataType | Literal["unknown", "default"] = field(repr=False)
     unit: Literal["seconds", "minutes", "unknown", "default"] = field(init=False)
     value: int | float | None = field(init=False)
 

--- a/zwave_js_server/model/log_message.py
+++ b/zwave_js_server/model/log_message.py
@@ -27,7 +27,7 @@ class LogMessageContextDataType(TypedDict, total=False):
 class LogMessageContext:
     """Represent log message context information."""
 
-    data: LogMessageContextDataType
+    data: LogMessageContextDataType = field(repr=False)
     source: Literal["config", "serial", "controller", "driver"] = field(init=False)
     type: Literal["controller", "value", "node"] | None = field(init=False)
     node_id: int | None = field(init=False)
@@ -90,7 +90,7 @@ def _process_message(message: str | list[str]) -> list[str]:
 class LogMessage:
     """Represent a log message."""
 
-    data: LogMessageDataType
+    data: LogMessageDataType = field(repr=False)
     message: list[str] = field(init=False)
     formatted_message: list[str] = field(init=False)
     direction: str = field(init=False)

--- a/zwave_js_server/model/node/firmware.py
+++ b/zwave_js_server/model/node/firmware.py
@@ -65,7 +65,7 @@ class NodeFirmwareUpdateCapabilitiesDict(TypedDict, total=False):
 class NodeFirmwareUpdateCapabilities:
     """Model for firmware update capabilities."""
 
-    data: NodeFirmwareUpdateCapabilitiesDataType
+    data: NodeFirmwareUpdateCapabilitiesDataType = field(repr=False)
     firmware_upgradable: bool = field(init=False)
 
     def __post_init__(self) -> None:
@@ -147,7 +147,7 @@ class NodeFirmwareUpdateProgress:
     """Model for a node firmware update progress data."""
 
     node: "Node"
-    data: NodeFirmwareUpdateProgressDataType
+    data: NodeFirmwareUpdateProgressDataType = field(repr=False)
     current_file: int = field(init=False)
     total_files: int = field(init=False)
     sent_fragments: int = field(init=False)
@@ -177,7 +177,7 @@ class NodeFirmwareUpdateResult:
     """Model for node firmware update result data."""
 
     node: "Node"
-    data: NodeFirmwareUpdateResultDataType
+    data: NodeFirmwareUpdateResultDataType = field(repr=False)
     status: NodeFirmwareUpdateStatus = field(init=False)
     success: bool = field(init=False)
     wait_time: int | None = field(init=False)

--- a/zwave_js_server/model/node/health_check.py
+++ b/zwave_js_server/model/node/health_check.py
@@ -33,7 +33,7 @@ class LifelineHealthCheckSummaryDataType(TypedDict):
 class LifelineHealthCheckResult:
     """Represent a lifeline health check result."""
 
-    data: LifelineHealthCheckResultDataType
+    data: LifelineHealthCheckResultDataType = field(repr=False)
     latency: int = field(init=False)
     num_neighbors: int = field(init=False)
     failed_pings_node: int = field(init=False)
@@ -60,7 +60,7 @@ class LifelineHealthCheckResult:
 class LifelineHealthCheckSummary:
     """Represent a lifeline health check summary update."""
 
-    data: LifelineHealthCheckSummaryDataType
+    data: LifelineHealthCheckSummaryDataType = field(repr=False)
     rating: int = field(init=False)
     results: list[LifelineHealthCheckResult] = field(init=False)
 
@@ -96,7 +96,7 @@ class RouteHealthCheckSummaryDataType(TypedDict):
 class RouteHealthCheckResult:
     """Represent a route health check result."""
 
-    data: RouteHealthCheckResultDataType
+    data: RouteHealthCheckResultDataType = field(repr=False)
     num_neighbors: int = field(init=False)
     rating: int = field(init=False)
     failed_pings_to_target: int | None = field(init=False)
@@ -120,7 +120,7 @@ class RouteHealthCheckResult:
 class RouteHealthCheckSummary:
     """Represent a route health check summary update."""
 
-    data: RouteHealthCheckSummaryDataType
+    data: RouteHealthCheckSummaryDataType = field(repr=False)
     rating: int = field(init=False)
     results: list[RouteHealthCheckResult] = field(init=False)
 

--- a/zwave_js_server/model/node/statistics.py
+++ b/zwave_js_server/model/node/statistics.py
@@ -35,8 +35,8 @@ class NodeStatisticsDataType(TypedDict, total=False):
 class NodeStatistics:
     """Represent a node statistics update."""
 
-    client: "Client"
-    data: NodeStatisticsDataType
+    client: "Client" = field(repr=False)
+    data: NodeStatisticsDataType = field(repr=False)
     commands_tx: int = field(init=False)
     commands_rx: int = field(init=False)
     commands_dropped_rx: int = field(init=False)

--- a/zwave_js_server/model/notification.py
+++ b/zwave_js_server/model/notification.py
@@ -31,8 +31,8 @@ class BaseNotification:
     """Model for a Zwave Node's notification event."""
 
     node: Node
-    data: BaseNotificationDataType
-    node_id: int = field(init=False)
+    data: BaseNotificationDataType = field(repr=False)
+    node_id: int = field(init=False, repr=False)
     endpoint_idx: int = field(init=False)
     command_class: int = field(init=False)
 
@@ -63,7 +63,7 @@ class EntryControlNotificationDataType(BaseNotificationDataType):
 class EntryControlNotification(BaseNotification):
     """Model for a Zwave Node's Entry Control CC notification event."""
 
-    data: EntryControlNotificationDataType
+    data: EntryControlNotificationDataType = field(repr=False)
     event_type: int = field(init=False)
     event_type_label: str = field(init=False)
     data_type: int = field(init=False)
@@ -101,7 +101,7 @@ class NotificationNotificationDataType(BaseNotificationDataType):
 class NotificationNotification(BaseNotification):
     """Model for a Zwave Node's Notification CC notification event."""
 
-    data: NotificationNotificationDataType
+    data: NotificationNotificationDataType = field(repr=False)
     type_: int = field(init=False)
     label: str = field(init=False)
     event: int = field(init=False)
@@ -136,7 +136,7 @@ class PowerLevelNotificationDataType(BaseNotificationDataType):
 class PowerLevelNotification(BaseNotification):
     """Model for a Zwave Node's Power Level CC notification event."""
 
-    data: PowerLevelNotificationDataType
+    data: PowerLevelNotificationDataType = field(repr=False)
     test_node_id: int = field(init=False)
     status: PowerLevelTestStatus = field(init=False)
     acknowledged_frames: int = field(init=False)
@@ -167,7 +167,7 @@ class MultilevelSwitchNotificationDataType(BaseNotificationDataType):
 class MultilevelSwitchNotification(BaseNotification):
     """Model for a Zwave Node's Multi Level CC notification event."""
 
-    data: MultilevelSwitchNotificationDataType
+    data: MultilevelSwitchNotificationDataType = field(repr=False)
     event_type: MultilevelSwitchCommand = field(init=False)
     event_type_label: str = field(init=False)
     direction: str | None = field(init=False)

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -38,8 +38,8 @@ class RouteStatisticsDict(TypedDict):
 class RouteStatistics:
     """Represent route statistics."""
 
-    client: "Client"
-    data: RouteStatisticsDataType
+    client: "Client" = field(repr=False)
+    data: RouteStatisticsDataType = field(repr=False)
     protocol_data_rate: ProtocolDataRate = field(init=False)
 
     def __post_init__(self) -> None:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -345,7 +345,7 @@ class SetValueResultDataType(TypedDict, total=False):
 class SetValueResult:
     """Result from setValue command."""
 
-    data: SetValueResultDataType
+    data: SetValueResultDataType = field(repr=False)
     status: SetValueStatus = field(init=False)
     remaining_duration: Duration | None = field(init=False)
     message: str | None = field(init=False)


### PR DESCRIPTION
We don't need to print the TypedDicts or Clients for dataclasses.

There was also one place where we had both the Node and the node_id so decided to remove `node_id`