### PR TITLE
Add method to update the controller's inclusion state

### DIFF
--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -261,6 +261,10 @@ class Controller(EventBase):
                 self.data["rebuildRoutesProgress"]
             )
 
+    def update_inclusion_state(self, state: InclusionState) -> None:
+        """Update inclusion state."""
+        self.data["inclusionState"] = state
+
     async def async_begin_inclusion(
         self,
         inclusion_strategy: Literal[


### PR DESCRIPTION
This is necessary to be able to handle the `inclusion state changed` event, which is currently being ignored by HA, leading to a discrepancy between the assumed and actual inclusion state.

I'm not sure if this is the right approach. Ideally I'd like a method to update any property, not just the inclusion state, so we don't have to add another when we need to selectively update a different property in the future.