### PR TITLE
Reduce frequency of check for generated modules

### DIFF
--- a/.github/workflows/check-generated-modules.yml
+++ b/.github/workflows/check-generated-modules.yml
@@ -2,7 +2,7 @@ name: Check Generated Modules
 
 on:
   schedule:
-    - cron:  '30 3 * * *'
+    - cron:  '30 3 15 * *'
 
 jobs:
   check-generated-modules:


### PR DESCRIPTION
The upstream values may never change, and even if they do, I don't think we need a turnaround of 24 hours to catch the change. I think once a month is reasonable just to avoid wasting CPU cycles but would consider once a week if we feel that is too long between checks