### PR TITLE
Fix QRProvisioningInformation.from_dict()

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -594,27 +594,34 @@ async def test_provision_smart_start_node_qr_info(controller, uuid4, mock_comman
     )
     await controller.async_provision_smart_start_node(provisioning_entry)
 
+    qr_entry = {
+        "version": 1,
+        "securityClasses": [0],
+        "requestedSecurityClasses": [0],
+        "status": 1,
+        "dsk": "test1",
+        "genericDeviceClass": 1,
+        "specificDeviceClass": 2,
+        "installerIconType": 3,
+        "manufacturerId": 4,
+        "productType": 5,
+        "productId": 6,
+        "applicationVersion": "test2",
+        "maxInclusionRequestInterval": 7,
+        "uuid": "test3",
+    }
+
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.provision_smart_start_node",
-        "entry": {
-            "version": 1,
-            "securityClasses": [0],
-            "requestedSecurityClasses": [0],
-            "status": 1,
-            "dsk": "test1",
-            "genericDeviceClass": 1,
-            "specificDeviceClass": 2,
-            "installerIconType": 3,
-            "manufacturerId": 4,
-            "productType": 5,
-            "productId": 6,
-            "applicationVersion": "test2",
-            "maxInclusionRequestInterval": 7,
-            "uuid": "test3",
-        },
+        "entry": qr_entry,
         "messageId": uuid4,
     }
