### PR TITLE
Fix inclusion started event model

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -27,6 +27,7 @@ from zwave_js_server.model import (
     association as association_pkg,
     controller as controller_pkg,
 )
+from zwave_js_server.model.controller import Controller
 from zwave_js_server.model.controller.firmware import ControllerFirmwareUpdateStatus
 from zwave_js_server.model.controller.rebuild_routes import (
     RebuildRoutesOptions,
@@ -2230,7 +2231,7 @@ async def test_unknown_event(controller):
         )
 
 
-async def test_additional_events(controller):
+async def test_additional_events(controller: Controller) -> None:
     """Test that remaining events pass pydantic validation."""
     event = Event(
         "exclusion failed", {"source": "controller", "event": "exclusion failed"}
@@ -2250,7 +2251,7 @@ async def test_additional_events(controller):
     controller.receive_event(event)
     event = Event(
         "inclusion started",
-        {"source": "controller", "event": "inclusion started", "secure": True},
+        {"source": "controller", "event": "inclusion started", "strategy": 0},
     )
     controller.receive_event(event)
     event = Event(

--- a/zwave_js_server/model/controller/event_model.py
+++ b/zwave_js_server/model/controller/event_model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal, TypedDict
 
-from ...const import RemoveNodeReason
+from ...const import InclusionStrategy, RemoveNodeReason
 from ...event import BaseEventModel
 from ..node.data_model import FoundNodeDataType, NodeDataType
 from .firmware import (
@@ -142,7 +142,7 @@ class InclusionStartedEventModel(BaseControllerEventModel):
     """Model for `inclusion started` event data."""
 
     event: Literal["inclusion started"]
-    secure: bool
+    strategy: InclusionStrategy
 
     @classmethod
     def from_dict(cls, data: dict) -> InclusionStartedEventModel:
@@ -150,7 +150,7 @@ class InclusionStartedEventModel(BaseControllerEventModel):
         return cls(
             source=data["source"],
             event=data["event"],
-            secure=data["secure"],
+            strategy=data["strategy"],
         )
 
 


### PR DESCRIPTION
- We missed updating the inclusion started event model when updating the library to handle changes in Z-Wave JS v 13.x. Fix that!
- Users of the `InclusionStartedEventModel` model need to update their attribute access to use the new attribute `strategy` instead of `secure` which was removed in v 13 of Z-Wave JS.