### PR TITLE
Wait for node command completion when node is dead

### DIFF
--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -505,7 +505,6 @@ class Node(EventBase):
             return result
         if wait_for_result is None and self.status not in (
             NodeStatus.ASLEEP,
-            NodeStatus.DEAD,
         ):
             result_task = asyncio.create_task(
                 self.client.async_send_command(message, **kwargs)


### PR DESCRIPTION
When https://github.com/home-assistant/core/pull/148611 gets merged, we should also keep track of the command execution when a node is currently considered dead - it might not actually be. With this change, we return the command result instead of `None` in that case.