### PR TITLE
Support `controller.cancel_secure_bootstrap_s2`

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -240,7 +240,7 @@ def version_data_fixture():
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 39,
+        "maxSchemaVersion": 40,
     }
 
 

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -796,6 +796,21 @@ async def test_stop_inclusion(controller, uuid4, mock_command):
     }
 
 
+async def test_cancel_secure_bootstrap_s2(controller, uuid4, mock_command):
+    """Test cancel secure bootstrap S2."""
+    ack_commands = mock_command(
+        {"command": "controller.cancel_secure_bootstrap_s2"},
+        {},
+    )
+    assert await controller.async_cancel_secure_bootstrap_s2() is None
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.cancel_secure_bootstrap_s2",
+        "messageId": uuid4,
+    }
+
+
 async def test_begin_exclusion(controller, uuid4, mock_command):
     """Test begin exclusion."""
     ack_commands = mock_command(

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -461,7 +461,7 @@ async def test_additional_user_agent_components(client_session, url):
             {
                 "command": "initialize",
                 "messageId": "initialize",
-                "schemaVersion": 39,
+                "schemaVersion": 40,
                 "additionalUserAgentComponents": {
                     "zwave-js-server-python": __version__,
                     "foo": "bar",

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -106,7 +106,7 @@ async def test_dump_additional_user_agent_components(
         {
             "command": "initialize",
             "messageId": "initialize",
-            "schemaVersion": 39,
+            "schemaVersion": 40,
             "additionalUserAgentComponents": {
                 "zwave-js-server-python": __version__,
                 "foo": "bar",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -58,7 +58,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 39}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 40}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'initialize'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -13,7 +13,7 @@ __version__ = "0.59.1"
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 39
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 39
+MAX_SERVER_SCHEMA_VERSION = 40
 
 VALUE_UNKNOWN = "unknown"
 

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -410,6 +410,12 @@ class Controller(EventBase):
         )
         return cast(bool, data["success"])
 
+    async def async_cancel_secure_bootstrap_s2(self) -> None:
+        """Send cancelSecureBootstrapS2 command to Controller."""
+        await self.client.async_send_command(
+            {"command": "controller.cancel_secure_bootstrap_s2"}, require_schema=40
+        )
+
     async def async_begin_exclusion(
         self, strategy: ExclusionStrategy | None = None
     ) -> bool:


### PR DESCRIPTION
And bump schema to 40

https://github.com/zwave-js/certification-backlog/issues/34