### PR TITLE
Add support for schema 47 driver commands (2/4)

### DIFF
--- a/test/model/test_driver.py
+++ b/test/model/test_driver.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from zwave_js_server.client import Client
-from zwave_js_server.const import LogLevel
+from zwave_js_server.const import CommandClass, LogLevel
 from zwave_js_server.event import Event
 from zwave_js_server.model import (
     log_config as log_config_pkg,
@@ -381,6 +381,143 @@ async def test_shutdown(driver, uuid4, mock_command):
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "driver.shutdown",
+        "messageId": uuid4,
+    }
+
+
+async def test_soft_reset_and_restart(
+    driver: Driver, uuid4: str, mock_command: MockCommandProtocol
+) -> None:
+    """Test soft reset and restart command."""
+    ack_commands = mock_command({"command": "driver.soft_reset_and_restart"}, {})
+    await driver.async_soft_reset_and_restart()
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "driver.soft_reset_and_restart",
+        "messageId": uuid4,
+    }
+
+
+async def test_enter_bootloader(
+    driver: Driver, uuid4: str, mock_command: MockCommandProtocol
+) -> None:
+    """Test enter bootloader command."""
+    ack_commands = mock_command({"command": "driver.enter_bootloader"}, {})
+    await driver.async_enter_bootloader()
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "driver.enter_bootloader",
+        "messageId": uuid4,
+    }
+
+
+async def test_leave_bootloader(
+    driver: Driver, uuid4: str, mock_command: MockCommandProtocol
+) -> None:
+    """Test leave bootloader command."""
+    ack_commands = mock_command({"command": "driver.leave_bootloader"}, {})
+    await driver.async_leave_bootloader()
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "driver.leave_bootloader",
+        "messageId": uuid4,
+    }
+
+
+async def test_get_supported_cc_version(
+    driver: Driver, uuid4: str, mock_command: MockCommandProtocol
+) -> None:
+    """Test get supported CC version command."""
+    ack_commands = mock_command(
+        {"command": "driver.get_supported_cc_version"}, {"version": 3}
+    )
+    result = await driver.async_get_supported_cc_version(
+        CommandClass.SWITCH_BINARY, node_id=52
+    )
+    assert result == 3
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "driver.get_supported_cc_version",
+        "messageId": uuid4,
+        "cc": CommandClass.SWITCH_BINARY.value,
+        "nodeId": 52,
+        "endpointIndex": 0,
+    }
+
+
+async def test_get_safe_cc_version(
+    driver: Driver, uuid4: str, mock_command: MockCommandProtocol
+) -> None:
+    """Test get safe CC version command."""
+    ack_commands = mock_command(
+        {"command": "driver.get_safe_cc_version"}, {"version": 2}
+    )
+    result = await driver.async_get_safe_cc_version(
+        CommandClass.SWITCH_BINARY, node_id=52, endpoint_index=1
+    )
+    assert result == 2
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "driver.get_safe_cc_version",
+        "messageId": uuid4,
+        "cc": CommandClass.SWITCH_BINARY.value,
+        "nodeId": 52,
+        "endpointIndex": 1,
+    }
+
+
+async def test_get_safe_cc_version_none(
+    driver: Driver, uuid4: str, mock_command: MockCommandProtocol
+) -> None:
+    """Test get safe CC version returns None when version is absent."""
+    mock_command({"command": "driver.get_safe_cc_version"}, {})
+    result = await driver.async_get_safe_cc_version(
+        CommandClass.SWITCH_BINARY, node_id=52
+    )
+    assert result is None
+
+
+async def test_update_user_agent(
+    driver: Driver, uuid4: str, mock_command: MockCommandProtocol
+) -> None:
+    """Test update user agent command."""
+    ack_commands = mock_command({"command": "driver.update_user_agent"}, {})
+    await driver.async_update_user_agent({"my-app": "1.0.0"})
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "driver.update_user_agent",
+        "messageId": uuid4,
+        "components": {"my-app": "1.0.0"},
+    }
+
+
+async def test_enable_frequent_rssi_monitoring(
+    driver: Driver, uuid4: str, mock_command: MockCommandProtocol
+) -> None:
+    """Test enable frequent RSSI monitoring command."""
+    ack_commands = mock_command(
+        {"command": "driver.enable_frequent_rssi_monitoring"}, {}
+    )
+    await driver.async_enable_frequent_rssi_monitoring(duration_ms=60000)
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "driver.enable_frequent_rssi_monitoring",
+        "messageId": uuid4,
+        "durationMs": 60000,
+    }
+
+
+async def test_disable_frequent_rssi_monitoring(
+    driver: Driver, uuid4: str, mock_command: MockCommandProtocol
+) -> None:
+    """Test disable frequent RSSI monitoring command."""
+    ack_commands = mock_command(
+        {"command": "driver.disable_frequent_rssi_monitoring"}, {}
+    )
+    await driver.async_disable_frequent_rssi_monitoring()
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "driver.disable_frequent_rssi_monitoring",
         "messageId": uuid4,
     }
 

--- a/test/model/test_driver.py
+++ b/test/model/test_driver.py
@@ -470,11 +470,19 @@ async def test_get_safe_cc_version_none(
     driver: Driver, uuid4: str, mock_command: MockCommandProtocol
 ) -> None:
     """Test get safe CC version returns None when version is absent."""
