### PR TITLE
Add exception handling to EventBase.emit

### DIFF
--- a/test/test_event.py
+++ b/test/test_event.py
@@ -10,3 +10,11 @@ def test_once():
     mock.emit("test-event", 1)
     mock.emit("test-event", 2)
     assert len(calls) == 1
+
+
+def test_exception_on_emit(caplog):
+    """Test exception on emit gets handled."""
+    mock = event.EventBase()
+    mock.on("test-event", lambda _: 1 / 0)
+    mock.emit("test-event", 1)
+    assert "Error handling event: test-event" in caplog.text

--- a/zwave_js_server/event.py
+++ b/zwave_js_server/event.py
@@ -65,7 +65,7 @@ class EventBase:
             try:
                 listener(data)
             except Exception:  # pylint: disable=broad-exception-caught
-                LOGGER.warning("Error handling event: %s", event_name, exc_info=True)
+                LOGGER.exception("Error handling event: %s", event_name)
 
     def _handle_event_protocol(self, event: Event) -> None:
         """Process an event based on event protocol."""

--- a/zwave_js_server/event.py
+++ b/zwave_js_server/event.py
@@ -62,7 +62,10 @@ class EventBase:
     def emit(self, event_name: str, data: dict) -> None:
         """Run all callbacks for an event."""
         for listener in self._listeners.get(event_name, []).copy():
-            listener(data)
+            try:
+                listener(data)
+            except Exception:  # pylint: disable=broad-exception-caught
+                LOGGER.warning("Error handling event: %s", event_name, exc_info=True)
 
     def _handle_event_protocol(self, event: Event) -> None:
         """Process an event based on event protocol."""


### PR DESCRIPTION
Prevents the lib from raising an exception while handling callbacks for events received from the server