### PR TITLE
Add driver firmware v15 commands

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -246,7 +246,7 @@ def version_data_fixture() -> dict[str, Any]:
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 43,
+        "maxSchemaVersion": 44,
     }
 
 

--- a/test/model/common.py
+++ b/test/model/common.py
@@ -1,17 +1,21 @@
 """Provide common tools for testing Z-Wave JS server models."""
 
-FIRMWARE_UPDATE_INFO = {
-    "version": "1.0.0",
-    "changelog": "changelog",
-    "channel": "stable",
-    "files": [{"target": 0, "url": "http://example.com", "integrity": "test"}],
-    "downgrade": True,
-    "normalizedVersion": "1.0.0",
-    "device": {
-        "manufacturerId": 1,
-        "productType": 2,
-        "productId": 3,
-        "firmwareVersion": "0.4.4",
-        "rfRegion": 1,
-    },
-}
+from zwave_js_server.model.firmware import FirmwareUpdateInfoDataType
+
+FIRMWARE_UPDATE_INFO = FirmwareUpdateInfoDataType(
+    **{
+        "version": "1.0.0",
+        "changelog": "changelog",
+        "channel": "stable",
+        "files": [{"target": 0, "url": "http://example.com", "integrity": "test"}],
+        "downgrade": True,
+        "normalizedVersion": "1.0.0",
+        "device": {
+            "manufacturerId": 1,
+            "productType": 2,
+            "productId": 3,
+            "firmwareVersion": "0.4.4",
+            "rfRegion": 1,
+        },
+    }
+)

--- a/test/model/common.py
+++ b/test/model/common.py
@@ -1,0 +1,17 @@
+"""Provide common tools for testing Z-Wave JS server models."""
+
+FIRMWARE_UPDATE_INFO = {
+    "version": "1.0.0",
+    "changelog": "changelog",
+    "channel": "stable",
+    "files": [{"target": 0, "url": "http://example.com", "integrity": "test"}],
+    "downgrade": True,
+    "normalizedVersion": "1.0.0",
+    "device": {
+        "manufacturerId": 1,
+        "productType": 2,
+        "productId": 3,
+        "firmwareVersion": "0.4.4",
+        "rfRegion": 1,
+    },
+}

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -37,22 +37,7 @@ from zwave_js_server.model.node import Node
 from zwave_js_server.model.node.firmware import NodeFirmwareUpdateInfo
 
 from .. import load_fixture
-
-FIRMWARE_UPDATE_INFO = {
-    "version": "1.0.0",
-    "changelog": "changelog",
-    "channel": "stable",
-    "files": [{"target": 0, "url": "http://example.com", "integrity": "test"}],
-    "downgrade": True,
-    "normalizedVersion": "1.0.0",
-    "device": {
-        "manufacturerId": 1,
-        "productType": 2,
-        "productId": 3,
-        "firmwareVersion": "0.4.4",
-        "rfRegion": 1,
-    },
-}
+from .common import FIRMWARE_UPDATE_INFO
 
 
 def test_from_state():

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -2172,21 +2172,6 @@ async def test_get_known_lifeline_routes_rssi_error(
     }
 
 
