### PR TITLE
Remove usage of kwargs

### DIFF
--- a/zwave_js_server/event.py
+++ b/zwave_js_server/event.py
@@ -21,6 +21,14 @@ class BaseEventModel(BaseModel):
     source: Literal["controller", "driver", "node"]
     event: str
 
+    @classmethod
+    def from_dict(cls, data: dict) -> BaseEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+        )
+
 
 @dataclass
 class Event:

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -869,7 +869,7 @@ class Controller(EventBase):
                 f"{event.data}"
             )
 
-        CONTROLLER_EVENT_MODEL_MAP[event.type](**event.data)
+        CONTROLLER_EVENT_MODEL_MAP[event.type].from_dict(event.data)
 
         self._handle_event_protocol(event)
 

--- a/zwave_js_server/model/controller/event_model.py
+++ b/zwave_js_server/model/controller/event_model.py
@@ -52,12 +52,30 @@ class FirmwareUpdateFinishedEventModel(BaseControllerEventModel):
     event: Literal["firmware update finished"]
     result: ControllerFirmwareUpdateResultDataType
 
+    @classmethod
+    def from_dict(cls, data: dict) -> FirmwareUpdateFinishedEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            result=data["result"],
+        )
+
 
 class FirmwareUpdateProgressEventModel(BaseControllerEventModel):
     """Model for `firmware update progress` event data."""
 
     event: Literal["firmware update progress"]
     progress: ControllerFirmwareUpdateProgressDataType
+
+    @classmethod
+    def from_dict(cls, data: dict) -> FirmwareUpdateProgressEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            progress=data["progress"],
+        )
 
 
 class GrantSecurityClassesEventModel(BaseControllerEventModel):
@@ -66,6 +84,15 @@ class GrantSecurityClassesEventModel(BaseControllerEventModel):
     event: Literal["grant security classes"]
     requested: InclusionGrantDataType
 
+    @classmethod
+    def from_dict(cls, data: dict) -> GrantSecurityClassesEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            requested=data["requested"],
+        )
+
 
 class RebuildRoutesDoneEventModel(BaseControllerEventModel):
     """Model for `rebuild routes done` event data."""
@@ -73,12 +100,30 @@ class RebuildRoutesDoneEventModel(BaseControllerEventModel):
     event: Literal["rebuild routes done"]
     result: dict[str, str]
 
+    @classmethod
+    def from_dict(cls, data: dict) -> RebuildRoutesDoneEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            result=data["result"],
+        )
+
 
 class RebuildRoutesProgressEventModel(BaseControllerEventModel):
     """Model for `rebuild routes progress` event data."""
 
     event: Literal["rebuild routes progress"]
     progress: dict[str, str]
+
+    @classmethod
+    def from_dict(cls, data: dict) -> RebuildRoutesProgressEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            progress=data["progress"],
+        )
 
 
 class InclusionAbortedEventModel(BaseControllerEventModel):
@@ -99,6 +144,15 @@ class InclusionStartedEventModel(BaseControllerEventModel):
     event: Literal["inclusion started"]
     secure: bool
 
+    @classmethod
+    def from_dict(cls, data: dict) -> InclusionStartedEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            secure=data["secure"],
+        )
+
 
 class InclusionStoppedEventModel(BaseControllerEventModel):
     """Model for `inclusion stopped` event data."""
@@ -113,12 +167,31 @@ class NodeAddedEventModel(BaseControllerEventModel):
     node: NodeDataType
     result: InclusionResultDataType
 
+    @classmethod
+    def from_dict(cls, data: dict) -> NodeAddedEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            node=data["node"],
+            result=data["result"],
+        )
+
 
 class NodeFoundEventModel(BaseControllerEventModel):
     """Model for `node found` event data."""
 
     event: Literal["node found"]
     node: FoundNodeDataType
+
+    @classmethod
+    def from_dict(cls, data: dict) -> NodeFoundEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            node=data["node"],
+        )
 
 
 class NodeRemovedEventModel(BaseControllerEventModel):
@@ -128,12 +201,32 @@ class NodeRemovedEventModel(BaseControllerEventModel):
     node: NodeDataType
     reason: RemoveNodeReason
 
+    @classmethod
+    def from_dict(cls, data: dict) -> NodeRemovedEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            node=data["node"],
+            reason=data["reason"],
+        )
+
 
 class NVMBackupAndConvertProgressEventModel(BaseControllerEventModel):
     """Base model for `nvm backup progress` and `nvm convert progress` event data."""
 
     bytesRead: int
     total: int
+
+    @classmethod
+    def from_dict(cls, data: dict) -> NVMBackupAndConvertProgressEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            bytesRead=data["bytesRead"],
+            total=data["total"],
+        )
 
 
 class NVMBackupProgressEventModel(NVMBackupAndConvertProgressEventModel):
@@ -155,12 +248,31 @@ class NVMRestoreProgressEventModel(BaseControllerEventModel):
     bytesWritten: int
     total: int
 
