### PR TITLE
Add function to backup/restore NVM in base64 format

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1780,6 +1780,37 @@ async def test_restore_nvm(controller, uuid4, mock_command):
     }
 
 
+async def test_backup_nvm_raw_base64(controller, uuid4, mock_command):
+    """Test backup NVM raw with base64 return."""
+    ack_commands = mock_command(
+        {"command": "controller.backup_nvm_raw"},
+        {"nvmData": "AAAAAAAAAAAAAA=="},
+    )
+    assert await controller.async_backup_nvm_raw_base64() == "AAAAAAAAAAAAAA=="
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.backup_nvm_raw",
+        "messageId": uuid4,
+    }
+
+
+async def test_restore_nvm_base64(controller, uuid4, mock_command):
+    """Test restore NVM with base64 input."""
+    ack_commands = mock_command(
+        {"command": "controller.restore_nvm"},
+        {},
+    )
+    await controller.async_restore_nvm_base64("AAAAAAAAAAAAAA==")
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.restore_nvm",
+        "nvmData": "AAAAAAAAAAAAAA==",
+        "messageId": uuid4,
+    }
+
+
 async def test_set_power_level(controller, uuid4, mock_command):
     """Test set powerlevel."""
     ack_commands = mock_command(

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -753,6 +753,23 @@ class Controller(EventBase):
             require_schema=14,
         )
 
+    async def async_backup_nvm_raw_base64(self) -> str:
+        """Send backupNVMRaw command to Controller and return base64 string directly."""
+        data = await self.client.async_send_command(
+            {"command": "controller.backup_nvm_raw"}, require_schema=14
+        )
+        return data["nvmData"]
+
+    async def async_restore_nvm_base64(self, base64_data: str) -> None:
+        """Send restoreNVM command to Controller with base64 data directly."""
+        await self.client.async_send_command(
+            {
+                "command": "controller.restore_nvm",
+                "nvmData": base64_data,
+            },
+            require_schema=14,
+        )
+
     async def async_get_power_level(self) -> dict[str, int]:
         """Send getPowerlevel command to Controller."""
         data = await self.client.async_send_command(


### PR DESCRIPTION
This will allow us to send it to the frontend over the websocket without redundant encoding/decoding.
Was wondering whether to update the existing functions or add new ones 🤷‍♂️ 