### PR TITLE
Bump lib to 0.56.0

### DIFF
--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -8,7 +8,7 @@ import logging
 from typing import TypedDict
 
 PACKAGE_NAME = "zwave-js-server-python"
-__version__ = "0.55.4"
+__version__ = "0.56.0"
 
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 35


### PR DESCRIPTION
Releases long range support and forces users to upgrade to a server version that supports long range