### PR TITLE
Remove validation for async_set_raw_config_parameter_value

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -2598,7 +2598,7 @@ async def test_set_raw_config_parameter_value(
         {},
     )
 
-    _, result = await node.async_set_raw_config_parameter_value(1, 101, 1)
+    result = await node.async_set_raw_config_parameter_value(1, 101, 1)
     assert result == SetConfigParameterResult(CommandStatus.QUEUED)
 
     assert len(ack_commands) == 1
@@ -2615,7 +2615,7 @@ async def test_set_raw_config_parameter_value(
         "messageId": uuid4,
     }
 
-    _, result = await node.async_set_raw_config_parameter_value(
+    result = await node.async_set_raw_config_parameter_value(
         "Disable", "Stay Awake in Battery Mode"
     )
     assert result == SetConfigParameterResult(CommandStatus.QUEUED)
@@ -2639,7 +2639,7 @@ async def test_set_raw_config_parameter_value(
     )
     node.receive_event(event)
 
-    _, result = await node.async_set_raw_config_parameter_value(
+    result = await node.async_set_raw_config_parameter_value(
         1, 2, value_size=1, value_format=ConfigurationValueFormat.SIGNED_INTEGER
     )
     assert result == SetConfigParameterResult(CommandStatus.ACCEPTED)
@@ -2691,7 +2691,7 @@ async def test_supervision_result(inovelli_switch: node_pkg.Node, uuid4, mock_co
         {"result": {"status": 1, "remainingDuration": "default"}},
     )
 
-    _, result = await node.async_set_raw_config_parameter_value(1, 1)
+    result = await node.async_set_raw_config_parameter_value(1, 1)
     assert result.result.status is SupervisionStatus.WORKING
     duration = result.result.remaining_duration
     assert duration.unit == "default"

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -2615,9 +2615,7 @@ async def test_set_raw_config_parameter_value(
         "messageId": uuid4,
     }
 
-    result = await node.async_set_raw_config_parameter_value(
-        "Disable", "Stay Awake in Battery Mode"
-    )
+    result = await node.async_set_raw_config_parameter_value(2, 0)
     assert result == SetConfigParameterResult(CommandStatus.QUEUED)
 
     assert len(ack_commands) == 2
@@ -2627,8 +2625,8 @@ async def test_set_raw_config_parameter_value(
         "nodeId": node.node_id,
         "endpoint": 0,
         "options": {
-            "parameter": 2,
-            "value": 0,
+            "parameter": 0,
+            "value": 2,
         },
         "messageId": uuid4,
     }
@@ -2660,14 +2658,6 @@ async def test_set_raw_config_parameter_value(
     }
 
     # Test failures
-    with pytest.raises(NotFoundError):
-        await node.async_set_raw_config_parameter_value(
-            "fake", "Stay Awake in Battery Mode"
-        )
-
-    with pytest.raises(NotFoundError):
-        await node.async_set_raw_config_parameter_value(1, 1000)
-
     with pytest.raises(ValueError):
         await node.async_set_raw_config_parameter_value(1, 101, 1, 1)
 

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -293,7 +293,7 @@ class Endpoint(EventBase):
 
     async def async_set_raw_config_parameter_value(
         self,
-        new_value: int | str,
+        new_value: int,
         property_: int | str,
         property_key: int | None = None,
         value_size: Literal[1, 2, 4] | None = None,

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -965,7 +965,7 @@ class Node(EventBase):
 
     async def async_set_raw_config_parameter_value(
         self,
-        new_value: int | str,
+        new_value: int,
         property_: int | str,
         property_key: int | None = None,
         value_size: Literal[1, 2, 4] | None = None,

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -970,7 +970,7 @@ class Node(EventBase):
         property_key: int | None = None,
         value_size: Literal[1, 2, 4] | None = None,
         value_format: ConfigurationValueFormat | None = None,
-    ) -> tuple[Value, SetConfigParameterResult | None]:
+    ) -> SetConfigParameterResult:
         """Send setRawConfigParameterValue."""
         return await self.endpoints[0].async_set_raw_config_parameter_value(
             new_value, property_, property_key, value_size, value_format


### PR DESCRIPTION
## Breaking change

The return result for `async_set_raw_config_parameter_value` has been changed from a tuple that includes the targeted Z-Wave value to just the result

resolves https://github.com/home-assistant-libs/zwave-js-server-python/issues/925