+    @classmethod
+    def from_dict(cls, data: dict) -> NVMRestoreProgressEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            bytesWritten=data["bytesWritten"],
+            total=data["total"],
+        )
+
 
 class StatisticsUpdatedEventModel(BaseControllerEventModel):
     """Model for `statistics updated` event data."""
 
     event: Literal["statistics updated"]
     statistics: ControllerStatisticsDataType
+
+    @classmethod
+    def from_dict(cls, data: dict) -> StatisticsUpdatedEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            statistics=data["statistics"],
+        )
 
 
 class ValidateDSKAndEnterPINEventModel(BaseControllerEventModel):
@@ -169,6 +281,15 @@ class ValidateDSKAndEnterPINEventModel(BaseControllerEventModel):
     event: Literal["validate dsk and enter pin"]
     dsk: str
 
+    @classmethod
+    def from_dict(cls, data: dict) -> ValidateDSKAndEnterPINEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            dsk=data["dsk"],
+        )
+
 
 class IdentifyEventModel(BaseControllerEventModel):
     """Model for `identify` event data."""
@@ -176,12 +297,30 @@ class IdentifyEventModel(BaseControllerEventModel):
     event: Literal["identify"]
     nodeId: int
 
+    @classmethod
+    def from_dict(cls, data: dict) -> IdentifyEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+        )
+
 
 class StatusChangedEventModel(BaseControllerEventModel):
     """Model for `status changed` event data."""
 
     event: Literal["status changed"]
     status: int
+
+    @classmethod
+    def from_dict(cls, data: dict) -> StatusChangedEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            status=data["status"],
+        )
 
 
 CONTROLLER_EVENT_MODEL_MAP: dict[str, type[BaseControllerEventModel]] = {

--- a/zwave_js_server/model/device_class.py
+++ b/zwave_js_server/model/device_class.py
@@ -38,9 +38,15 @@ class DeviceClass:
 
     def __init__(self, data: DeviceClassDataType) -> None:
         """Initialize."""
-        self._basic = DeviceClassItem(**data["basic"])
-        self._generic = DeviceClassItem(**data["generic"])
-        self._specific = DeviceClassItem(**data["specific"])
+        self._basic = DeviceClassItem(
+            key=data["basic"]["key"], label=data["basic"]["label"]
+        )
+        self._generic = DeviceClassItem(
+            key=data["generic"]["key"], label=data["generic"]["label"]
+        )
+        self._specific = DeviceClassItem(
+            key=data["specific"]["key"], label=data["specific"]["label"]
+        )
 
     @property
     def basic(self) -> DeviceClassItem:

--- a/zwave_js_server/model/device_class.py
+++ b/zwave_js_server/model/device_class.py
@@ -39,13 +39,16 @@ class DeviceClass:
     def __init__(self, data: DeviceClassDataType) -> None:
         """Initialize."""
         self._basic = DeviceClassItem(
-            key=data["basic"]["key"], label=data["basic"]["label"]
+            key=data["basic"]["key"],
+            label=data["basic"]["label"],
         )
         self._generic = DeviceClassItem(
-            key=data["generic"]["key"], label=data["generic"]["label"]
+            key=data["generic"]["key"],
+            label=data["generic"]["label"],
         )
         self._specific = DeviceClassItem(
-            key=data["specific"]["key"], label=data["specific"]["label"]
+            key=data["specific"]["key"],
+            label=data["specific"]["label"],
         )
 
     @property

--- a/zwave_js_server/model/driver.py
+++ b/zwave_js_server/model/driver.py
@@ -30,6 +30,15 @@ class LogConfigUpdatedEventModel(BaseDriverEventModel):
     event: Literal["log config updated"]
     config: LogConfigDataType
 
+    @classmethod
+    def from_dict(cls, data: dict) -> LogConfigUpdatedEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            config=data["config"],
+        )
+
 
 class AllNodesReadyEventModel(BaseDriverEventModel):
     """Model for `all nodes ready` event data."""
@@ -87,7 +96,7 @@ class Driver(EventBase):
             self.controller.receive_event(event)
             return
 
-        DRIVER_EVENT_MODEL_MAP[event.type](**event.data)
+        DRIVER_EVENT_MODEL_MAP[event.type].from_dict(event.data)
 
         self._handle_event_protocol(event)
 

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -475,7 +475,7 @@ class Node(EventBase):
 
     def receive_event(self, event: Event) -> None:
         """Receive an event."""
-        NODE_EVENT_MODEL_MAP[event.type](**event.data)
+        NODE_EVENT_MODEL_MAP[event.type].from_dict(event.data)
 
         self._handle_event_protocol(event)
         event.data["node"] = self

--- a/zwave_js_server/model/node/event_model.py
+++ b/zwave_js_server/model/node/event_model.py
@@ -32,6 +32,15 @@ class BaseNodeEventModel(BaseEventModel):
     source: Literal["node"]
     nodeId: int
 
+    @classmethod
+    def from_dict(cls, data: dict) -> BaseNodeEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+        )
+
 
 class AliveEventModel(BaseNodeEventModel):
     """Model for `alive` event data."""
@@ -49,6 +58,18 @@ class CheckHealthProgressEventModel(BaseNodeEventModel):
     rounds: int
     totalRounds: int
     lastRating: int
