### PR TITLE
Make config param function returns consistent

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -2522,9 +2522,8 @@ async def test_set_raw_config_parameter_value(
         {},
     )
 
-    assert await node.async_set_raw_config_parameter_value(
-        1, 101, 1
-    ) == SetConfigParameterResult(CommandStatus.QUEUED)
+    _, result = await node.async_set_raw_config_parameter_value(1, 101, 1)
+    assert result == SetConfigParameterResult(CommandStatus.QUEUED)
 
     assert len(ack_commands) == 1
 
@@ -2540,9 +2539,10 @@ async def test_set_raw_config_parameter_value(
         "messageId": uuid4,
     }
 
-    assert await node.async_set_raw_config_parameter_value(
+    _, result = await node.async_set_raw_config_parameter_value(
         "Disable", "Stay Awake in Battery Mode"
-    ) == SetConfigParameterResult(CommandStatus.QUEUED)
+    )
+    assert result == SetConfigParameterResult(CommandStatus.QUEUED)
 
     assert len(ack_commands) == 2
 
@@ -2563,9 +2563,10 @@ async def test_set_raw_config_parameter_value(
     )
     node.receive_event(event)
 
-    assert await node.async_set_raw_config_parameter_value(
+    _, result = await node.async_set_raw_config_parameter_value(
         1, 2, value_size=1, value_format=ConfigurationValueFormat.SIGNED_INTEGER
-    ) == SetConfigParameterResult(CommandStatus.ACCEPTED)
+    )
+    assert result == SetConfigParameterResult(CommandStatus.ACCEPTED)
 
     assert len(ack_commands) == 3
 
@@ -2614,7 +2615,7 @@ async def test_supervision_result(inovelli_switch: node_pkg.Node, uuid4, mock_co
         {"result": {"status": 1, "remainingDuration": "default"}},
     )
 
-    result = await node.async_set_raw_config_parameter_value(1, 1)
+    _, result = await node.async_set_raw_config_parameter_value(1, 1)
     assert result.result.status is SupervisionStatus.WORKING
     duration = result.result.remaining_duration
     assert duration.unit == "default"

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -294,7 +294,7 @@ class Endpoint(EventBase):
         property_key: int | None = None,
         value_size: Literal[1, 2, 4] | None = None,
         value_format: ConfigurationValueFormat | None = None,
-    ) -> SetConfigParameterResult:
+    ) -> tuple[Value, SetConfigParameterResult]:
         """Send setRawConfigParameterValue."""
         try:
             zwave_value = next(
@@ -361,11 +361,11 @@ class Endpoint(EventBase):
         )
 
         if data is None:
-            return SetConfigParameterResult(CommandStatus.QUEUED)
+            return zwave_value, SetConfigParameterResult(CommandStatus.QUEUED)
 
         if (result := data.get("result")) is None:
-            return SetConfigParameterResult(CommandStatus.ACCEPTED)
+            return zwave_value, SetConfigParameterResult(CommandStatus.ACCEPTED)
 
-        return SetConfigParameterResult(
+        return zwave_value, SetConfigParameterResult(
             CommandStatus.ACCEPTED, SupervisionResult(result)
         )

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -952,7 +952,7 @@ class Node(EventBase):
         property_key: int | None = None,
         value_size: Literal[1, 2, 4] | None = None,
         value_format: ConfigurationValueFormat | None = None,
-    ) -> SetConfigParameterResult | None:
+    ) -> tuple[Value, SetConfigParameterResult | None]:
         """Send setRawConfigParameterValue."""
         return await self.endpoints[0].async_set_raw_config_parameter_value(
             new_value, property_, property_key, value_size, value_format


### PR DESCRIPTION
The return for `async_set_raw_config_parameter_value` was different from the utility function `async_set_config_parameter`. While this isn't a problem necessarily, it makes implementation more difficult, and to make things easier the return signatures should match.

 Forgot to include this in the last release 🤦🏾‍♂️ 