+
+    assert (
+        qr_entry
+        == controller_pkg.QRProvisioningInformation.from_dict(qr_entry).to_dict()
+    )
 
     assert controller_pkg.QRProvisioningInformation(
         dsk="test1",

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -572,6 +572,9 @@ async def test_provision_smart_start_node_qr_info(controller, uuid4, mock_comman
     }
 
     ack_commands.clear()
+
+    # Test that when supported protocols aren't included, it should be None
+    # instead of an empty list.
     provisioning_entry = controller_pkg.QRProvisioningInformation(
         dsk="test1",
         security_classes=[SecurityClass.S2_UNAUTHENTICATED],
@@ -612,6 +615,41 @@ async def test_provision_smart_start_node_qr_info(controller, uuid4, mock_comman
         },
         "messageId": uuid4,
     }
+
+    assert controller_pkg.QRProvisioningInformation(
+        dsk="test1",
+        security_classes=[SecurityClass.S2_UNAUTHENTICATED],
+        requested_security_classes=[SecurityClass.S2_UNAUTHENTICATED],
+        status=ProvisioningEntryStatus.INACTIVE,
+        version=QRCodeVersion.SMART_START,
+        generic_device_class=1,
+        specific_device_class=2,
+        installer_icon_type=3,
+        manufacturer_id=4,
+        product_type=5,
+        product_id=6,
+        application_version="test2",
+        max_inclusion_request_interval=7,
+        uuid="test3",
+        supported_protocols=None,
+    ) == controller_pkg.QRProvisioningInformation.from_dict(
+        {
+            "version": 1,
+            "securityClasses": [0],
+            "requestedSecurityClasses": [0],
+            "status": 1,
+            "dsk": "test1",
+            "genericDeviceClass": 1,
+            "specificDeviceClass": 2,
+            "installerIconType": 3,
+            "manufacturerId": 4,
+            "productType": 5,
+            "productId": 6,
+            "applicationVersion": "test2",
+            "maxInclusionRequestInterval": 7,
+            "uuid": "test3",
+        }
+    )
 
     # Test that S2 QR Code can't be used with `async_provision_smart_start_node`
     provisioning_entry = controller_pkg.QRProvisioningInformation(

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -571,6 +571,48 @@ async def test_provision_smart_start_node_qr_info(controller, uuid4, mock_comman
         "messageId": uuid4,
     }
 
+    ack_commands.clear()
+    provisioning_entry = controller_pkg.QRProvisioningInformation(
+        dsk="test1",
+        security_classes=[SecurityClass.S2_UNAUTHENTICATED],
+        requested_security_classes=[SecurityClass.S2_UNAUTHENTICATED],
+        status=ProvisioningEntryStatus.INACTIVE,
+        version=QRCodeVersion.SMART_START,
+        generic_device_class=1,
+        specific_device_class=2,
+        installer_icon_type=3,
+        manufacturer_id=4,
+        product_type=5,
+        product_id=6,
+        application_version="test2",
+        max_inclusion_request_interval=7,
+        uuid="test3",
+        supported_protocols=None,
+    )
+    await controller.async_provision_smart_start_node(provisioning_entry)
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.provision_smart_start_node",
+        "entry": {
+            "version": 1,
+            "securityClasses": [0],
+            "requestedSecurityClasses": [0],
+            "status": 1,
+            "dsk": "test1",
+            "genericDeviceClass": 1,
+            "specificDeviceClass": 2,
+            "installerIconType": 3,
+            "manufacturerId": 4,
+            "productType": 5,
+            "productId": 6,
+            "applicationVersion": "test2",
+            "maxInclusionRequestInterval": 7,
+            "uuid": "test3",
+        },
+        "messageId": uuid4,
+    }
+
     # Test that S2 QR Code can't be used with `async_provision_smart_start_node`
     provisioning_entry = controller_pkg.QRProvisioningInformation(
         dsk="test1",

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -631,7 +631,8 @@ async def test_provision_smart_start_node_qr_info(controller, uuid4, mock_comman
         application_version="test2",
         max_inclusion_request_interval=7,
         uuid="test3",
-        supported_protocols=None,
+        supported_protocols=[Protocols.ZWAVE],
+        additional_properties={"test": "foo"},
     ) == controller_pkg.QRProvisioningInformation.from_dict(
         {
             "version": 1,
@@ -648,6 +649,8 @@ async def test_provision_smart_start_node_qr_info(controller, uuid4, mock_comman
             "applicationVersion": "test2",
             "maxInclusionRequestInterval": 7,
             "uuid": "test3",
+            "supportedProtocols": [0],
+            "test": "foo",
         }
     )
 

--- a/zwave_js_server/model/controller/inclusion_and_provisioning.py
+++ b/zwave_js_server/model/controller/inclusion_and_provisioning.py
@@ -154,7 +154,24 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
                 Protocols(supported_protocol)
                 for supported_protocol in data["supportedProtocols"]
             ]
-        additional_properties: dict[str, Any] | None = {
+        cls_instance = cls(
+            version=QRCodeVersion(data["version"]),
+            security_classes=[
+                SecurityClass(sec_cls) for sec_cls in data["securityClasses"]
+            ],
+            dsk=data["dsk"],
+            generic_device_class=data["genericDeviceClass"],
+            specific_device_class=data["specificDeviceClass"],
+            installer_icon_type=data["installerIconType"],
+            manufacturer_id=data["manufacturerId"],
+            product_type=data["productType"],
+            product_id=data["productId"],
+            application_version=data["applicationVersion"],
+            max_inclusion_request_interval=data.get("maxInclusionRequestInterval"),
+            uuid=data.get("uuid"),
+            supported_protocols=supported_protocols,
+        )
+        if additional_properties := {
             k: v
             for k, v in data.items()
             if k
@@ -175,27 +192,8 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
                 "supportedProtocols",
                 "status",
             )
-        }
-        if not additional_properties:
-            additional_properties = None
-        cls_instance = cls(
-            version=QRCodeVersion(data["version"]),
-            security_classes=[
-                SecurityClass(sec_cls) for sec_cls in data["securityClasses"]
-            ],
-            dsk=data["dsk"],
-            generic_device_class=data["genericDeviceClass"],
-            specific_device_class=data["specificDeviceClass"],
-            installer_icon_type=data["installerIconType"],
-            manufacturer_id=data["manufacturerId"],
-            product_type=data["productType"],
-            product_id=data["productId"],
-            application_version=data["applicationVersion"],
-            max_inclusion_request_interval=data.get("maxInclusionRequestInterval"),
-            uuid=data.get("uuid"),
-            supported_protocols=supported_protocols,
-            additional_properties=additional_properties,
-        )
+        }:
+            cls_instance.additional_properties = additional_properties
         if "requestedSecurityClasses" in data:
             cls_instance.requested_security_classes = [
                 SecurityClass(sec_cls) for sec_cls in data["requestedSecurityClasses"]

--- a/zwave_js_server/model/controller/inclusion_and_provisioning.py
+++ b/zwave_js_server/model/controller/inclusion_and_provisioning.py
@@ -148,6 +148,12 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> QRProvisioningInformation:
         """Return QRProvisioningInformation from data dict."""
+        supported_protocols: list[Protocols] | None = None
+        if "supportedProtocols" in data:
+            supported_protocols = [
+                Protocols(supported_protocol)
+                for supported_protocol in data["supportedProtocols"]
+            ]
         cls_instance = cls(
             version=QRCodeVersion(data["version"]),
             security_classes=[
@@ -163,10 +169,7 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
             application_version=data["applicationVersion"],
             max_inclusion_request_interval=data.get("maxInclusionRequestInterval"),
             uuid=data.get("uuid"),
-            supported_protocols=[
-                Protocols(supported_protocol)
-                for supported_protocol in data.get("supportedProtocols", [])
-            ],
+            supported_protocols=supported_protocols,
             additional_properties={
                 k: v
                 for k, v in data.items()

--- a/zwave_js_server/model/controller/inclusion_and_provisioning.py
+++ b/zwave_js_server/model/controller/inclusion_and_provisioning.py
@@ -158,7 +158,7 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
             k: v
             for k, v in data.items()
             if k
-            not in {
+            not in (
                 "version",
                 "securityClasses",
                 "requestedSecurityClasses",
@@ -174,7 +174,7 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
                 "uuid",
                 "supportedProtocols",
                 "status",
-            }
+            )
         }
         if not additional_properties:
             additional_properties = None

--- a/zwave_js_server/model/controller/inclusion_and_provisioning.py
+++ b/zwave_js_server/model/controller/inclusion_and_provisioning.py
@@ -76,13 +76,13 @@ class ProvisioningEntry:
             security_classes=[
                 SecurityClass(sec_cls) for sec_cls in data["securityClasses"]
             ],
-            additional_properties={
-                k: v
-                for k, v in data.items()
-                if k
-                not in {"dsk", "securityClasses", "requestedSecurityClasses", "status"}
-            },
         )
+        if additional_properties := {
+            k: v
+            for k, v in data.items()
+            if k not in ("dsk", "securityClasses", "requestedSecurityClasses", "status")
+        }:
+            cls_instance.additional_properties = additional_properties
         if "requestedSecurityClasses" in data:
             cls_instance.requested_security_classes = [
                 SecurityClass(sec_cls) for sec_cls in data["requestedSecurityClasses"]

--- a/zwave_js_server/model/controller/inclusion_and_provisioning.py
+++ b/zwave_js_server/model/controller/inclusion_and_provisioning.py
@@ -154,8 +154,7 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
                 Protocols(supported_protocol)
                 for supported_protocol in data["supportedProtocols"]
             ]
-        additional_properties: dict[str, Any] | None = None
-        if _additional_properties := {
+        additional_properties: dict[str, Any] | None = {
             k: v
             for k, v in data.items()
             if k
@@ -176,8 +175,9 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
                 "supportedProtocols",
                 "status",
             }
-        }:
-            additional_properties = _additional_properties
+        }
+        if not additional_properties:
+            additional_properties = None
         cls_instance = cls(
             version=QRCodeVersion(data["version"]),
             security_classes=[

--- a/zwave_js_server/model/controller/inclusion_and_provisioning.py
+++ b/zwave_js_server/model/controller/inclusion_and_provisioning.py
@@ -154,6 +154,30 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
                 Protocols(supported_protocol)
                 for supported_protocol in data["supportedProtocols"]
             ]
+        additional_properties: dict[str, Any] | None = None
+        if _additional_properties := {
+            k: v
+            for k, v in data.items()
+            if k
+            not in {
+                "version",
+                "securityClasses",
+                "requestedSecurityClasses",
+                "dsk",
+                "genericDeviceClass",
+                "specificDeviceClass",
+                "installerIconType",
+                "manufacturerId",
+                "productType",
+                "productId",
+                "applicationVersion",
+                "maxInclusionRequestInterval",
+                "uuid",
+                "supportedProtocols",
+                "status",
+            }
+        }:
+            additional_properties = _additional_properties
         cls_instance = cls(
             version=QRCodeVersion(data["version"]),
             security_classes=[
@@ -170,28 +194,7 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
             max_inclusion_request_interval=data.get("maxInclusionRequestInterval"),
             uuid=data.get("uuid"),
             supported_protocols=supported_protocols,
-            additional_properties={
-                k: v
-                for k, v in data.items()
-                if k
-                not in {
-                    "version",
-                    "securityClasses",
-                    "requestedSecurityClasses",
-                    "dsk",
-                    "genericDeviceClass",
-                    "specificDeviceClass",
-                    "installerIconType",
-                    "manufacturerId",
-                    "productType",
-                    "productId",
-                    "applicationVersion",
-                    "maxInclusionRequestInterval",
-                    "uuid",
-                    "supportedProtocols",
-                    "status",
-                }
-            },
+            additional_properties=additional_properties,
         )
         if "requestedSecurityClasses" in data:
             cls_instance.requested_security_classes = [


### PR DESCRIPTION
Currently the logic returns an empty list when supported protocols don't exist, but it should be `None`. There's a similar problem with additional properties