### PR TITLE
Add lock util function to set multiple usercodes

### DIFF
--- a/test/util/test_lock.py
+++ b/test/util/test_lock.py
@@ -20,6 +20,7 @@ from zwave_js_server.const.command_class.lock import (
 )
 from zwave_js_server.exceptions import NotFoundError
 from zwave_js_server.model.node import Node
+from zwave_js_server.model.value import SupervisionResult
 from zwave_js_server.util.lock import (
     clear_usercode,
     get_code_slots,
@@ -116,7 +117,9 @@ async def test_set_usercodes(lock_schlage_be469, mock_command, uuid4):
     )
 
     # Test wrong types to ensure values get converted
-    await set_usercodes(node, {"1": 1234})
+    assert await set_usercodes(node, {"1": 1234}) == SupervisionResult(
+        {"status": SupervisionStatus.SUCCESS}
+    )
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "endpoint.invoke_cc_api",
@@ -142,6 +145,18 @@ async def test_set_usercodes(lock_schlage_be469, mock_command, uuid4):
 
     # assert no new command calls
     assert len(ack_commands) == 1
+
+
+async def test_set_usercodes_invalid(lock_schlage_be469, mock_command):
+    """Test set_usercodes utility function with invalid response."""
+    node = lock_schlage_be469
+    mock_command(
+        {"command": "endpoint.invoke_cc_api", "endpoint": 0, "nodeId": node.node_id},
+        {"response": {}},
+    )
+
+    with pytest.raises(ValueError):
+        assert await set_usercodes(node, {"1": 1234})
 
 
 async def test_clear_usercode(lock_schlage_be469, mock_command, uuid4):

--- a/test/util/test_lock.py
+++ b/test/util/test_lock.py
@@ -108,7 +108,9 @@ async def test_set_usercode(lock_schlage_be469, mock_command, uuid4):
     assert len(ack_commands) == 1
 
 