+
+    @classmethod
+    def from_dict(cls, data: dict) -> CheckHealthProgressEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            rounds=data["rounds"],
+            totalRounds=data["totalRounds"],
+            lastRating=data["lastRating"],
+        )
 
 
 class CheckLifelineHealthProgressEventModel(CheckHealthProgressEventModel):
@@ -83,6 +104,19 @@ class InterviewFailedEventArgsModel(BaseModel):
     attempt: int | None
     maxAttempts: int | None
 
+    @classmethod
+    def from_dict(cls, data: dict) -> InterviewFailedEventArgsModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            errorMessage=data["errorMessage"],
+            isFinal=data["isFinal"],
+            attempt=data["attempt"],
+            maxAttempts=data["maxAttempts"],
+        )
+
 
 class InterviewFailedEventModel(BaseNodeEventModel):
     """Model for `interview failed` event data."""
@@ -90,12 +124,32 @@ class InterviewFailedEventModel(BaseNodeEventModel):
     event: Literal["interview failed"]
     args: InterviewFailedEventArgsModel
 
+    @classmethod
+    def from_dict(cls, data: dict) -> InterviewFailedEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            args=data["args"],
+        )
+
 
 class InterviewStageCompletedEventModel(BaseNodeEventModel):
     """Model for `interview stage completed` event data."""
 
     event: Literal["interview stage completed"]
     stageName: str
+
+    @classmethod
+    def from_dict(cls, data: dict) -> InterviewStageCompletedEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            stageName=data["stageName"],
+        )
 
 
 class InterviewStartedEventModel(BaseNodeEventModel):
@@ -118,12 +172,34 @@ class NotificationEventModel(BaseNodeEventModel):
         | MultilevelSwitchNotificationArgsDataType
     )
 
+    @classmethod
+    def from_dict(cls, data: dict) -> NotificationEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            endpointIndex=data["endpointIndex"],
+            ccId=data["ccId"],
+            args=data["args"],
+        )
+
 
 class ReadyEventModel(BaseNodeEventModel):
     """Model for `ready` event data."""
 
     event: Literal["ready"]
     nodeState: NodeDataType
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ReadyEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            nodeState=data["nodeState"],
+        )
 
 
 class SleepEventModel(BaseNodeEventModel):
@@ -138,6 +214,16 @@ class StatisticsUpdatedEventModel(BaseNodeEventModel):
     event: Literal["statistics updated"]
     statistics: NodeStatisticsDataType
 
+    @classmethod
+    def from_dict(cls, data: dict) -> StatisticsUpdatedEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            statistics=data["statistics"],
+        )
+
 
 class TestPowerLevelProgressEventModel(BaseNodeEventModel):
     """Model for `test powerlevel progress` event data."""
@@ -145,6 +231,17 @@ class TestPowerLevelProgressEventModel(BaseNodeEventModel):
     event: Literal["test powerlevel progress"]
     acknowledged: int
     total: int
+
+    @classmethod
+    def from_dict(cls, data: dict) -> TestPowerLevelProgressEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            acknowledged=data["acknowledged"],
+            total=data["total"],
+        )
 
 
 class ValueEventModel(BaseNodeEventModel):
@@ -156,6 +253,16 @@ class ValueEventModel(BaseNodeEventModel):
     """
 
     args: ValueDataType
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ValueEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            args=data["args"],
+        )
 
 
 class MetadataUpdatedEventModel(ValueEventModel):
@@ -200,12 +307,32 @@ class FirmwareUpdateFinishedEventModel(BaseNodeEventModel):
     event: Literal["firmware update finished"]
     result: NodeFirmwareUpdateResultDataType
 
+    @classmethod
+    def from_dict(cls, data: dict) -> FirmwareUpdateFinishedEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            result=data["result"],
+        )
+
 
 class FirmwareUpdateProgressEventModel(BaseNodeEventModel):
     """Model for `firmware update progress` event data."""
 
     event: Literal["firmware update progress"]
     progress: NodeFirmwareUpdateProgressDataType
+
+    @classmethod
+    def from_dict(cls, data: dict) -> FirmwareUpdateProgressEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            progress=data["progress"],
+        )
 
 
 NODE_EVENT_MODEL_MAP: dict[str, type[BaseNodeEventModel]] = {

--- a/zwave_js_server/model/node/firmware.py
+++ b/zwave_js_server/model/node/firmware.py
@@ -213,7 +213,11 @@ class NodeFirmwareUpdateFileInfo:
         cls, data: NodeFirmwareUpdateFileInfoDataType
     ) -> NodeFirmwareUpdateFileInfo:
         """Initialize from dict."""
-        return cls(**data)
+        return cls(
+            target=data["target"],
+            url=data["url"],
+            integrity=data["integrity"],
+        )
 
     def to_dict(self) -> NodeFirmwareUpdateFileInfoDataType:
         """Return dict representation of the object."""


### PR DESCRIPTION
Remove the usage of keyword arguments. Keyword arguments tend to blow up when the data format is expanded with new attributes and makes the code less resilient. 