### PR TITLE
Use codecov token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,3 +49,5 @@ jobs:
         uses: actions/download-artifact@v3.0.2
       - name: Upload coverage report
         uses: codecov/codecov-action@v3.1.6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- https://github.com/codecov/codecov-action now requires a token.