### PR TITLE
Make disable_server_logging a callback

### DIFF
--- a/zwave_js_server/client.py
+++ b/zwave_js_server/client.py
@@ -419,14 +419,9 @@ class Client:
 
         await self.async_start_listening_logs()
 
-    async def disable_server_logging(self) -> None:
+    def disable_server_logging(self) -> None:
         """Disable logging from the server."""
-        if not self.connected or not self.driver:
-            raise InvalidState(
-                "Can't disable server logging when not connected to server"
-            )
         if not self._server_logging_enabled or not self._server_logger_unsubs:
-            LOGGER.info("Server logging is already disabled")
             return
 
         for unsub in self._server_logger_unsubs:


### PR DESCRIPTION
- The `Client.disable_server_logging` method doesn't need to be a coroutine function since it doesn't do any I/O or blocking calls. The client doesn't need to be connected to call this method.
- Update affected test and add type annotations for it and used fixtures.