### PR TITLE
Use PEP 639 license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,7 @@ authors = [{ name = "Home Assistant Team", email = "hello@home-assistant.io" }]
 description = "Python wrapper for zwave-js-server"
 readme = "README.md"
 requires-python = ">=3.12"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 keywords = ["home", "automation", "zwave", "zwave-js"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Followup to https://github.com/home-assistant-libs/zwave-js-server-python/pull/1029

With v77 setuptools added full support for PEP 639 license expression. With that it's now possible to use `project.license` directly which will map to `License-Expression` in the project metadata.