### PR TITLE
Bump python version to 3.12

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "zwave-js-server-python Dev",
-    "image": "mcr.microsoft.com/devcontainers/python:3.11",
+    "image": "mcr.microsoft.com/devcontainers/python:3.12",
     "postCreateCommand": "scripts/setup",
     "customizations": {
         "vscode": {

--- a/.github/workflows/check-generated-modules.yml
+++ b/.github/workflows/check-generated-modules.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v4.1.4

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.4
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5.1.0
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install wheel
         run: |-
           pip install wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v4.1.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "zwave-js-server-python"
 authors = [{ name = "Home Assistant Team", email = "hello@home-assistant.io" }]
 description = "Python wrapper for zwave-js-server"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = { file = "LICENSE" }
 keywords = ["home", "automation", "zwave", "zwave-js"]
 classifiers = [
@@ -15,7 +15,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Home Automation",
 ]
 dependencies = ["aiohttp>3", "pydantic>=1.10.0"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py311, lint, mypy
+envlist = py312, lint, mypy
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.11: py311, lint, mypy
+  3.12: py312, lint, mypy
 
 [testenv]
 commands =


### PR DESCRIPTION
## Breaking Change
The minimum python version that is supported is now python 3.12 whereas it used to be 3.11

Based on the upstream changes