### PR TITLE
Fix message format for get/set raw config

### DIFF
--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -324,7 +324,7 @@ class Endpoint(EventBase):
 
         data = await self.async_send_command(
             "set_raw_config_parameter_value",
-            options={k: v for k, v in options.items() if v is not None},
+            **options,
             require_schema=33,
         )
 
@@ -353,7 +353,7 @@ class Endpoint(EventBase):
 
         result = await self.async_send_command(
             "get_raw_config_parameter_value",
-            options={k: v for k, v in options.items() if v is not None},
+            **options,
             require_schema=39,
             wait_for_result=True,
         )


### PR DESCRIPTION
Format issue discovered by @AlCalzone https://github.com/zwave-js/certification-backlog/issues/31#issuecomment-2470432220
I am confused as to how `async_set_raw_config_parameter_value` worked before but maybe it didn't 🤷‍♂️ 