-async def test_set_usercodes(lock_schlage_be469, mock_command, uuid4):
+async def test_set_usercodes(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
     """Test set_usercodes utility function."""
     node = lock_schlage_be469
     ack_commands = mock_command(

--- a/test/util/test_lock.py
+++ b/test/util/test_lock.py
@@ -11,6 +11,10 @@ from zwave_js_server.const.command_class.lock import (
     ATTR_IN_USE,
     ATTR_NAME,
     ATTR_USERCODE,
+    LOCK_USERCODE_ID_PROPERTY,
+    LOCK_USERCODE_PROPERTY,
+    LOCK_USERCODE_STATUS_PROPERTY,
+    CodeSlotStatus,
     DoorLockCCConfigurationSetOptions,
     OperationType,
 )
@@ -24,6 +28,7 @@ from zwave_js_server.util.lock import (
     get_usercodes,
     set_configuration,
     set_usercode,
+    set_usercodes,
 )
 
 from .const import CODE_SLOTS
@@ -97,6 +102,43 @@ async def test_set_usercode(lock_schlage_be469, mock_command, uuid4):
     # Test invalid code length
     with pytest.raises(ValueError):
         await set_usercode(node, 1, "123")
+
+    # assert no new command calls
+    assert len(ack_commands) == 1
+
+
+async def test_set_usercodes(lock_schlage_be469, mock_command, uuid4):
+    """Test set_usercodes utility function."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {"command": "endpoint.invoke_cc_api", "endpoint": 0, "nodeId": node.node_id},
+        {"response": {"status": 255}},
+    )
+
+    # Test wrong types to ensure values get converted
+    await set_usercodes(node, {"1": 1234})
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "endpoint.invoke_cc_api",
+        "commandClass": 99,
+        "endpoint": 0,
+        "methodName": "setMany",
+        "nodeId": 20,
+        "messageId": uuid4,
+        "args": [
+            [
+                {
+                    LOCK_USERCODE_STATUS_PROPERTY: CodeSlotStatus.ENABLED,
+                    LOCK_USERCODE_ID_PROPERTY: 1,
+                    LOCK_USERCODE_PROPERTY: "1234",
+                }
+            ]
+        ],
+    }
+
+    # Test invalid code length
+    with pytest.raises(ValueError):
+        await set_usercodes(node, {1: "123"})
 
     # assert no new command calls
     assert len(ack_commands) == 1

--- a/test/util/test_lock.py
+++ b/test/util/test_lock.py
@@ -149,7 +149,9 @@ async def test_set_usercodes(
     assert len(ack_commands) == 1
 
 
-async def test_set_usercodes_invalid(lock_schlage_be469, mock_command):
+async def test_set_usercodes_invalid(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol
+) -> None:
     """Test set_usercodes utility function with invalid response."""
     node = lock_schlage_be469
     mock_command(

--- a/zwave_js_server/const/command_class/lock.py
+++ b/zwave_js_server/const/command_class/lock.py
@@ -118,6 +118,7 @@ LOCKED_PROPERTY = "locked"
 
 # User Code CC constants
 LOCK_USERCODE_PROPERTY = "userCode"
+LOCK_USERCODE_ID_PROPERTY = "userId"
 LOCK_USERCODE_STATUS_PROPERTY = "userIdStatus"
 
 ATTR_CODE_SLOT = "code_slot"

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -14,6 +14,7 @@ from ..const.command_class.lock import (
     CURRENT_BLOCK_TO_BLOCK_PROPERTY,
     CURRENT_HOLD_AND_RELEASE_TIME_PROPERTY,
     CURRENT_TWIST_ASSIST_PROPERTY,
+    LOCK_USERCODE_ID_PROPERTY,
     LOCK_USERCODE_PROPERTY,
     LOCK_USERCODE_STATUS_PROPERTY,
     CodeSlotStatus,
@@ -68,7 +69,7 @@ def _get_code_slots(node: Node, include_usercode: bool = False) -> list[CodeSlot
         except NotFoundError:
             return slots
 
-        code_slot = int(value.property_key)  # type: ignore[arg-type]
+        code_slot = int(value.property_key)
         in_use = (
             None
             if status_value.value is None
@@ -104,7 +105,7 @@ def get_usercode(node: Node, code_slot: int) -> CodeSlot:
     value = get_code_slot_value(node, code_slot, LOCK_USERCODE_PROPERTY)
     status_value = get_code_slot_value(node, code_slot, LOCK_USERCODE_STATUS_PROPERTY)
 
-    code_slot = int(value.property_key)  # type: ignore[arg-type]
+    code_slot = int(value.property_key)
     in_use = (
         None
         if status_value.value is None
@@ -130,6 +131,7 @@ async def get_usercode_from_node(node: Node, code_slot: int) -> CodeSlot:
     This call will populate the ValueDB and trigger value update events from the
     driver.
     """
+    # https://zwave-js.github.io/node-zwave-js/#/api/CCs/UserCode?id=get
     await node.async_invoke_cc_api(
         CommandClass.USER_CODE, "get", code_slot, wait_for_result=True
     )
@@ -141,11 +143,36 @@ async def set_usercode(
 ) -> SetValueResult | None:
     """Set the usercode to index X on the lock."""
     value = get_code_slot_value(node, code_slot, LOCK_USERCODE_PROPERTY)
+    usercode = str(usercode)
 
-    if len(str(usercode)) < 4:
+    if len(usercode) < 4:
         raise ValueError("User code must be at least 4 digits")
 
     return await node.async_set_value(value, usercode)
+
+
+async def set_usercodes(node: Node, codes: dict[int, str]) -> SetValueResult | None:
+    """Set the usercode to index X on the lock."""
+    if any(len(str(usercode)) < 4 for usercode in codes.values()):
+        raise ValueError("User codes must be at least 4 digits")
+
+    codes_api = [
+        {
+            LOCK_USERCODE_ID_PROPERTY: int(code_slot),
+            LOCK_USERCODE_STATUS_PROPERTY: CodeSlotStatus.ENABLED,
+            LOCK_USERCODE_PROPERTY: str(usercode),
+        }
+        for code_slot, usercode in codes.items()
+    ]
+
+    # https://zwave-js.github.io/node-zwave-js/#/api/CCs/UserCode?id=setmany
+    data = await node.async_invoke_cc_api(
+        CommandClass.USER_CODE, "setMany", codes_api, wait_for_result=True
+    )
+
+    if not data:
+        return None
+    return SupervisionResult(data)
 
 
 async def clear_usercode(node: Node, code_slot: int) -> SetValueResult | None:
@@ -197,6 +224,7 @@ async def set_configuration(
     if errors:
         raise ValueError("\n".join(errors))
 
+    # https://zwave-js.github.io/node-zwave-js/#/api/CCs/UserCode?id=setconfiguration
     data = await endpoint.async_invoke_cc_api(
         CommandClass.DOOR_LOCK, "setConfiguration", configuration.to_dict()
     )

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -153,9 +153,6 @@ async def set_usercode(
 
 async def set_usercodes(node: Node, codes: dict[int, str]) -> SupervisionResult | None:
     """Set the usercode to index X on the lock."""
-    if any(len(str(usercode)) < 4 for usercode in codes.values()):
-        raise ValueError("User codes must be at least 4 digits")
-
     cc_api_codes = [
         {
             LOCK_USERCODE_ID_PROPERTY: int(code_slot),
@@ -163,7 +160,11 @@ async def set_usercodes(node: Node, codes: dict[int, str]) -> SupervisionResult 
             LOCK_USERCODE_PROPERTY: str(usercode),
         }
         for code_slot, usercode in codes.items()
+        if len(str(usercode)) >= 4
     ]
+
+    if len(cc_api_codes) != len(codes):
+        raise ValueError("User codes must be at least 4 digits")
 
     # https://zwave-js.github.io/node-zwave-js/#/api/CCs/UserCode?id=setmany
     data = await node.async_invoke_cc_api(

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -156,7 +156,7 @@ async def set_usercodes(node: Node, codes: dict[int, str]) -> SupervisionResult 
     if any(len(str(usercode)) < 4 for usercode in codes.values()):
         raise ValueError("User codes must be at least 4 digits")
 
-    codes_api = [
+    cc_api_codes = [
         {
             LOCK_USERCODE_ID_PROPERTY: int(code_slot),
             LOCK_USERCODE_STATUS_PROPERTY: CodeSlotStatus.ENABLED,
@@ -167,7 +167,7 @@ async def set_usercodes(node: Node, codes: dict[int, str]) -> SupervisionResult 
 
     # https://zwave-js.github.io/node-zwave-js/#/api/CCs/UserCode?id=setmany
     data = await node.async_invoke_cc_api(
-        CommandClass.USER_CODE, "setMany", codes_api, wait_for_result=True
+        CommandClass.USER_CODE, "setMany", cc_api_codes, wait_for_result=True
     )
 
     if not data:

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -163,7 +163,7 @@ async def set_usercodes(node: Node, codes: dict[int, str]) -> SupervisionResult 
         if len(str(usercode)) >= 4
     ]
 
-    if len(cc_api_codes) != len(codes):
+    if len(cc_api_codes) < len(codes):
         raise ValueError("User codes must be at least 4 digits")
 
     # https://zwave-js.github.io/node-zwave-js/#/api/CCs/UserCode?id=setmany

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -171,7 +171,7 @@ async def set_usercodes(node: Node, codes: dict[int, str]) -> SupervisionResult 
     )
 
     if not data:
-        return None
+        raise ValueError("Received unexpected response from User Code CC setMany API")
 
     return SupervisionResult(data)
 

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -69,7 +69,7 @@ def _get_code_slots(node: Node, include_usercode: bool = False) -> list[CodeSlot
         except NotFoundError:
             return slots
 
-        code_slot = int(value.property_key)
+        code_slot = int(value.property_key)  # type: ignore[arg-type]
         in_use = (
             None
             if status_value.value is None
@@ -105,7 +105,7 @@ def get_usercode(node: Node, code_slot: int) -> CodeSlot:
     value = get_code_slot_value(node, code_slot, LOCK_USERCODE_PROPERTY)
     status_value = get_code_slot_value(node, code_slot, LOCK_USERCODE_STATUS_PROPERTY)
 
-    code_slot = int(value.property_key)
+    code_slot = int(value.property_key)  # type: ignore[arg-type]
     in_use = (
         None
         if status_value.value is None
@@ -151,7 +151,7 @@ async def set_usercode(
     return await node.async_set_value(value, usercode)
 
 
-async def set_usercodes(node: Node, codes: dict[int, str]) -> SetValueResult | None:
+async def set_usercodes(node: Node, codes: dict[int, str]) -> SupervisionResult | None:
     """Set the usercode to index X on the lock."""
     if any(len(str(usercode)) < 4 for usercode in codes.values()):
         raise ValueError("User codes must be at least 4 digits")
@@ -172,6 +172,7 @@ async def set_usercodes(node: Node, codes: dict[int, str]) -> SetValueResult | N
 
     if not data:
         return None
+
     return SupervisionResult(data)
 
 


### PR DESCRIPTION
Z-Wave JS allows applications to send locks a single command with multiple user codes to set. This PR adds a utility function so that we can create a corresponding service in Home Assistant