### PR TITLE
Add reset value definition for Meter CC

### DIFF
--- a/zwave_js_server/const/command_class/meter.py
+++ b/zwave_js_server/const/command_class/meter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from enum import IntEnum
 
 VALUE_PROPERTY = "value"
+RESET_PROPERTY = "reset"
 
 CC_SPECIFIC_SCALE = "scale"
 CC_SPECIFIC_METER_TYPE = "meterType"


### PR DESCRIPTION
This PR adds the `reset` property name for the Meter CC as a constant so it can be used in consuming applications

This is needed for https://github.com/home-assistant/core/pull/119968, which is needed for https://github.com/zwave-js/certification-backlog/issues/17