### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{ name = "Home Assistant Team", email = "hello@home-assistant.io" }]
 description = "Python wrapper for zwave-js-server"
 readme = "README.md"
 requires-python = ">=3.12"
-license = { file = "LICENSE" }
+license = { text = "Apache-2.0" }
 keywords = ["home", "automation", "zwave", "zwave-js"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Use the SPDX license identifier for `Apache-2.0` instead of the whole license file inside the project metadata. This will make it easier to correctly identify the project license. See also [PEP-639](https://peps.python.org/pep-0639/) which is close to being finalized.

https://spdx.org/licenses/

https://github.com/home-assistant-libs/zwave-js-server-python/blob/11652fd1045661d6e0485cb78437084d22e49a07/LICENSE#L1-L3