### PR TITLE
Update nodes internal state data

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -196,7 +196,11 @@ async def test_last_seen(lock_schlage_be469):
     assert lock_schlage_be469.last_seen == datetime(
         2023, 7, 18, 15, 42, 34, 701000, UTC
     )
-    assert lock_schlage_be469.last_seen == lock_schlage_be469.statistics.last_seen
+    assert (
+        lock_schlage_be469.last_seen
+        == lock_schlage_be469.statistics.last_seen
+        == datetime.fromisoformat(lock_schlage_be469.statistics.data.get("lastSeen"))
+    )
 
 
 async def test_highest_security_value(lock_schlage_be469, ring_keypad):
@@ -556,9 +560,7 @@ async def test_get_value_metadata(multisensor_6, uuid4, mock_command):
         },
     )
 
-    value_id = "52-32-0-targetValue"
-    value = node.values[value_id]
-    result = await node.async_get_value_metadata(value)
+    result = await node.async_get_value_metadata("52-32-0-targetValue")
 
     assert result.type == "any"
     assert result.readable is True
@@ -573,6 +575,8 @@ async def test_get_value_metadata(multisensor_6, uuid4, mock_command):
         "valueId": {"commandClass": 32, "endpoint": 0, "property": "targetValue"},
         "messageId": uuid4,
     }
+
+    ack_commands.clear()
 
 
 async def test_abort_firmware_update(multisensor_6, uuid4, mock_command):

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from ..const import (
     VALUE_UNKNOWN,
-    CommandClass,
     CommandStatus,
     ConfigurationValueType,
     SetValueStatus,
@@ -73,13 +72,6 @@ class ValueDataType(TypedDict, total=False):
     prevValue: Any
     metadata: MetaDataType  # required
     ccVersion: int  # required
-
-
-def _init_value(node: Node, val: ValueDataType) -> Value | ConfigurationValue:
-    """Initialize a Value object from ValueDataType."""
-    if val["commandClass"] == CommandClass.CONFIGURATION:
-        return ConfigurationValue(node, val)
-    return Value(node, val)
 
 
 def _get_value_id_str_from_dict(node: Node, val: ValueDataType) -> str:


### PR DESCRIPTION
When making updates to the lib's last seen state, we were not updating its internal state (`node.data`). The sensor entity uses `node.data` to populate its state, and if there is no last seen state data, the entity becomes `unknown` as a result.

I'm separately wondering if we should update the statistics sensor entity descriptions to use the actual model (e.g. `node.last_seen`) instead of the node's internal state (`node.data["lastSeen"]`)). Do we generally want to avoid accessing the internal state of things in the lib from the integration code? If so, I'm guessing there are other places we are doing that as well.

Thanks @kpine for finding the issue!