### PR TITLE
Add migrateOptions to nvm restore methods

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1769,13 +1769,24 @@ async def test_restore_nvm(controller, uuid4, mock_command):
         {"command": "controller.restore_nvm"},
         {},
     )
-    await controller.async_restore_nvm(bytes(10))
+    await controller.async_restore_nvm(bytes(10), {})
 
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.restore_nvm",
         "nvmData": "AAAAAAAAAAAAAA==",
         "messageId": uuid4,
+        "migrateOptions": {},
+    }
+
+    await controller.async_restore_nvm(bytes(10), {"preserveRoutes": False})
+
+    assert len(ack_commands) == 2
+    assert ack_commands[1] == {
+        "command": "controller.restore_nvm",
+        "nvmData": "AAAAAAAAAAAAAA==",
+        "messageId": uuid4,
+        "migrateOptions": {"preserveRoutes": False},
     }
 
 
@@ -1807,6 +1818,7 @@ async def test_restore_nvm_base64(controller, uuid4, mock_command):
         "command": "controller.restore_nvm",
         "nvmData": "AAAAAAAAAAAAAA==",
         "messageId": uuid4,
+        "migrateOptions": {},
     }
 
 

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -736,12 +736,13 @@ class Controller(EventBase):
         )
         return convert_base64_to_bytes(data["nvmData"])
 
-    async def async_restore_nvm(self, file: bytes) -> None:
+    async def async_restore_nvm(self, file: bytes, options: dict[str, bool] = {}) -> None:
         """Send restoreNVM command to Controller."""
         await self.client.async_send_command(
             {
                 "command": "controller.restore_nvm",
                 "nvmData": convert_bytes_to_base64(file),
+                "migrateOptions": options,
             },
             require_schema=14,
         )
@@ -753,12 +754,13 @@ class Controller(EventBase):
         )
         return data["nvmData"]
 
-    async def async_restore_nvm_base64(self, base64_data: str) -> None:
+    async def async_restore_nvm_base64(self, base64_data: str, options: dict[str, bool] = {}) -> None:
         """Send restoreNVM command to Controller with base64 data directly."""
         await self.client.async_send_command(
             {
                 "command": "controller.restore_nvm",
                 "nvmData": base64_data,
+                "migrateOptions": options,
             },
             require_schema=14,
         )

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -744,7 +744,7 @@ class Controller(EventBase):
                 "nvmData": convert_bytes_to_base64(file),
                 "migrateOptions": options,
             },
-            require_schema=14,
+            require_schema=42,
         )
 
     async def async_backup_nvm_raw_base64(self) -> str:
@@ -762,7 +762,7 @@ class Controller(EventBase):
                 "nvmData": base64_data,
                 "migrateOptions": options,
             },
-            require_schema=14,
+            require_schema=42,
         )
 
     async def async_get_power_level(self) -> dict[str, int]:

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -736,13 +736,15 @@ class Controller(EventBase):
         )
         return convert_base64_to_bytes(data["nvmData"])
 
-    async def async_restore_nvm(self, file: bytes, options: dict[str, bool] = {}) -> None:
+    async def async_restore_nvm(
+        self, file: bytes, options: dict[str, bool] | None = None
+    ) -> None:
         """Send restoreNVM command to Controller."""
         await self.client.async_send_command(
             {
                 "command": "controller.restore_nvm",
                 "nvmData": convert_bytes_to_base64(file),
-                "migrateOptions": options,
+                "migrateOptions": {} if options is None else options,
             },
             require_schema=42,
         )
@@ -754,13 +756,15 @@ class Controller(EventBase):
         )
         return data["nvmData"]
 
-    async def async_restore_nvm_base64(self, base64_data: str, options: dict[str, bool] = {}) -> None:
+    async def async_restore_nvm_base64(
+        self, base64_data: str, options: dict[str, bool] | None = None
+    ) -> None:
         """Send restoreNVM command to Controller with base64 data directly."""
         await self.client.async_send_command(
             {
                 "command": "controller.restore_nvm",
                 "nvmData": base64_data,
-                "migrateOptions": options,
+                "migrateOptions": {} if options is None else options,
             },
             require_schema=42,
         )


### PR DESCRIPTION
For https://github.com/zwave-js/backlog/issues/88

Wasn't sure if I should increase the require_schema. The options were added in 42 but the command would work in earlier versions. The options would just be ignored.