### PR TITLE
Drop min schema version required

### DIFF
--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -10,7 +10,7 @@ PACKAGE_NAME = "zwave-js-server-python"
 __version__ = "0.55.0"
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 34
+MIN_SERVER_SCHEMA_VERSION = 33
 # max server schema version we can handle (and our code is compatible with)
 MAX_SERVER_SCHEMA_VERSION = 34
 


### PR DESCRIPTION
We technically don't need to support the latest schema because worst case scenario, we get nothing back for existing rebuild route progress state. If we do the dependency bump to this, it's no longer a breaking change