### PR TITLE
Update window covering property constants

### DIFF
--- a/zwave_js_server/const/command_class/window_covering.py
+++ b/zwave_js_server/const/command_class/window_covering.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from enum import IntEnum
 
 NO_POSITION_SUFFIX = "(no position)"
-WINDOW_COVERING_LEVEL_CHANGE_DOWN = "levelChangeDown"
-WINDOW_COVERING_LEVEL_CHANGE_UP = "levelChangeUp"
+WINDOW_COVERING_LEVEL_CHANGE_DOWN_PROPERTY = "levelChangeDown"
+WINDOW_COVERING_LEVEL_CHANGE_UP_PROPERTY = "levelChangeUp"
 
 
 class WindowCoveringPropertyKey(IntEnum):

--- a/zwave_js_server/const/command_class/window_covering.py
+++ b/zwave_js_server/const/command_class/window_covering.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from enum import IntEnum
 
 NO_POSITION_SUFFIX = "(no position)"
-WINDOW_COVERING_OPEN_PROPERTY = "open"
-WINDOW_COVERING_CLOSE_PROPERTY = "close"
+WINDOW_COVERING_LEVEL_CHANGE_DOWN = "levelChangeDown"
+WINDOW_COVERING_LEVEL_CHANGE_UP = "levelChangeUp"
 
 
 class WindowCoveringPropertyKey(IntEnum):


### PR DESCRIPTION
# Breaking change

Two Window Covering CC constants were removed because they were no longer valid

# Description

these were changed in https://github.com/zwave-js/node-zwave-js/pull/5807 and I missed it. Thanks to @kpine for tracking this one down