-    mock_command({"command": "driver.get_safe_cc_version"}, {})
+    ack_commands = mock_command({"command": "driver.get_safe_cc_version"}, {})
     result = await driver.async_get_safe_cc_version(
         CommandClass.SWITCH_BINARY, node_id=52
     )
     assert result is None
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "driver.get_safe_cc_version",
+        "messageId": uuid4,
+        "cc": CommandClass.SWITCH_BINARY.value,
+        "nodeId": 52,
+        "endpointIndex": 0,
+    }
 
 
 async def test_update_user_agent(

--- a/zwave_js_server/model/driver/__init__.py
+++ b/zwave_js_server/model/driver/__init__.py
@@ -12,6 +12,7 @@ from zwave_js_server.model.firmware import (
     FirmwareUpdateInfoDataType,
 )
 
+from ...const import CommandClass
 from ...event import BaseEventModel, Event, EventBase
 from ..config_manager import ConfigManager
 from ..controller import Controller
@@ -362,6 +363,64 @@ class Driver(EventBase):
         """Send command to shutdown controller."""
         data = await self._async_send_command("shutdown", require_schema=27)
         return cast(bool, data["success"])
+
+    async def async_soft_reset_and_restart(self) -> None:
+        """Send command to soft reset the controller and restart the driver."""
+        await self._async_send_command("soft_reset_and_restart", require_schema=47)
+
+    async def async_enter_bootloader(self) -> None:
+        """Send command to enter the bootloader."""
+        await self._async_send_command("enter_bootloader", require_schema=47)
+
+    async def async_leave_bootloader(self) -> None:
+        """Send command to leave the bootloader."""
+        await self._async_send_command("leave_bootloader", require_schema=47)
+
+    async def async_get_supported_cc_version(
+        self, cc: CommandClass, node_id: int, endpoint_index: int = 0
+    ) -> int:
+        """Get the version of a CC the given node/endpoint supports."""
+        data = await self._async_send_command(
+            "get_supported_cc_version",
+            require_schema=47,
+            cc=cc.value,
+            nodeId=node_id,
+            endpointIndex=endpoint_index,
+        )
+        return cast(int, data["version"])
+
+    async def async_get_safe_cc_version(
+        self, cc: CommandClass, node_id: int, endpoint_index: int = 0
+    ) -> int | None:
+        """Get the safe version of a CC the given node/endpoint supports."""
+        data = await self._async_send_command(
+            "get_safe_cc_version",
+            require_schema=47,
+            cc=cc.value,
+            nodeId=node_id,
+            endpointIndex=endpoint_index,
+        )
+        return data.get("version")
+
+    async def async_update_user_agent(self, components: dict[str, str | None]) -> None:
+        """Update the user agent components sent to the controller."""
+        await self._async_send_command(
+            "update_user_agent", require_schema=47, components=components
+        )
+
+    async def async_enable_frequent_rssi_monitoring(self, duration_ms: int) -> None:
+        """Enable frequent RSSI monitoring for the specified duration."""
+        await self._async_send_command(
+            "enable_frequent_rssi_monitoring",
+            require_schema=47,
+            durationMs=duration_ms,
+        )
+
+    async def async_disable_frequent_rssi_monitoring(self) -> None:
+        """Disable frequent RSSI monitoring."""
+        await self._async_send_command(
+            "disable_frequent_rssi_monitoring", require_schema=47
+        )
 
     def handle_logging(self, event: Event) -> None:
         """Process a driver logging event."""


### PR DESCRIPTION
## Summary

Second of four PRs adding schema 47 support, mirroring upstream zwave-js-server PR [#1510](https://github.com/zwave-js/zwave-js-server/pull/1510).

### New driver commands

| Command | Parameters | Returns | Description |
|---|---|---|---|
| `soft_reset_and_restart` | — | — | Soft reset the controller and restart the driver |
| `enter_bootloader` | — | — | Enter the bootloader |
| `leave_bootloader` | — | — | Leave the bootloader |
| `get_supported_cc_version` | `cc`, `node_id`, `endpoint_index` | `int` | Get the version of a CC supported by a node/endpoint |
| `get_safe_cc_version` | `cc`, `node_id`, `endpoint_index` | `int \| None` | Get the safe version of a CC (None if unknown) |
| `update_user_agent` | `components: dict[str, str \| None]` | — | Update user agent components |
| `enable_frequent_rssi_monitoring` | `duration_ms: int` | — | Enable frequent RSSI monitoring |
| `disable_frequent_rssi_monitoring` | — | — | Disable frequent RSSI monitoring |

### Not included

The firmware update change from upstream (automatic ZIP extraction via `parseAndExtractFirmware`) is **server-side only** — the Python lib already sends raw file bytes as base64 and the server handles extraction. No client code change needed.

## Stacking

⚠️ **Stacked on #1404** (schema 47 state/events 1/4). The diff currently includes changes from earlier PRs; once #1404 merges I will rebase.

## Test plan

- [x] `pytest -q` — 311/311 passing locally (+9 net new tests covering all 8 commands including the `get_safe_cc_version` None case)
- [x] black + ruff + pylint + mypy all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)