-async def test_is_firmware_update_in_progress(controller, uuid4, mock_command):
-    """Test is_firmware_update_in_progress command."""
-    ack_commands = mock_command(
-        {"command": "controller.is_firmware_update_in_progress"},
-        {"progress": True},
-    )
-    assert await controller.async_is_firmware_update_in_progress()
-
-    assert len(ack_commands) == 1
-    assert ack_commands[0] == {
-        "command": "controller.is_firmware_update_in_progress",
-        "messageId": uuid4,
-    }
-
-
 async def test_nvm_events(controller):
     """Test NVM progress events."""
     event = Event(

--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -2157,6 +2157,21 @@ async def test_get_known_lifeline_routes_rssi_error(
     }
 
 
+async def test_is_firmware_update_in_progress(controller, uuid4, mock_command):
+    """Test is_firmware_update_in_progress command."""
+    ack_commands = mock_command(
+        {"command": "controller.is_firmware_update_in_progress"},
+        {"progress": True},
+    )
+    assert await controller.async_is_firmware_update_in_progress()
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "controller.is_firmware_update_in_progress",
+        "messageId": uuid4,
+    }
+
+
 async def test_nvm_events(controller):
     """Test NVM progress events."""
     event = Event(

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -463,7 +463,7 @@ async def test_additional_user_agent_components(client_session, url):
             {
                 "command": "initialize",
                 "messageId": "initialize",
-                "schemaVersion": 43,
+                "schemaVersion": 44,
                 "additionalUserAgentComponents": {
                     "zwave-js-server-python": __version__,
                     "foo": "bar",

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -106,7 +106,7 @@ async def test_dump_additional_user_agent_components(
         {
             "command": "initialize",
             "messageId": "initialize",
-            "schemaVersion": 43,
+            "schemaVersion": 44,
             "additionalUserAgentComponents": {
                 "zwave-js-server-python": __version__,
                 "foo": "bar",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -58,7 +58,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 43}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 44}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'initialize'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -11,9 +11,9 @@ PACKAGE_NAME = "zwave-js-server-python"
 __version__ = "0.66.0"
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 41
+MIN_SERVER_SCHEMA_VERSION = 44
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 43
+MAX_SERVER_SCHEMA_VERSION = 44
 
 VALUE_UNKNOWN = "unknown"
 

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -876,13 +876,6 @@ class Controller(EventBase):
         )
         return NodeFirmwareUpdateResult(node, data["result"])
 
-    async def async_is_firmware_update_in_progress(self) -> bool:
-        """Send isFirmwareUpdateInProgress command to Controller."""
-        data = await self.client.async_send_command(
-            {"command": "controller.is_firmware_update_in_progress"}, require_schema=26
-        )
-        return cast(bool, data["progress"])
-
     def receive_event(self, event: Event) -> None:
         """Receive an event."""
         if event.data["source"] == "node":

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -876,6 +876,13 @@ class Controller(EventBase):
         )
         return NodeFirmwareUpdateResult(node, data["result"])
 
+    async def async_is_firmware_update_in_progress(self) -> bool:
+        """Send isFirmwareUpdateInProgress command to Controller."""
+        data = await self.client.async_send_command(
+            {"command": "controller.is_firmware_update_in_progress"}, require_schema=26
+        )
+        return cast(bool, data["progress"])
+
     def receive_event(self, event: Event) -> None:
         """Receive an event."""
         if event.data["source"] == "node":

--- a/zwave_js_server/model/driver/__init__.py
+++ b/zwave_js_server/model/driver/__init__.py
@@ -242,6 +242,18 @@ class Driver(EventBase):
         )
         return cast(bool, result["success"])
 
+    async def async_firmware_update_otw(self) -> DriverFirmwareUpdateResult:
+        """Send firmwareUpdateOTW command to Driver."""
+        data = await self._async_send_command("firmware_update_otw", require_schema=41)
+        return DriverFirmwareUpdateResult(data["result"])
+
+    async def async_is_otw_firmware_update_in_progress(self) -> bool:
+        """Send isOTWFirmwareUpdateInProgress command to Driver."""
+        result = await self._async_send_command(
+            "is_otw_firmware_update_in_progress", require_schema=41
+        )
+        return cast(bool, result["progress"])
+
     async def async_set_preferred_scales(
         self, scales: dict[str | int, str | int]
     ) -> None:

--- a/zwave_js_server/model/driver/__init__.py
+++ b/zwave_js_server/model/driver/__init__.py
@@ -270,7 +270,7 @@ class Driver(EventBase):
         elif update_info is not None:
             params = {"updateInfo": update_info.to_dict()}
         data = await self._async_send_command(
-            "firmware_update_otw", require_schema=41, **params
+            "firmware_update_otw", require_schema=44, **params
         )
         return DriverFirmwareUpdateResult(data["result"])
 

--- a/zwave_js_server/model/driver/__init__.py
+++ b/zwave_js_server/model/driver/__init__.py
@@ -264,11 +264,11 @@ class Driver(EventBase):
             raise ValueError(
                 "Only one of update_data or update_info can be provided for firmware update."
             )
-        params: FirmwareUpdateDataDataType | FirmwareUpdateInfoDataType
+        params: FirmwareUpdateDataDataType | dict[str, FirmwareUpdateInfoDataType]
         if update_data is not None:
             params = update_data.to_dict()
         elif update_info is not None:
-            params = update_info.to_dict()
+            params = {"updateInfo": update_info.to_dict()}
         data = await self._async_send_command(
             "firmware_update_otw", require_schema=41, **params
         )


### PR DESCRIPTION
- Implement the changes in Z-Wave JS v15: https://zwave-js.github.io/zwave-js/#/getting-started/migrating/v15?id=moved-otw-firmware-update-functionality-from-controller-to-driver-class
- Bumped to schema version 44 to allow new signature of `async_firmware_update_otw`.