### PR TITLE
Add support for new credential management API, schema 48

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ except zwave_js_server.client.FailedCommand as err:
 Schema 48 adds typed access-control helpers exposed via the `AccessControlAPI`
 wrapper:
 
-- `node.access_control` — shortcut for the root endpoint API.
-- `endpoint.access_control` — API for a specific endpoint.
+- `node.access_control`: shortcut for the root endpoint API.
+- `endpoint.access_control`: API for a specific endpoint.
 - Call `await endpoint.access_control.async_is_supported()` before using other
   methods.
 - Credential payloads accept `str | bytes`; binary credentials are converted to

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ wrapper:
 
 - `node.access_control`: shortcut for the root endpoint API.
 - `endpoint.access_control`: API for a specific endpoint.
-- Call `await endpoint.access_control.async_is_supported()` before using other
+- Call `await endpoint.access_control.is_supported()` before using other
   methods.
 - Credential payloads accept `str | bytes`; binary credentials are converted to
   the websocket Buffer transport shape internally.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ try:
 except zwave_js_server.client.FailedCommand as err:
     print("Command failed with", err.error_code)
 ```
+
+## Access control
+
+Schema 48 adds typed access-control helpers exposed via the `AccessControlAPI`
+wrapper:
+
+- `node.access_control` — shortcut for the root endpoint API.
+- `endpoint.access_control` — API for a specific endpoint.
+- Call `await endpoint.access_control.async_is_supported()` before using other
+  methods.
+- Credential payloads accept `str | bytes`; binary credentials are converted to
+  the websocket Buffer transport shape internally.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -262,7 +262,7 @@ def version_data_fixture() -> dict[str, Any]:
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 47,
+        "maxSchemaVersion": 48,
     }
 
 

--- a/test/model/test_access_control.py
+++ b/test/model/test_access_control.py
@@ -52,11 +52,13 @@ def test_credential_capabilities_from_dict() -> None:
             },
             "supportsAdminCode": True,
             "supportsAdminCodeDeactivation": False,
+            "supportsCredentialAssignment": True,
         }
     )
 
     assert capabilities.supports_admin_code
     assert not capabilities.supports_admin_code_deactivation
+    assert capabilities.supports_credential_assignment
     assert UserCredentialType.PIN_CODE in capabilities.supported_credential_types
     pin_code = capabilities.supported_credential_types[UserCredentialType.PIN_CODE]
     assert pin_code.number_of_credential_slots == 2
@@ -119,6 +121,7 @@ async def test_access_control_support_and_capabilities(
                 },
                 "supportsAdminCode": True,
                 "supportsAdminCodeDeactivation": True,
+                "supportsCredentialAssignment": True,
             }
         },
     )
@@ -157,6 +160,7 @@ async def test_access_control_support_and_capabilities(
     )
     assert credential_capabilities.supports_admin_code
     assert credential_capabilities.supports_admin_code_deactivation
+    assert credential_capabilities.supports_credential_assignment
     assert (
         credential_capabilities.supported_credential_types[
             UserCredentialType.PIN_CODE

--- a/test/model/test_access_control.py
+++ b/test/model/test_access_control.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from zwave_js_server.const import SupervisionStatus
 from zwave_js_server.const.command_class.access_control import (
     AssignCredentialResult,
@@ -26,8 +24,11 @@ from zwave_js_server.model.access_control import (
     CredentialLearnProgressArgs,
     SetUserOptions,
     UserCapabilities,
+    UserCredentialCapability,
     UserData,
     UserDeletedArgs,
+    deserialize_credential_data,
+    serialize_credential_data,
 )
 from zwave_js_server.model.node import Node
 
@@ -126,10 +127,10 @@ async def test_access_control_support_and_capabilities(
         },
     )
 
-    assert await endpoint.access_control.async_is_supported()
-    user_capabilities = await node.access_control.async_get_user_capabilities_cached()
+    assert await endpoint.access_control.is_supported()
+    user_capabilities = await node.access_control.get_user_capabilities_cached()
     credential_capabilities = (
-        await node.access_control.async_get_credential_capabilities_cached()
+        await node.access_control.get_credential_capabilities_cached()
     )
 
     assert len(ack_commands) == 3
@@ -208,8 +209,8 @@ async def test_access_control_get_user_and_credential(
         },
     )
 
-    user = await node.access_control.async_get_user(3)
-    credential = await node.access_control.async_get_credential(
+    user = await node.access_control.get_user(3)
+    credential = await node.access_control.get_credential(
         UserCredentialType.PIN_CODE, 0
     )
 
@@ -245,109 +246,163 @@ async def test_access_control_get_user_and_credential(
     )
 
 
-@pytest.mark.parametrize(
-    ("command", "expected_payload", "call", "result_enum"),
-    [
-        (
-            "set_user",
-            {
-                "userId": 3,
-                "options": {
-                    "active": True,
-                    "userType": UserCredentialUserType.GENERAL,
-                    "userName": "Guest",
-                    "credentialRule": UserCredentialRule.SINGLE,
-                },
-            },
-            "set_user",
-            SetUserResult,
-        ),
-        (
-            "delete_user",
-            {"userId": 3},
-            "delete_user",
-            SetUserResult,
-        ),
-        (
-            "delete_all_users",
-            {},
-            "delete_all_users",
-            SetUserResult,
-        ),
-        (
-            "set_credential",
-            {
-                "userId": 3,
-                "credentialType": UserCredentialType.PIN_CODE,
-                "credentialSlot": 0,
-                "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
-            },
-            "set_credential",
-            SetCredentialResult,
-        ),
-        (
-            "delete_credential",
-            {
-                "userId": 3,
-                "credentialType": UserCredentialType.PIN_CODE,
-                "credentialSlot": 0,
-            },
-            "delete_credential",
-            SetCredentialResult,
-        ),
-    ],
-)
-async def test_access_control_set_commands(
-    lock_schlage_be469: Node,
-    mock_command: MockCommandProtocol,
-    uuid4: str,
-    command: str,
-    expected_payload: dict[str, Any],
-    call: str,
-    result_enum: type[SetUserResult] | type[SetCredentialResult],
+async def test_access_control_set_user(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
 ) -> None:
-    """Test access-control set/delete commands return result enum."""
-
+    """Test set_user returns SetUserResult."""
     node = lock_schlage_be469
     ack_commands = mock_command(
         {
-            "command": f"endpoint.access_control.{command}",
+            "command": "endpoint.access_control.set_user",
             "nodeId": node.node_id,
             "endpoint": 0,
         },
-        {"result": result_enum.OK},
+        {"result": SetUserResult.OK},
     )
 
-    if call == "set_user":
-        result = await node.access_control.async_set_user(
-            3,
-            SetUserOptions(
-                active=True,
-                user_type=UserCredentialUserType.GENERAL,
-                user_name="Guest",
-                credential_rule=UserCredentialRule.SINGLE,
-            ),
-        )
-    elif call == "delete_user":
-        result = await node.access_control.async_delete_user(3)
-    elif call == "delete_all_users":
-        result = await node.access_control.async_delete_all_users()
-    elif call == "set_credential":
-        result = await node.access_control.async_set_credential(
-            3, UserCredentialType.PIN_CODE, 0, b"1234"
-        )
-    else:
-        result = await node.access_control.async_delete_credential(
-            3, UserCredentialType.PIN_CODE, 0
-        )
+    result = await node.access_control.set_user(
+        3,
+        SetUserOptions(
+            active=True,
+            user_type=UserCredentialUserType.GENERAL,
+            user_name="Guest",
+            credential_rule=UserCredentialRule.SINGLE,
+        ),
+    )
 
-    assert result is result_enum.OK
+    assert result is SetUserResult.OK
     assert ack_commands == [
         {
-            "command": f"endpoint.access_control.{command}",
+            "command": "endpoint.access_control.set_user",
             "nodeId": node.node_id,
             "endpoint": 0,
-            **expected_payload,
+            "userId": 3,
+            "options": {
+                "active": True,
+                "userType": UserCredentialUserType.GENERAL,
+                "userName": "Guest",
+                "credentialRule": UserCredentialRule.SINGLE,
+            },
+            "messageId": uuid4,
+        }
+    ]
+
+
+async def test_access_control_delete_user(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test delete_user returns SetUserResult."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.delete_user",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"result": SetUserResult.OK},
+    )
+
+    result = await node.access_control.delete_user(3)
+
+    assert result is SetUserResult.OK
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.delete_user",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "userId": 3,
+            "messageId": uuid4,
+        }
+    ]
+
+
+async def test_access_control_delete_all_users(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test delete_all_users returns SetUserResult."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.delete_all_users",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"result": SetUserResult.OK},
+    )
+
+    result = await node.access_control.delete_all_users()
+
+    assert result is SetUserResult.OK
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.delete_all_users",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "messageId": uuid4,
+        }
+    ]
+
+
+async def test_access_control_set_credential(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test set_credential returns SetCredentialResult and wraps bytes payload."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.set_credential",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"result": SetCredentialResult.OK},
+    )
+
+    result = await node.access_control.set_credential(
+        3, UserCredentialType.PIN_CODE, 0, b"1234"
+    )
+
+    assert result is SetCredentialResult.OK
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.set_credential",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "userId": 3,
+            "credentialType": UserCredentialType.PIN_CODE,
+            "credentialSlot": 0,
+            "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
+            "messageId": uuid4,
+        }
+    ]
+
+
+async def test_access_control_delete_credential(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test delete_credential returns SetCredentialResult."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.delete_credential",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"result": SetCredentialResult.OK},
+    )
+
+    result = await node.access_control.delete_credential(
+        3, UserCredentialType.PIN_CODE, 0
+    )
+
+    assert result is SetCredentialResult.OK
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.delete_credential",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "userId": 3,
+            "credentialType": UserCredentialType.PIN_CODE,
+            "credentialSlot": 0,
             "messageId": uuid4,
         }
     ]
@@ -367,7 +422,7 @@ async def test_access_control_assign_credential(
         {"result": AssignCredentialResult.OK},
     )
 
-    result = await node.access_control.async_assign_credential(
+    result = await node.access_control.assign_credential(
         UserCredentialType.PIN_CODE, 1, 5
     )
 
@@ -385,68 +440,92 @@ async def test_access_control_assign_credential(
     ]
 
 
-@pytest.mark.parametrize(
-    ("command", "expected_payload", "call"),
-    [
-        (
-            "start_credential_learn",
-            {
-                "userId": 3,
-                "credentialType": UserCredentialType.PIN_CODE,
-                "credentialSlot": 0,
-                "timeout": 30,
-            },
-            "start_credential_learn",
-        ),
-        (
-            "cancel_credential_learn",
-            {},
-            "cancel_credential_learn",
-        ),
-        (
-            "set_admin_code",
-            {"code": "2468"},
-            "set_admin_code",
-        ),
-    ],
-)
-async def test_access_control_supervised_commands(
-    lock_schlage_be469: Node,
-    mock_command: MockCommandProtocol,
-    uuid4: str,
-    command: str,
-    expected_payload: dict[str, Any],
-    call: str,
+async def test_access_control_start_credential_learn(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
 ) -> None:
-    """Test access-control commands that still return supervision results."""
-
+    """Test start_credential_learn returns supervision result."""
     node = lock_schlage_be469
     ack_commands = mock_command(
         {
-            "command": f"endpoint.access_control.{command}",
+            "command": "endpoint.access_control.start_credential_learn",
             "nodeId": node.node_id,
             "endpoint": 0,
         },
         {"result": {"status": SupervisionStatus.SUCCESS}},
     )
 
-    if call == "start_credential_learn":
-        result = await node.access_control.async_start_credential_learn(
-            3, UserCredentialType.PIN_CODE, 0, 30
-        )
-    elif call == "cancel_credential_learn":
-        result = await node.access_control.async_cancel_credential_learn()
-    else:
-        result = await node.access_control.async_set_admin_code("2468")
+    result = await node.access_control.start_credential_learn(
+        3, UserCredentialType.PIN_CODE, 0, 30
+    )
 
     assert result is not None
     assert result.status is SupervisionStatus.SUCCESS
     assert ack_commands == [
         {
-            "command": f"endpoint.access_control.{command}",
+            "command": "endpoint.access_control.start_credential_learn",
             "nodeId": node.node_id,
             "endpoint": 0,
-            **expected_payload,
+            "userId": 3,
+            "credentialType": UserCredentialType.PIN_CODE,
+            "credentialSlot": 0,
+            "timeout": 30,
+            "messageId": uuid4,
+        }
+    ]
+
+
+async def test_access_control_cancel_credential_learn(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test cancel_credential_learn returns supervision result."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.cancel_credential_learn",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"result": {"status": SupervisionStatus.SUCCESS}},
+    )
+
+    result = await node.access_control.cancel_credential_learn()
+
+    assert result is not None
+    assert result.status is SupervisionStatus.SUCCESS
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.cancel_credential_learn",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "messageId": uuid4,
+        }
+    ]
+
+
+async def test_access_control_set_admin_code(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test set_admin_code returns supervision result."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.set_admin_code",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"result": {"status": SupervisionStatus.SUCCESS}},
+    )
+
+    result = await node.access_control.set_admin_code("2468")
+
+    assert result is not None
+    assert result.status is SupervisionStatus.SUCCESS
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.set_admin_code",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "code": "2468",
             "messageId": uuid4,
         }
     ]
@@ -467,7 +546,7 @@ async def test_access_control_get_admin_code(
         {"code": "2468"},
     )
 
-    assert await node.access_control.async_get_admin_code() == "2468"
+    assert await node.access_control.get_admin_code() == "2468"
     assert ack_commands == [
         {
             "command": "endpoint.access_control.get_admin_code",
@@ -478,102 +557,10 @@ async def test_access_control_get_admin_code(
     ]
 
 
-@pytest.mark.parametrize(
-    ("event_type", "args", "expected_type"),
-    [
-        (
-            "user added",
-            {
-                "userId": 3,
-                "active": True,
-                "userType": UserCredentialUserType.GENERAL,
-                "userName": "Guest",
-                "credentialRule": UserCredentialRule.SINGLE,
-            },
-            UserData,
-        ),
-        (
-            "user modified",
-            {
-                "userId": 3,
-                "active": False,
-                "userType": UserCredentialUserType.EXPIRING,
-                "userName": "Temp",
-                "credentialRule": UserCredentialRule.DUAL,
-                "expiringTimeoutMinutes": 30,
-            },
-            UserData,
-        ),
-        ("user deleted", {"userId": 3}, UserDeletedArgs),
-        (
-            "credential added",
-            {
-                "userId": 3,
-                "credentialType": UserCredentialType.PIN_CODE,
-                "credentialSlot": 0,
-                "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
-            },
-            CredentialChangedArgs,
-        ),
-        (
-            "credential modified",
-            {
-                "userId": 3,
-                "credentialType": UserCredentialType.PIN_CODE,
-                "credentialSlot": 0,
-                "data": "2468",
-            },
-            CredentialChangedArgs,
-        ),
-        (
-            "credential deleted",
-            {
-                "userId": 3,
-                "credentialType": UserCredentialType.PIN_CODE,
-                "credentialSlot": 0,
-            },
-            CredentialDeletedArgs,
-        ),
-        (
-            "credential learn progress",
-            {
-                "userId": 3,
-                "credentialType": UserCredentialType.PIN_CODE,
-                "credentialSlot": 0,
-                "stepsRemaining": 2,
-                "status": UserCredentialLearnStatus.STEP_RETRY,
-            },
-            CredentialLearnProgressArgs,
-        ),
-        (
-            "credential learn completed",
-            {
-                "userId": 3,
-                "credentialType": UserCredentialType.PIN_CODE,
-                "credentialSlot": 0,
-                "status": UserCredentialLearnStatus.SUCCESS,
-                "success": True,
-            },
-            CredentialLearnCompletedArgs,
-        ),
-    ],
-)
-def test_access_control_events(
-    lock_schlage_be469: Node,
-    event_type: str,
-    args: dict[str, Any],
-    expected_type: type[
-        UserData
-        | UserDeletedArgs
-        | CredentialChangedArgs
-        | CredentialDeletedArgs
-        | CredentialLearnProgressArgs
-        | CredentialLearnCompletedArgs
-    ],
-) -> None:
-    """Test schema 48 access-control node event normalization."""
-
-    node = lock_schlage_be469
+def _dispatch_access_control_event(
+    node: Node, event_type: str, args: dict[str, Any]
+) -> dict[str, Any]:
+    """Dispatch a schema-48 access-control event and return the observed payload."""
     observed: list[dict[str, Any]] = []
     node.on(event_type, observed.append)
 
@@ -595,30 +582,156 @@ def test_access_control_events(
     assert event_data["node"] is node
     assert event_data["endpoint"] is node.endpoints[0]
     assert event_data["endpointIndex"] == 0
-    parsed_args = event_data["args"]
-    assert isinstance(parsed_args, expected_type)
+    return event_data
 
-    if isinstance(parsed_args, UserData):
-        assert parsed_args.user_id == 3
-        assert isinstance(parsed_args.user_type, UserCredentialUserType)
-    elif isinstance(parsed_args, UserDeletedArgs):
-        assert parsed_args.user_id == 3
-    elif isinstance(parsed_args, CredentialChangedArgs):
-        assert parsed_args.user_id == 3
-        assert parsed_args.credential_type is UserCredentialType.PIN_CODE
-        if event_type == "credential added":
-            assert parsed_args.data == b"1234"
-        else:
-            assert parsed_args.data == "2468"
-    elif isinstance(parsed_args, CredentialDeletedArgs):
-        assert parsed_args.credential_slot == 0
-        assert parsed_args.credential_type is UserCredentialType.PIN_CODE
-    elif isinstance(parsed_args, CredentialLearnProgressArgs):
-        assert parsed_args.steps_remaining == 2
-        assert parsed_args.status is UserCredentialLearnStatus.STEP_RETRY
-    else:
-        assert parsed_args.success
-        assert parsed_args.status is UserCredentialLearnStatus.SUCCESS
+
+def test_access_control_user_added_event(lock_schlage_be469: Node) -> None:
+    """Test `user added` event normalization."""
+    event_data = _dispatch_access_control_event(
+        lock_schlage_be469,
+        "user added",
+        {
+            "userId": 3,
+            "active": True,
+            "userType": UserCredentialUserType.GENERAL,
+            "userName": "Guest",
+            "credentialRule": UserCredentialRule.SINGLE,
+        },
+    )
+    parsed = event_data["args"]
+    assert isinstance(parsed, UserData)
+    assert parsed.user_id == 3
+    assert parsed.user_type is UserCredentialUserType.GENERAL
+    assert parsed.user_name == "Guest"
+    assert parsed.credential_rule is UserCredentialRule.SINGLE
+
+
+def test_access_control_user_modified_event(lock_schlage_be469: Node) -> None:
+    """Test `user modified` event normalization."""
+    event_data = _dispatch_access_control_event(
+        lock_schlage_be469,
+        "user modified",
+        {
+            "userId": 3,
+            "active": False,
+            "userType": UserCredentialUserType.EXPIRING,
+            "userName": "Temp",
+            "credentialRule": UserCredentialRule.DUAL,
+            "expiringTimeoutMinutes": 30,
+        },
+    )
+    parsed = event_data["args"]
+    assert isinstance(parsed, UserData)
+    assert parsed.user_id == 3
+    assert parsed.user_type is UserCredentialUserType.EXPIRING
+    assert parsed.expiring_timeout_minutes == 30
+
+
+def test_access_control_user_deleted_event(lock_schlage_be469: Node) -> None:
+    """Test `user deleted` event normalization."""
+    event_data = _dispatch_access_control_event(
+        lock_schlage_be469, "user deleted", {"userId": 3}
+    )
+    parsed = event_data["args"]
+    assert isinstance(parsed, UserDeletedArgs)
+    assert parsed.user_id == 3
+
+
+def test_access_control_credential_added_event(lock_schlage_be469: Node) -> None:
+    """Test `credential added` event normalization with bytes payload."""
+    event_data = _dispatch_access_control_event(
+        lock_schlage_be469,
+        "credential added",
+        {
+            "userId": 3,
+            "credentialType": UserCredentialType.PIN_CODE,
+            "credentialSlot": 0,
+            "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
+        },
+    )
+    parsed = event_data["args"]
+    assert isinstance(parsed, CredentialChangedArgs)
+    assert parsed.user_id == 3
+    assert parsed.credential_type is UserCredentialType.PIN_CODE
+    assert parsed.data == b"1234"
+
+
+def test_access_control_credential_modified_event(lock_schlage_be469: Node) -> None:
+    """Test `credential modified` event normalization with str payload."""
+    event_data = _dispatch_access_control_event(
+        lock_schlage_be469,
+        "credential modified",
+        {
+            "userId": 3,
+            "credentialType": UserCredentialType.PIN_CODE,
+            "credentialSlot": 0,
+            "data": "2468",
+        },
+    )
+    parsed = event_data["args"]
+    assert isinstance(parsed, CredentialChangedArgs)
+    assert parsed.user_id == 3
+    assert parsed.credential_type is UserCredentialType.PIN_CODE
+    assert parsed.data == "2468"
+
+
+def test_access_control_credential_deleted_event(lock_schlage_be469: Node) -> None:
+    """Test `credential deleted` event normalization."""
+    event_data = _dispatch_access_control_event(
+        lock_schlage_be469,
+        "credential deleted",
+        {
+            "userId": 3,
+            "credentialType": UserCredentialType.PIN_CODE,
+            "credentialSlot": 0,
+        },
+    )
+    parsed = event_data["args"]
+    assert isinstance(parsed, CredentialDeletedArgs)
+    assert parsed.credential_slot == 0
+    assert parsed.credential_type is UserCredentialType.PIN_CODE
+
+
+def test_access_control_credential_learn_progress_event(
+    lock_schlage_be469: Node,
+) -> None:
+    """Test `credential learn progress` event normalization."""
+    event_data = _dispatch_access_control_event(
+        lock_schlage_be469,
+        "credential learn progress",
+        {
+            "userId": 3,
+            "credentialType": UserCredentialType.PIN_CODE,
+            "credentialSlot": 0,
+            "stepsRemaining": 2,
+            "status": UserCredentialLearnStatus.STEP_RETRY,
+        },
+    )
+    parsed = event_data["args"]
+    assert isinstance(parsed, CredentialLearnProgressArgs)
+    assert parsed.steps_remaining == 2
+    assert parsed.status is UserCredentialLearnStatus.STEP_RETRY
+
+
+def test_access_control_credential_learn_completed_event(
+    lock_schlage_be469: Node,
+) -> None:
+    """Test `credential learn completed` event normalization."""
+    event_data = _dispatch_access_control_event(
+        lock_schlage_be469,
+        "credential learn completed",
+        {
+            "userId": 3,
+            "credentialType": UserCredentialType.PIN_CODE,
+            "credentialSlot": 0,
+            "status": UserCredentialLearnStatus.SUCCESS,
+            "success": True,
+        },
+    )
+    parsed = event_data["args"]
+    assert isinstance(parsed, CredentialLearnCompletedArgs)
+    assert parsed.success
+    assert parsed.status is UserCredentialLearnStatus.SUCCESS
 
 
 async def test_access_control_list_commands(
@@ -720,34 +833,32 @@ async def test_access_control_list_commands(
         {"credentials": [credential_payload]},
     )
 
-    assert await node.access_control.async_get_users() == [
+    assert await node.access_control.get_users() == [UserData.from_dict(user_payload)]
+    assert await node.access_control.get_users_cached() == [
         UserData.from_dict(user_payload)
     ]
-    assert await node.access_control.async_get_users_cached() == [
-        UserData.from_dict(user_payload)
-    ]
-    assert await node.access_control.async_get_user_cached(1) == UserData.from_dict(
+    assert await node.access_control.get_user_cached(1) == UserData.from_dict(
         user_payload
     )
-    assert await node.access_control.async_get_credentials(1) == [
+    assert await node.access_control.get_credentials(1) == [
         CredentialData.from_dict(credential_payload)
     ]
-    assert await node.access_control.async_get_credentials_cached(1) == [
+    assert await node.access_control.get_credentials_cached(1) == [
         CredentialData.from_dict(credential_payload)
     ]
-    assert await node.access_control.async_get_credential_cached(
+    assert await node.access_control.get_credential_cached(
         UserCredentialType.PIN_CODE, 0
     ) == CredentialData.from_dict(credential_payload)
-    assert await node.access_control.async_get_credentials_by_type(
+    assert await node.access_control.get_credentials_by_type(
         UserCredentialType.PIN_CODE
     ) == [CredentialData.from_dict(credential_payload)]
-    assert await node.access_control.async_get_credentials_by_type_cached(
+    assert await node.access_control.get_credentials_by_type_cached(
         UserCredentialType.PIN_CODE
     ) == [CredentialData.from_dict(credential_payload)]
-    assert await node.access_control.async_get_all_credentials() == [
+    assert await node.access_control.get_all_credentials() == [
         CredentialData.from_dict(credential_payload)
     ]
-    assert await node.access_control.async_get_all_credentials_cached() == [
+    assert await node.access_control.get_all_credentials_cached() == [
         CredentialData.from_dict(credential_payload)
     ]
 
@@ -757,26 +868,28 @@ async def test_access_control_none_results(
 ) -> None:
     """Test that missing user/credential/admin-code responses return None."""
     node = lock_schlage_be469
-    mock_command(
-        {
-            "command": "endpoint.access_control.get_user",
-            "nodeId": node.node_id,
-            "endpoint": 0,
-        },
-        {},
-    )
-    mock_command(
-        {
-            "command": "endpoint.access_control.get_credential",
-            "nodeId": node.node_id,
-            "endpoint": 0,
-        },
-        {},
-    )
+    for command in (
+        "get_user",
+        "get_user_cached",
+        "get_credential",
+        "get_credential_cached",
+    ):
+        mock_command(
+            {
+                "command": f"endpoint.access_control.{command}",
+                "nodeId": node.node_id,
+                "endpoint": 0,
+            },
+            {},
+        )
 
-    assert await node.access_control.async_get_user(1) is None
+    assert await node.access_control.get_user(1) is None
+    assert await node.access_control.get_user_cached(1) is None
     assert (
-        await node.access_control.async_get_credential(UserCredentialType.PIN_CODE, 0)
+        await node.access_control.get_credential(UserCredentialType.PIN_CODE, 0) is None
+    )
+    assert (
+        await node.access_control.get_credential_cached(UserCredentialType.PIN_CODE, 0)
         is None
     )
 
@@ -795,7 +908,7 @@ async def test_access_control_set_credential_str_data(
         {"result": SetCredentialResult.OK},
     )
 
-    result = await node.access_control.async_set_credential(
+    result = await node.access_control.set_credential(
         3, UserCredentialType.PIN_CODE, 0, "1234"
     )
 
@@ -828,7 +941,7 @@ async def test_access_control_start_credential_learn_no_timeout(
         {"result": {"status": SupervisionStatus.SUCCESS}},
     )
 
-    result = await node.access_control.async_start_credential_learn(
+    result = await node.access_control.start_credential_learn(
         3, UserCredentialType.PIN_CODE, 0
     )
 
@@ -845,3 +958,249 @@ async def test_access_control_start_credential_learn_no_timeout(
             "messageId": uuid4,
         }
     ]
+
+
+def test_credential_data_serialize_helpers() -> None:
+    """Test (de)serialization helpers for credential payloads."""
+
+    assert deserialize_credential_data(None) is None
+    assert deserialize_credential_data("abcd") == "abcd"
+    assert deserialize_credential_data({"type": "Buffer", "data": [1, 2]}) == bytes(
+        [1, 2]
+    )
+    assert serialize_credential_data("abcd") == "abcd"
+    assert serialize_credential_data(b"\x01\x02") == {
+        "type": "Buffer",
+        "data": [1, 2],
+    }
+
+
+def test_user_credential_capability_round_trip() -> None:
+    """Test UserCredentialCapability round-trips via from_dict/to_dict."""
+
+    full_payload = {
+        "numberOfCredentialSlots": 5,
+        "minCredentialLength": 4,
+        "maxCredentialLength": 8,
+        "maxCredentialHashLength": 0,
+        "supportsCredentialLearn": True,
+        "credentialLearnRecommendedTimeout": 30,
+        "credentialLearnNumberOfSteps": 3,
+    }
+    minimal_payload = {
+        "numberOfCredentialSlots": 5,
+        "minCredentialLength": 4,
+        "maxCredentialLength": 8,
+        "maxCredentialHashLength": 0,
+        "supportsCredentialLearn": False,
+    }
+
+    assert UserCredentialCapability.from_dict(full_payload).to_dict() == full_payload
+    assert (
+        UserCredentialCapability.from_dict(minimal_payload).to_dict() == minimal_payload
+    )
+
+
+def test_credential_capabilities_to_dict() -> None:
+    """Test CredentialCapabilities serialization including nested capability."""
+
+    payload = {
+        "supportedCredentialTypes": {
+            str(UserCredentialType.PIN_CODE.value): {
+                "numberOfCredentialSlots": 2,
+                "minCredentialLength": 4,
+                "maxCredentialLength": 8,
+                "maxCredentialHashLength": 0,
+                "supportsCredentialLearn": True,
+                "credentialLearnRecommendedTimeout": 30,
+                "credentialLearnNumberOfSteps": 3,
+            }
+        },
+        "supportsAdminCode": True,
+        "supportsAdminCodeDeactivation": False,
+        "supportsCredentialAssignment": True,
+    }
+
+    assert CredentialCapabilities.from_dict(payload).to_dict() == payload
+
+
+def test_user_capabilities_to_dict() -> None:
+    """Test UserCapabilities serialization with and without optional fields."""
+
+    full_payload = {
+        "maxUsers": 25,
+        "supportedUserTypes": [
+            UserCredentialUserType.GENERAL,
+            UserCredentialUserType.EXPIRING,
+        ],
+        "maxUserNameLength": 10,
+        "supportedCredentialRules": [
+            UserCredentialRule.SINGLE,
+            UserCredentialRule.DUAL,
+        ],
+    }
+    minimal_payload = {
+        "maxUsers": 25,
+        "supportedUserTypes": [],
+        "supportedCredentialRules": [],
+    }
+
+    assert UserCapabilities.from_dict(full_payload).to_dict() == full_payload
+    assert UserCapabilities.from_dict(minimal_payload).to_dict() == minimal_payload
+
+
+def test_user_data_to_dict() -> None:
+    """Test UserData serialization with all and minimal fields."""
+
+    full_payload = {
+        "userId": 3,
+        "active": True,
+        "userType": UserCredentialUserType.EXPIRING,
+        "userName": "Temp",
+        "credentialRule": UserCredentialRule.DUAL,
+        "expiringTimeoutMinutes": 30,
+    }
+    minimal_payload = {
+        "userId": 7,
+        "active": False,
+        "userType": UserCredentialUserType.GENERAL,
+    }
+
+    assert UserData.from_dict(full_payload).to_dict() == full_payload
+    assert UserData.from_dict(minimal_payload).to_dict() == minimal_payload
+
+
+def test_set_user_options_to_dict_with_expiring_timeout() -> None:
+    """Test SetUserOptions serialization includes expiringTimeoutMinutes."""
+
+    options = SetUserOptions(
+        active=True,
+        user_type=UserCredentialUserType.EXPIRING,
+        user_name="Temp",
+        credential_rule=UserCredentialRule.DUAL,
+        expiring_timeout_minutes=15,
+    )
+
+    assert options.to_dict() == {
+        "active": True,
+        "userType": UserCredentialUserType.EXPIRING,
+        "userName": "Temp",
+        "credentialRule": UserCredentialRule.DUAL,
+        "expiringTimeoutMinutes": 15,
+    }
+
+
+def test_set_user_options_to_dict_empty() -> None:
+    """Test SetUserOptions serialization omits all unset fields."""
+
+    assert SetUserOptions().to_dict() == {}
+
+
+def test_set_user_options_to_dict_partial() -> None:
+    """Test SetUserOptions serialization omits fields left as None."""
+
+    options = SetUserOptions(
+        active=False,
+        user_name="Guest",
+    )
+
+    assert options.to_dict() == {
+        "active": False,
+        "userName": "Guest",
+    }
+
+
+def test_credential_data_to_dict() -> None:
+    """Test CredentialData serialization for bytes, str, and missing data."""
+
+    bytes_payload = {
+        "userId": 3,
+        "type": UserCredentialType.PIN_CODE,
+        "slot": 0,
+        "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
+    }
+    str_payload = {
+        "userId": 3,
+        "type": UserCredentialType.PIN_CODE,
+        "slot": 0,
+        "data": "1234",
+    }
+    no_data_payload = {
+        "userId": 3,
+        "type": UserCredentialType.PIN_CODE,
+        "slot": 0,
+    }
+
+    assert CredentialData.from_dict(bytes_payload).to_dict() == bytes_payload
+    assert CredentialData.from_dict(str_payload).to_dict() == str_payload
+    assert CredentialData.from_dict(no_data_payload).to_dict() == no_data_payload
+
+
+def test_user_deleted_args_to_dict() -> None:
+    """Test UserDeletedArgs round-trips via from_dict/to_dict."""
+
+    payload = {"userId": 3}
+    assert UserDeletedArgs.from_dict(payload).to_dict() == payload
+
+
+def test_credential_changed_args_to_dict() -> None:
+    """Test CredentialChangedArgs serialization for bytes, str, and missing data."""
+
+    bytes_payload = {
+        "userId": 3,
+        "credentialType": UserCredentialType.PIN_CODE,
+        "credentialSlot": 0,
+        "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
+    }
+    str_payload = {
+        "userId": 3,
+        "credentialType": UserCredentialType.PIN_CODE,
+        "credentialSlot": 0,
+        "data": "2468",
+    }
+    no_data_payload = {
+        "userId": 3,
+        "credentialType": UserCredentialType.PIN_CODE,
+        "credentialSlot": 0,
+    }
+
+    assert CredentialChangedArgs.from_dict(bytes_payload).to_dict() == bytes_payload
+    assert CredentialChangedArgs.from_dict(str_payload).to_dict() == str_payload
+    assert CredentialChangedArgs.from_dict(no_data_payload).to_dict() == no_data_payload
+
+
+def test_credential_deleted_args_to_dict() -> None:
+    """Test CredentialDeletedArgs round-trips via from_dict/to_dict."""
+
+    payload = {
+        "userId": 3,
+        "credentialType": UserCredentialType.PIN_CODE,
+        "credentialSlot": 0,
+    }
+    assert CredentialDeletedArgs.from_dict(payload).to_dict() == payload
+
+
+def test_credential_learn_progress_args_to_dict() -> None:
+    """Test CredentialLearnProgressArgs round-trips via from_dict/to_dict."""
+
+    payload = {
+        "userId": 3,
+        "credentialType": UserCredentialType.PIN_CODE,
+        "credentialSlot": 0,
+        "stepsRemaining": 2,
+        "status": UserCredentialLearnStatus.STEP_RETRY,
+    }
+    assert CredentialLearnProgressArgs.from_dict(payload).to_dict() == payload
+
+
+def test_credential_learn_completed_args_to_dict() -> None:
+    """Test CredentialLearnCompletedArgs round-trips via from_dict/to_dict."""
+
+    payload = {
+        "userId": 3,
+        "credentialType": UserCredentialType.PIN_CODE,
+        "credentialSlot": 0,
+        "status": UserCredentialLearnStatus.SUCCESS,
+        "success": True,
+    }
+    assert CredentialLearnCompletedArgs.from_dict(payload).to_dict() == payload

--- a/test/model/test_access_control.py
+++ b/test/model/test_access_control.py
@@ -209,9 +209,9 @@ async def test_access_control_get_user_and_credential(
         },
     )
 
-    user = await node.access_control.get_user(3)
+    user = await node.access_control.get_user(user_id=3)
     credential = await node.access_control.get_credential(
-        UserCredentialType.PIN_CODE, 0
+        credential_type=UserCredentialType.PIN_CODE, credential_slot=0
     )
 
     assert len(ack_commands) == 2
@@ -261,8 +261,8 @@ async def test_access_control_set_user(
     )
 
     result = await node.access_control.set_user(
-        3,
-        SetUserOptions(
+        user_id=3,
+        options=SetUserOptions(
             active=True,
             user_type=UserCredentialUserType.GENERAL,
             user_name="Guest",
@@ -302,7 +302,7 @@ async def test_access_control_delete_user(
         {"result": SetUserResult.OK},
     )
 
-    result = await node.access_control.delete_user(3)
+    result = await node.access_control.delete_user(user_id=3)
 
     assert result is SetUserResult.OK
     assert ack_commands == [
@@ -358,7 +358,10 @@ async def test_access_control_set_credential(
     )
 
     result = await node.access_control.set_credential(
-        3, UserCredentialType.PIN_CODE, 0, b"1234"
+        user_id=3,
+        credential_type=UserCredentialType.PIN_CODE,
+        credential_slot=0,
+        data=b"1234",
     )
 
     assert result is SetCredentialResult.OK
@@ -391,7 +394,9 @@ async def test_access_control_delete_credential(
     )
 
     result = await node.access_control.delete_credential(
-        3, UserCredentialType.PIN_CODE, 0
+        user_id=3,
+        credential_type=UserCredentialType.PIN_CODE,
+        credential_slot=0,
     )
 
     assert result is SetCredentialResult.OK
@@ -423,7 +428,9 @@ async def test_access_control_assign_credential(
     )
 
     result = await node.access_control.assign_credential(
-        UserCredentialType.PIN_CODE, 1, 5
+        credential_type=UserCredentialType.PIN_CODE,
+        credential_slot=1,
+        destination_user_id=5,
     )
 
     assert result is AssignCredentialResult.OK
@@ -455,7 +462,10 @@ async def test_access_control_start_credential_learn(
     )
 
     result = await node.access_control.start_credential_learn(
-        3, UserCredentialType.PIN_CODE, 0, 30
+        user_id=3,
+        credential_type=UserCredentialType.PIN_CODE,
+        credential_slot=0,
+        timeout=30,
     )
 
     assert result is not None
@@ -516,7 +526,7 @@ async def test_access_control_set_admin_code(
         {"result": {"status": SupervisionStatus.SUCCESS}},
     )
 
-    result = await node.access_control.set_admin_code("2468")
+    result = await node.access_control.set_admin_code(code="2468")
 
     assert result is not None
     assert result.status is SupervisionStatus.SUCCESS
@@ -837,23 +847,23 @@ async def test_access_control_list_commands(
     assert await node.access_control.get_users_cached() == [
         UserData.from_dict(user_payload)
     ]
-    assert await node.access_control.get_user_cached(1) == UserData.from_dict(
+    assert await node.access_control.get_user_cached(user_id=1) == UserData.from_dict(
         user_payload
     )
-    assert await node.access_control.get_credentials(1) == [
+    assert await node.access_control.get_credentials(user_id=1) == [
         CredentialData.from_dict(credential_payload)
     ]
-    assert await node.access_control.get_credentials_cached(1) == [
+    assert await node.access_control.get_credentials_cached(user_id=1) == [
         CredentialData.from_dict(credential_payload)
     ]
     assert await node.access_control.get_credential_cached(
-        UserCredentialType.PIN_CODE, 0
+        credential_type=UserCredentialType.PIN_CODE, credential_slot=0
     ) == CredentialData.from_dict(credential_payload)
     assert await node.access_control.get_credentials_by_type(
-        UserCredentialType.PIN_CODE
+        credential_type=UserCredentialType.PIN_CODE
     ) == [CredentialData.from_dict(credential_payload)]
     assert await node.access_control.get_credentials_by_type_cached(
-        UserCredentialType.PIN_CODE
+        credential_type=UserCredentialType.PIN_CODE
     ) == [CredentialData.from_dict(credential_payload)]
     assert await node.access_control.get_all_credentials() == [
         CredentialData.from_dict(credential_payload)
@@ -863,33 +873,80 @@ async def test_access_control_list_commands(
     ]
 
 
-async def test_access_control_none_results(
+async def test_access_control_get_user_none_result(
     lock_schlage_be469: Node, mock_command: MockCommandProtocol
 ) -> None:
-    """Test that missing user/credential/admin-code responses return None."""
+    """Test that a missing user response returns None."""
     node = lock_schlage_be469
-    for command in (
-        "get_user",
-        "get_user_cached",
-        "get_credential",
-        "get_credential_cached",
-    ):
-        mock_command(
-            {
-                "command": f"endpoint.access_control.{command}",
-                "nodeId": node.node_id,
-                "endpoint": 0,
-            },
-            {},
-        )
-
-    assert await node.access_control.get_user(1) is None
-    assert await node.access_control.get_user_cached(1) is None
-    assert (
-        await node.access_control.get_credential(UserCredentialType.PIN_CODE, 0) is None
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_user",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {},
     )
+
+    assert await node.access_control.get_user(user_id=1) is None
+
+
+async def test_access_control_get_user_cached_none_result(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol
+) -> None:
+    """Test that a missing cached user response returns None."""
+    node = lock_schlage_be469
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_user_cached",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {},
+    )
+
+    assert await node.access_control.get_user_cached(user_id=1) is None
+
+
+async def test_access_control_get_credential_none_result(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol
+) -> None:
+    """Test that a missing credential response returns None."""
+    node = lock_schlage_be469
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_credential",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {},
+    )
+
     assert (
-        await node.access_control.get_credential_cached(UserCredentialType.PIN_CODE, 0)
+        await node.access_control.get_credential(
+            credential_type=UserCredentialType.PIN_CODE, credential_slot=0
+        )
+        is None
+    )
+
+
+async def test_access_control_get_credential_cached_none_result(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol
+) -> None:
+    """Test that a missing cached credential response returns None."""
+    node = lock_schlage_be469
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_credential_cached",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {},
+    )
+
+    assert (
+        await node.access_control.get_credential_cached(
+            credential_type=UserCredentialType.PIN_CODE, credential_slot=0
+        )
         is None
     )
 
@@ -909,7 +966,10 @@ async def test_access_control_set_credential_str_data(
     )
 
     result = await node.access_control.set_credential(
-        3, UserCredentialType.PIN_CODE, 0, "1234"
+        user_id=3,
+        credential_type=UserCredentialType.PIN_CODE,
+        credential_slot=0,
+        data="1234",
     )
 
     assert result is SetCredentialResult.OK
@@ -942,7 +1002,9 @@ async def test_access_control_start_credential_learn_no_timeout(
     )
 
     result = await node.access_control.start_credential_learn(
-        3, UserCredentialType.PIN_CODE, 0
+        user_id=3,
+        credential_type=UserCredentialType.PIN_CODE,
+        credential_slot=0,
     )
 
     assert result is not None

--- a/test/model/test_access_control.py
+++ b/test/model/test_access_control.py
@@ -8,9 +8,9 @@ import pytest
 
 from zwave_js_server.const import SupervisionStatus
 from zwave_js_server.const.command_class.access_control import (
-    AssignCredentialStatus,
-    SetCredentialStatus,
-    SetUserStatus,
+    AssignCredentialResult,
+    SetCredentialResult,
+    SetUserResult,
     UserCredentialLearnStatus,
     UserCredentialRule,
     UserCredentialType,
@@ -242,7 +242,7 @@ async def test_access_control_get_user_and_credential(
 
 
 @pytest.mark.parametrize(
-    ("command", "expected_payload", "call", "status_enum"),
+    ("command", "expected_payload", "call", "result_enum"),
     [
         (
             "set_user",
@@ -256,19 +256,19 @@ async def test_access_control_get_user_and_credential(
                 },
             },
             "set_user",
-            SetUserStatus,
+            SetUserResult,
         ),
         (
             "delete_user",
             {"userId": 3},
             "delete_user",
-            SetUserStatus,
+            SetUserResult,
         ),
         (
             "delete_all_users",
             {},
             "delete_all_users",
-            SetUserStatus,
+            SetUserResult,
         ),
         (
             "set_credential",
@@ -279,7 +279,7 @@ async def test_access_control_get_user_and_credential(
                 "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
             },
             "set_credential",
-            SetCredentialStatus,
+            SetCredentialResult,
         ),
         (
             "delete_credential",
@@ -289,7 +289,7 @@ async def test_access_control_get_user_and_credential(
                 "credentialSlot": 0,
             },
             "delete_credential",
-            SetCredentialStatus,
+            SetCredentialResult,
         ),
     ],
 )
@@ -300,9 +300,9 @@ async def test_access_control_set_commands(
     command: str,
     expected_payload: dict[str, Any],
     call: str,
-    status_enum: type[SetUserStatus] | type[SetCredentialStatus],
+    result_enum: type[SetUserResult] | type[SetCredentialResult],
 ) -> None:
-    """Test access-control set/delete commands return status enum."""
+    """Test access-control set/delete commands return result enum."""
 
     node = lock_schlage_be469
     ack_commands = mock_command(
@@ -311,7 +311,7 @@ async def test_access_control_set_commands(
             "nodeId": node.node_id,
             "endpoint": 0,
         },
-        {"status": status_enum.OK},
+        {"result": result_enum.OK},
     )
 
     if call == "set_user":
@@ -337,7 +337,7 @@ async def test_access_control_set_commands(
             3, UserCredentialType.PIN_CODE, 0
         )
 
-    assert result is status_enum.OK
+    assert result is result_enum.OK
     assert ack_commands == [
         {
             "command": f"endpoint.access_control.{command}",
@@ -352,7 +352,7 @@ async def test_access_control_set_commands(
 async def test_access_control_assign_credential(
     lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
 ) -> None:
-    """Test assign_credential returns AssignCredentialStatus."""
+    """Test assign_credential returns AssignCredentialResult."""
     node = lock_schlage_be469
     ack_commands = mock_command(
         {
@@ -360,14 +360,14 @@ async def test_access_control_assign_credential(
             "nodeId": node.node_id,
             "endpoint": 0,
         },
-        {"status": AssignCredentialStatus.OK},
+        {"result": AssignCredentialResult.OK},
     )
 
     result = await node.access_control.async_assign_credential(
         UserCredentialType.PIN_CODE, 1, 5
     )
 
-    assert result is AssignCredentialStatus.OK
+    assert result is AssignCredentialResult.OK
     assert ack_commands == [
         {
             "command": "endpoint.access_control.assign_credential",
@@ -788,14 +788,14 @@ async def test_access_control_set_credential_str_data(
             "nodeId": node.node_id,
             "endpoint": 0,
         },
-        {"status": SetCredentialStatus.OK},
+        {"result": SetCredentialResult.OK},
     )
 
     result = await node.access_control.async_set_credential(
         3, UserCredentialType.PIN_CODE, 0, "1234"
     )
 
-    assert result is SetCredentialStatus.OK
+    assert result is SetCredentialResult.OK
     assert ack_commands == [
         {
             "command": "endpoint.access_control.set_credential",

--- a/test/model/test_access_control.py
+++ b/test/model/test_access_control.py
@@ -1,0 +1,723 @@
+"""Test access-control models and API wrappers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from zwave_js_server.const import SupervisionStatus
+from zwave_js_server.const.command_class.access_control import (
+    UserCredentialLearnStatus,
+    UserCredentialRule,
+    UserCredentialType,
+    UserCredentialUserType,
+)
+from zwave_js_server.event import Event
+from zwave_js_server.model.access_control import (
+    CredentialCapabilities,
+    CredentialChangedArgs,
+    CredentialData,
+    CredentialDeletedArgs,
+    CredentialLearnCompletedArgs,
+    CredentialLearnProgressArgs,
+    SetUserOptions,
+    UserCapabilities,
+    UserData,
+    UserDeletedArgs,
+)
+from zwave_js_server.model.node import Node
+
+from ..common import MockCommandProtocol
+
+
+def test_credential_capabilities_from_dict() -> None:
+    """Test credential capability map normalization."""
+
+    capabilities = CredentialCapabilities.from_dict(
+        {
+            "supportedCredentialTypes": {
+                str(UserCredentialType.PIN_CODE.value): {
+                    "numberOfCredentialSlots": 2,
+                    "minCredentialLength": 4,
+                    "maxCredentialLength": 8,
+                    "maxCredentialHashLength": 0,
+                    "supportsCredentialLearn": True,
+                    "credentialLearnRecommendedTimeout": 30,
+                    "credentialLearnNumberOfSteps": 3,
+                }
+            },
+            "supportsAdminCode": True,
+            "supportsAdminCodeDeactivation": False,
+        }
+    )
+
+    assert capabilities.supports_admin_code
+    assert not capabilities.supports_admin_code_deactivation
+    assert UserCredentialType.PIN_CODE in capabilities.supported_credential_types
+    pin_code = capabilities.supported_credential_types[UserCredentialType.PIN_CODE]
+    assert pin_code.number_of_credential_slots == 2
+    assert pin_code.supports_credential_learn
+    assert pin_code.credential_learn_number_of_steps == 3
+
+
+async def test_access_control_support_and_capabilities(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test support checks and cached capability commands."""
+
+    node = lock_schlage_be469
+    endpoint = node.endpoints[0]
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.is_supported",
+            "nodeId": node.node_id,
+            "endpoint": endpoint.index,
+        },
+        {"supported": True},
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_user_capabilities_cached",
+            "nodeId": node.node_id,
+            "endpoint": endpoint.index,
+        },
+        {
+            "capabilities": {
+                "maxUsers": 25,
+                "supportedUserTypes": [
+                    UserCredentialUserType.GENERAL,
+                    UserCredentialUserType.EXPIRING,
+                ],
+                "maxUserNameLength": 10,
+                "supportedCredentialRules": [
+                    UserCredentialRule.SINGLE,
+                    UserCredentialRule.DUAL,
+                ],
+            }
+        },
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_credential_capabilities_cached",
+            "nodeId": node.node_id,
+            "endpoint": endpoint.index,
+        },
+        {
+            "capabilities": {
+                "supportedCredentialTypes": {
+                    str(UserCredentialType.PIN_CODE.value): {
+                        "numberOfCredentialSlots": 5,
+                        "minCredentialLength": 4,
+                        "maxCredentialLength": 8,
+                        "maxCredentialHashLength": 0,
+                        "supportsCredentialLearn": False,
+                    }
+                },
+                "supportsAdminCode": True,
+                "supportsAdminCodeDeactivation": True,
+            }
+        },
+    )
+
+    assert await endpoint.access_control.async_is_supported()
+    user_capabilities = await node.access_control.async_get_user_capabilities_cached()
+    credential_capabilities = (
+        await node.access_control.async_get_credential_capabilities_cached()
+    )
+
+    assert len(ack_commands) == 3
+    assert ack_commands[0] == {
+        "command": "endpoint.access_control.is_supported",
+        "nodeId": node.node_id,
+        "endpoint": endpoint.index,
+        "messageId": uuid4,
+    }
+    assert ack_commands[1]["command"] == (
+        "endpoint.access_control.get_user_capabilities_cached"
+    )
+    assert ack_commands[2]["command"] == (
+        "endpoint.access_control.get_credential_capabilities_cached"
+    )
+
+    assert user_capabilities == UserCapabilities(
+        max_users=25,
+        supported_user_types=[
+            UserCredentialUserType.GENERAL,
+            UserCredentialUserType.EXPIRING,
+        ],
+        max_user_name_length=10,
+        supported_credential_rules=[
+            UserCredentialRule.SINGLE,
+            UserCredentialRule.DUAL,
+        ],
+    )
+    assert credential_capabilities.supports_admin_code
+    assert credential_capabilities.supports_admin_code_deactivation
+    assert (
+        credential_capabilities.supported_credential_types[
+            UserCredentialType.PIN_CODE
+        ].number_of_credential_slots
+        == 5
+    )
+
+
+async def test_access_control_get_user_and_credential(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test fetching access-control users and credentials through node proxies."""
+
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.get_user",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {
+            "user": {
+                "userId": 3,
+                "active": True,
+                "userType": UserCredentialUserType.EXPIRING,
+                "userName": "Guest",
+                "credentialRule": UserCredentialRule.DUAL,
+                "expiringTimeoutMinutes": 60,
+            }
+        },
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_credential",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {
+            "credential": {
+                "userId": 3,
+                "type": UserCredentialType.PIN_CODE,
+                "slot": 0,
+                "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
+            }
+        },
+    )
+
+    user = await node.access_control.async_get_user(3)
+    credential = await node.access_control.async_get_credential(
+        3, UserCredentialType.PIN_CODE, 0
+    )
+
+    assert len(ack_commands) == 2
+    assert ack_commands[0] == {
+        "command": "endpoint.access_control.get_user",
+        "nodeId": node.node_id,
+        "endpoint": 0,
+        "userId": 3,
+        "messageId": uuid4,
+    }
+    assert ack_commands[1] == {
+        "command": "endpoint.access_control.get_credential",
+        "nodeId": node.node_id,
+        "endpoint": 0,
+        "userId": 3,
+        "credentialType": UserCredentialType.PIN_CODE,
+        "credentialSlot": 0,
+        "messageId": uuid4,
+    }
+    assert user == UserData(
+        user_id=3,
+        active=True,
+        user_type=UserCredentialUserType.EXPIRING,
+        user_name="Guest",
+        credential_rule=UserCredentialRule.DUAL,
+        expiring_timeout_minutes=60,
+    )
+    assert credential == CredentialData(
+        user_id=3,
+        type=UserCredentialType.PIN_CODE,
+        slot=0,
+        data=b"1234",
+    )
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_payload", "call"),
+    [
+        (
+            "set_user",
+            {
+                "userId": 3,
+                "options": {
+                    "active": True,
+                    "userType": UserCredentialUserType.GENERAL,
+                    "userName": "Guest",
+                    "credentialRule": UserCredentialRule.SINGLE,
+                },
+            },
+            "set_user",
+        ),
+        (
+            "delete_user",
+            {"userId": 3},
+            "delete_user",
+        ),
+        (
+            "delete_all_users",
+            {},
+            "delete_all_users",
+        ),
+        (
+            "set_credential",
+            {
+                "userId": 3,
+                "credentialType": UserCredentialType.PIN_CODE,
+                "credentialSlot": 0,
+                "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
+            },
+            "set_credential",
+        ),
+        (
+            "delete_credential",
+            {
+                "userId": 3,
+                "credentialType": UserCredentialType.PIN_CODE,
+                "credentialSlot": 0,
+            },
+            "delete_credential",
+        ),
+        (
+            "start_credential_learn",
+            {
+                "userId": 3,
+                "credentialType": UserCredentialType.PIN_CODE,
+                "credentialSlot": 0,
+                "timeout": 30,
+            },
+            "start_credential_learn",
+        ),
+        (
+            "cancel_credential_learn",
+            {},
+            "cancel_credential_learn",
+        ),
+        (
+            "set_admin_code",
+            {"code": "2468"},
+            "set_admin_code",
+        ),
+    ],
+)
+async def test_access_control_mutation_commands(
+    lock_schlage_be469: Node,
+    mock_command: MockCommandProtocol,
+    uuid4: str,
+    command: str,
+    expected_payload: dict[str, Any],
+    call: str,
+) -> None:
+    """Test access-control mutation commands and supervision parsing."""
+
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": f"endpoint.access_control.{command}",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"result": {"status": SupervisionStatus.SUCCESS}},
+    )
+
+    if call == "set_user":
+        result = await node.access_control.async_set_user(
+            3,
+            SetUserOptions(
+                active=True,
+                user_type=UserCredentialUserType.GENERAL,
+                user_name="Guest",
+                credential_rule=UserCredentialRule.SINGLE,
+            ),
+        )
+    elif call == "delete_user":
+        result = await node.access_control.async_delete_user(3)
+    elif call == "delete_all_users":
+        result = await node.access_control.async_delete_all_users()
+    elif call == "set_credential":
+        result = await node.access_control.async_set_credential(
+            3, UserCredentialType.PIN_CODE, 0, b"1234"
+        )
+    elif call == "delete_credential":
+        result = await node.access_control.async_delete_credential(
+            3, UserCredentialType.PIN_CODE, 0
+        )
+    elif call == "start_credential_learn":
+        result = await node.access_control.async_start_credential_learn(
+            3, UserCredentialType.PIN_CODE, 0, 30
+        )
+    elif call == "cancel_credential_learn":
+        result = await node.access_control.async_cancel_credential_learn()
+    else:
+        result = await node.access_control.async_set_admin_code("2468")
+
+    assert result is not None
+    assert result.status is SupervisionStatus.SUCCESS
+    assert ack_commands == [
+        {
+            "command": f"endpoint.access_control.{command}",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            **expected_payload,
+            "messageId": uuid4,
+        }
+    ]
+
+
+async def test_access_control_get_admin_code(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test fetching access-control admin code."""
+
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.get_admin_code",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"code": "2468"},
+    )
+
+    assert await node.access_control.async_get_admin_code() == "2468"
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.get_admin_code",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "messageId": uuid4,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("event_type", "args", "expected_type"),
+    [
+        (
+            "user added",
+            {
+                "userId": 3,
+                "active": True,
+                "userType": UserCredentialUserType.GENERAL,
+                "userName": "Guest",
+                "credentialRule": UserCredentialRule.SINGLE,
+            },
+            UserData,
+        ),
+        (
+            "user modified",
+            {
+                "userId": 3,
+                "active": False,
+                "userType": UserCredentialUserType.EXPIRING,
+                "userName": "Temp",
+                "credentialRule": UserCredentialRule.DUAL,
+                "expiringTimeoutMinutes": 30,
+            },
+            UserData,
+        ),
+        ("user deleted", {"userId": 3}, UserDeletedArgs),
+        (
+            "credential added",
+            {
+                "userId": 3,
+                "credentialType": UserCredentialType.PIN_CODE,
+                "credentialSlot": 0,
+                "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
+            },
+            CredentialChangedArgs,
+        ),
+        (
+            "credential modified",
+            {
+                "userId": 3,
+                "credentialType": UserCredentialType.PIN_CODE,
+                "credentialSlot": 0,
+                "data": "2468",
+            },
+            CredentialChangedArgs,
+        ),
+        (
+            "credential deleted",
+            {
+                "userId": 3,
+                "credentialType": UserCredentialType.PIN_CODE,
+                "credentialSlot": 0,
+            },
+            CredentialDeletedArgs,
+        ),
+        (
+            "credential learn progress",
+            {
+                "userId": 3,
+                "credentialType": UserCredentialType.PIN_CODE,
+                "credentialSlot": 0,
+                "stepsRemaining": 2,
+                "status": UserCredentialLearnStatus.STEP_RETRY,
+            },
+            CredentialLearnProgressArgs,
+        ),
+        (
+            "credential learn completed",
+            {
+                "userId": 3,
+                "credentialType": UserCredentialType.PIN_CODE,
+                "credentialSlot": 0,
+                "status": UserCredentialLearnStatus.SUCCESS,
+                "success": True,
+            },
+            CredentialLearnCompletedArgs,
+        ),
+    ],
+)
+def test_access_control_events(
+    lock_schlage_be469: Node,
+    event_type: str,
+    args: dict[str, Any],
+    expected_type: type[
+        UserData
+        | UserDeletedArgs
+        | CredentialChangedArgs
+        | CredentialDeletedArgs
+        | CredentialLearnProgressArgs
+        | CredentialLearnCompletedArgs
+    ],
+) -> None:
+    """Test schema 48 access-control node event normalization."""
+
+    node = lock_schlage_be469
+    observed: list[dict[str, Any]] = []
+    node.on(event_type, observed.append)
+
+    node.receive_event(
+        Event(
+            event_type,
+            {
+                "source": "node",
+                "event": event_type,
+                "nodeId": node.node_id,
+                "endpointIndex": 0,
+                "args": args,
+            },
+        )
+    )
+
+    assert len(observed) == 1
+    event_data = observed[0]
+    assert event_data["node"] is node
+    assert event_data["endpoint"] is node.endpoints[0]
+    assert event_data["endpointIndex"] == 0
+    parsed_args = event_data["args"]
+    assert isinstance(parsed_args, expected_type)
+
+    if isinstance(parsed_args, UserData):
+        assert parsed_args.user_id == 3
+        assert isinstance(parsed_args.user_type, UserCredentialUserType)
+    elif isinstance(parsed_args, UserDeletedArgs):
+        assert parsed_args.user_id == 3
+    elif isinstance(parsed_args, CredentialChangedArgs):
+        assert parsed_args.user_id == 3
+        assert parsed_args.credential_type is UserCredentialType.PIN_CODE
+        if event_type == "credential added":
+            assert parsed_args.data == b"1234"
+        else:
+            assert parsed_args.data == "2468"
+    elif isinstance(parsed_args, CredentialDeletedArgs):
+        assert parsed_args.credential_slot == 0
+        assert parsed_args.credential_type is UserCredentialType.PIN_CODE
+    elif isinstance(parsed_args, CredentialLearnProgressArgs):
+        assert parsed_args.steps_remaining == 2
+        assert parsed_args.status is UserCredentialLearnStatus.STEP_RETRY
+    else:
+        assert parsed_args.success
+        assert parsed_args.status is UserCredentialLearnStatus.SUCCESS
+
+
+async def test_access_control_list_commands(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol
+) -> None:
+    """Test fetching lists of users and credentials (fresh and cached)."""
+    node = lock_schlage_be469
+    user_payload = {
+        "userId": 1,
+        "active": True,
+        "userType": UserCredentialUserType.GENERAL,
+        "userName": "Owner",
+        "credentialRule": UserCredentialRule.SINGLE,
+    }
+    credential_payload = {
+        "userId": 1,
+        "type": UserCredentialType.PIN_CODE,
+        "slot": 0,
+        "data": "1234",
+    }
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_users",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"users": [user_payload]},
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_users_cached",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"users": [user_payload]},
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_user_cached",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"user": user_payload},
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_credentials",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"credentials": [credential_payload]},
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_credentials_cached",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"credentials": [credential_payload]},
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_credential_cached",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"credential": credential_payload},
+    )
+
+    assert await node.access_control.async_get_users() == [
+        UserData.from_dict(user_payload)
+    ]
+    assert await node.access_control.async_get_users_cached() == [
+        UserData.from_dict(user_payload)
+    ]
+    assert await node.access_control.async_get_user_cached(1) == UserData.from_dict(
+        user_payload
+    )
+    assert await node.access_control.async_get_credentials(1) == [
+        CredentialData.from_dict(credential_payload)
+    ]
+    assert await node.access_control.async_get_credentials_cached(1) == [
+        CredentialData.from_dict(credential_payload)
+    ]
+    assert await node.access_control.async_get_credential_cached(
+        1, UserCredentialType.PIN_CODE, 0
+    ) == CredentialData.from_dict(credential_payload)
+
+
+async def test_access_control_none_results(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol
+) -> None:
+    """Test that missing user/credential/admin-code responses return None."""
+    node = lock_schlage_be469
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_user",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {},
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_credential",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {},
+    )
+
+    assert await node.access_control.async_get_user(1) is None
+    assert (
+        await node.access_control.async_get_credential(
+            1, UserCredentialType.PIN_CODE, 0
+        )
+        is None
+    )
+
+
+async def test_access_control_set_credential_str_data(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test that string credential payloads are sent without Buffer wrapping."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.set_credential",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"result": {"status": SupervisionStatus.SUCCESS}},
+    )
+
+    result = await node.access_control.async_set_credential(
+        3, UserCredentialType.PIN_CODE, 0, "1234"
+    )
+
+    assert result is not None
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.set_credential",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "userId": 3,
+            "credentialType": UserCredentialType.PIN_CODE,
+            "credentialSlot": 0,
+            "data": "1234",
+            "messageId": uuid4,
+        }
+    ]
+
+
+async def test_access_control_start_credential_learn_no_timeout(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test that start_credential_learn omits timeout when not provided."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.start_credential_learn",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"result": {"status": SupervisionStatus.SUCCESS}},
+    )
+
+    result = await node.access_control.async_start_credential_learn(
+        3, UserCredentialType.PIN_CODE, 0
+    )
+
+    assert result is not None
+    assert "timeout" not in ack_commands[0]
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.start_credential_learn",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "userId": 3,
+            "credentialType": UserCredentialType.PIN_CODE,
+            "credentialSlot": 0,
+            "messageId": uuid4,
+        }
+    ]

--- a/test/model/test_access_control.py
+++ b/test/model/test_access_control.py
@@ -8,6 +8,9 @@ import pytest
 
 from zwave_js_server.const import SupervisionStatus
 from zwave_js_server.const.command_class.access_control import (
+    AssignCredentialStatus,
+    SetCredentialStatus,
+    SetUserStatus,
     UserCredentialLearnStatus,
     UserCredentialRule,
     UserCredentialType,
@@ -203,7 +206,7 @@ async def test_access_control_get_user_and_credential(
 
     user = await node.access_control.async_get_user(3)
     credential = await node.access_control.async_get_credential(
-        3, UserCredentialType.PIN_CODE, 0
+        UserCredentialType.PIN_CODE, 0
     )
 
     assert len(ack_commands) == 2
@@ -218,7 +221,6 @@ async def test_access_control_get_user_and_credential(
         "command": "endpoint.access_control.get_credential",
         "nodeId": node.node_id,
         "endpoint": 0,
-        "userId": 3,
         "credentialType": UserCredentialType.PIN_CODE,
         "credentialSlot": 0,
         "messageId": uuid4,
@@ -240,7 +242,7 @@ async def test_access_control_get_user_and_credential(
 
 
 @pytest.mark.parametrize(
-    ("command", "expected_payload", "call"),
+    ("command", "expected_payload", "call", "status_enum"),
     [
         (
             "set_user",
@@ -254,16 +256,19 @@ async def test_access_control_get_user_and_credential(
                 },
             },
             "set_user",
+            SetUserStatus,
         ),
         (
             "delete_user",
             {"userId": 3},
             "delete_user",
+            SetUserStatus,
         ),
         (
             "delete_all_users",
             {},
             "delete_all_users",
+            SetUserStatus,
         ),
         (
             "set_credential",
@@ -274,6 +279,7 @@ async def test_access_control_get_user_and_credential(
                 "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
             },
             "set_credential",
+            SetCredentialStatus,
         ),
         (
             "delete_credential",
@@ -283,7 +289,101 @@ async def test_access_control_get_user_and_credential(
                 "credentialSlot": 0,
             },
             "delete_credential",
+            SetCredentialStatus,
         ),
+    ],
+)
+async def test_access_control_set_commands(
+    lock_schlage_be469: Node,
+    mock_command: MockCommandProtocol,
+    uuid4: str,
+    command: str,
+    expected_payload: dict[str, Any],
+    call: str,
+    status_enum: type[SetUserStatus] | type[SetCredentialStatus],
+) -> None:
+    """Test access-control set/delete commands return status enum."""
+
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": f"endpoint.access_control.{command}",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"status": status_enum.OK},
+    )
+
+    if call == "set_user":
+        result = await node.access_control.async_set_user(
+            3,
+            SetUserOptions(
+                active=True,
+                user_type=UserCredentialUserType.GENERAL,
+                user_name="Guest",
+                credential_rule=UserCredentialRule.SINGLE,
+            ),
+        )
+    elif call == "delete_user":
+        result = await node.access_control.async_delete_user(3)
+    elif call == "delete_all_users":
+        result = await node.access_control.async_delete_all_users()
+    elif call == "set_credential":
+        result = await node.access_control.async_set_credential(
+            3, UserCredentialType.PIN_CODE, 0, b"1234"
+        )
+    else:
+        result = await node.access_control.async_delete_credential(
+            3, UserCredentialType.PIN_CODE, 0
+        )
+
+    assert result is status_enum.OK
+    assert ack_commands == [
+        {
+            "command": f"endpoint.access_control.{command}",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            **expected_payload,
+            "messageId": uuid4,
+        }
+    ]
+
+
+async def test_access_control_assign_credential(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test assign_credential returns AssignCredentialStatus."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.assign_credential",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"status": AssignCredentialStatus.OK},
+    )
+
+    result = await node.access_control.async_assign_credential(
+        UserCredentialType.PIN_CODE, 1, 5
+    )
+
+    assert result is AssignCredentialStatus.OK
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.assign_credential",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "credentialType": UserCredentialType.PIN_CODE,
+            "credentialSlot": 1,
+            "destinationUserId": 5,
+            "messageId": uuid4,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_payload", "call"),
+    [
         (
             "start_credential_learn",
             {
@@ -306,7 +406,7 @@ async def test_access_control_get_user_and_credential(
         ),
     ],
 )
-async def test_access_control_mutation_commands(
+async def test_access_control_supervised_commands(
     lock_schlage_be469: Node,
     mock_command: MockCommandProtocol,
     uuid4: str,
@@ -314,7 +414,7 @@ async def test_access_control_mutation_commands(
     expected_payload: dict[str, Any],
     call: str,
 ) -> None:
-    """Test access-control mutation commands and supervision parsing."""
+    """Test access-control commands that still return supervision results."""
 
     node = lock_schlage_be469
     ack_commands = mock_command(
@@ -326,29 +426,7 @@ async def test_access_control_mutation_commands(
         {"result": {"status": SupervisionStatus.SUCCESS}},
     )
 
-    if call == "set_user":
-        result = await node.access_control.async_set_user(
-            3,
-            SetUserOptions(
-                active=True,
-                user_type=UserCredentialUserType.GENERAL,
-                user_name="Guest",
-                credential_rule=UserCredentialRule.SINGLE,
-            ),
-        )
-    elif call == "delete_user":
-        result = await node.access_control.async_delete_user(3)
-    elif call == "delete_all_users":
-        result = await node.access_control.async_delete_all_users()
-    elif call == "set_credential":
-        result = await node.access_control.async_set_credential(
-            3, UserCredentialType.PIN_CODE, 0, b"1234"
-        )
-    elif call == "delete_credential":
-        result = await node.access_control.async_delete_credential(
-            3, UserCredentialType.PIN_CODE, 0
-        )
-    elif call == "start_credential_learn":
+    if call == "start_credential_learn":
         result = await node.access_control.async_start_credential_learn(
             3, UserCredentialType.PIN_CODE, 0, 30
         )
@@ -605,6 +683,38 @@ async def test_access_control_list_commands(
         },
         {"credential": credential_payload},
     )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_credentials_by_type",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"credentials": [credential_payload]},
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_credentials_by_type_cached",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"credentials": [credential_payload]},
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_all_credentials",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"credentials": [credential_payload]},
+    )
+    mock_command(
+        {
+            "command": "endpoint.access_control.get_all_credentials_cached",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"credentials": [credential_payload]},
+    )
 
     assert await node.access_control.async_get_users() == [
         UserData.from_dict(user_payload)
@@ -622,8 +732,20 @@ async def test_access_control_list_commands(
         CredentialData.from_dict(credential_payload)
     ]
     assert await node.access_control.async_get_credential_cached(
-        1, UserCredentialType.PIN_CODE, 0
+        UserCredentialType.PIN_CODE, 0
     ) == CredentialData.from_dict(credential_payload)
+    assert await node.access_control.async_get_credentials_by_type(
+        UserCredentialType.PIN_CODE
+    ) == [CredentialData.from_dict(credential_payload)]
+    assert await node.access_control.async_get_credentials_by_type_cached(
+        UserCredentialType.PIN_CODE
+    ) == [CredentialData.from_dict(credential_payload)]
+    assert await node.access_control.async_get_all_credentials() == [
+        CredentialData.from_dict(credential_payload)
+    ]
+    assert await node.access_control.async_get_all_credentials_cached() == [
+        CredentialData.from_dict(credential_payload)
+    ]
 
 
 async def test_access_control_none_results(
@@ -650,9 +772,7 @@ async def test_access_control_none_results(
 
     assert await node.access_control.async_get_user(1) is None
     assert (
-        await node.access_control.async_get_credential(
-            1, UserCredentialType.PIN_CODE, 0
-        )
+        await node.access_control.async_get_credential(UserCredentialType.PIN_CODE, 0)
         is None
     )
 
@@ -668,14 +788,14 @@ async def test_access_control_set_credential_str_data(
             "nodeId": node.node_id,
             "endpoint": 0,
         },
-        {"result": {"status": SupervisionStatus.SUCCESS}},
+        {"status": SetCredentialStatus.OK},
     )
 
     result = await node.access_control.async_set_credential(
         3, UserCredentialType.PIN_CODE, 0, "1234"
     )
 
-    assert result is not None
+    assert result is SetCredentialStatus.OK
     assert ack_commands == [
         {
             "command": "endpoint.access_control.set_credential",

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -463,7 +463,7 @@ async def test_additional_user_agent_components(client_session, url):
             {
                 "command": "initialize",
                 "messageId": "initialize",
-                "schemaVersion": 47,
+                "schemaVersion": 48,
                 "additionalUserAgentComponents": {
                     "zwave-js-server-python": __version__,
                     "foo": "bar",

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -106,7 +106,7 @@ async def test_dump_additional_user_agent_components(
         {
             "command": "initialize",
             "messageId": "initialize",
-            "schemaVersion": 47,
+            "schemaVersion": 48,
             "additionalUserAgentComponents": {
                 "zwave-js-server-python": __version__,
                 "foo": "bar",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -58,7 +58,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 47}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 48}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'initialize'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -13,7 +13,7 @@ __version__ = "0.69.0"
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 47
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 47
+MAX_SERVER_SCHEMA_VERSION = 48
 
 VALUE_UNKNOWN = "unknown"
 

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -13,7 +13,7 @@ __version__ = "0.70.0"
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 47
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 47
+MAX_SERVER_SCHEMA_VERSION = 48
 
 VALUE_UNKNOWN = "unknown"
 

--- a/zwave_js_server/const/command_class/access_control.py
+++ b/zwave_js_server/const/command_class/access_control.py
@@ -56,8 +56,8 @@ class UserCredentialLearnStatus(IntEnum):
     INVALID_MODIFY_OPERATION_TYPE = 0xFF
 
 
-class SetUserStatus(IntEnum):
-    """Result status for set_user / delete_user / delete_all_users commands."""
+class SetUserResult(IntEnum):
+    """Result for set_user / delete_user / delete_all_users commands."""
 
     OK = 0
     ERROR_ADD_REJECTED_LOCATION_OCCUPIED = 1
@@ -65,8 +65,8 @@ class SetUserStatus(IntEnum):
     ERROR_UNKNOWN = 0xFF
 
 
-class SetCredentialStatus(IntEnum):
-    """Result status for set_credential / delete_credential commands."""
+class SetCredentialResult(IntEnum):
+    """Result for set_credential / delete_credential commands."""
 
     OK = 0
     ERROR_ADD_REJECTED_LOCATION_OCCUPIED = 1
@@ -78,8 +78,8 @@ class SetCredentialStatus(IntEnum):
     ERROR_UNKNOWN = 0xFF
 
 
-class AssignCredentialStatus(IntEnum):
-    """Result status for assign_credential commands."""
+class AssignCredentialResult(IntEnum):
+    """Result for assign_credential commands."""
 
     OK = 0
     ERROR_INVALID_CREDENTIAL = 1

--- a/zwave_js_server/const/command_class/access_control.py
+++ b/zwave_js_server/const/command_class/access_control.py
@@ -1,0 +1,56 @@
+"""Constants for access control related command classes."""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class UserCredentialType(IntEnum):
+    """Credential types supported by User Credential CC."""
+
+    NONE = 0x00
+    PIN_CODE = 0x01
+    PASSWORD = 0x02
+    RFID_CODE = 0x03
+    BLE = 0x04
+    NFC = 0x05
+    UWB = 0x06
+    EYE_BIOMETRIC = 0x07
+    FACE_BIOMETRIC = 0x08
+    FINGER_BIOMETRIC = 0x09
+    HAND_BIOMETRIC = 0x0A
+    UNSPECIFIED_BIOMETRIC = 0x0B
+    DESFIRE = 0x0C
+
+
+class UserCredentialUserType(IntEnum):
+    """User types supported by User Credential CC."""
+
+    GENERAL = 0x00
+    PROGRAMMING = 0x03
+    NON_ACCESS = 0x04
+    DURESS = 0x05
+    DISPOSABLE = 0x06
+    EXPIRING = 0x07
+    REMOTE_ONLY = 0x09
+
+
+class UserCredentialRule(IntEnum):
+    """Credential rules supported by User Credential CC."""
+
+    SINGLE = 0x01
+    DUAL = 0x02
+    TRIPLE = 0x03
+
+
+class UserCredentialLearnStatus(IntEnum):
+    """Credential learn statuses supported by User Credential CC."""
+
+    STARTED = 0x00
+    SUCCESS = 0x01
+    ALREADY_IN_PROGRESS = 0x02
+    ENDED_NOT_DUE_TO_TIMEOUT = 0x03
+    TIMEOUT = 0x04
+    STEP_RETRY = 0x05
+    INVALID_ADD_OPERATION_TYPE = 0xFE
+    INVALID_MODIFY_OPERATION_TYPE = 0xFF

--- a/zwave_js_server/const/command_class/access_control.py
+++ b/zwave_js_server/const/command_class/access_control.py
@@ -8,52 +8,52 @@ from enum import IntEnum
 class UserCredentialType(IntEnum):
     """Credential types supported by User Credential CC."""
 
-    NONE = 0x00
-    PIN_CODE = 0x01
-    PASSWORD = 0x02
-    RFID_CODE = 0x03
-    BLE = 0x04
-    NFC = 0x05
-    UWB = 0x06
-    EYE_BIOMETRIC = 0x07
-    FACE_BIOMETRIC = 0x08
-    FINGER_BIOMETRIC = 0x09
-    HAND_BIOMETRIC = 0x0A
-    UNSPECIFIED_BIOMETRIC = 0x0B
-    DESFIRE = 0x0C
+    NONE = 0
+    PIN_CODE = 1
+    PASSWORD = 2
+    RFID_CODE = 3
+    BLE = 4
+    NFC = 5
+    UWB = 6
+    EYE_BIOMETRIC = 7
+    FACE_BIOMETRIC = 8
+    FINGER_BIOMETRIC = 9
+    HAND_BIOMETRIC = 10
+    UNSPECIFIED_BIOMETRIC = 11
+    DESFIRE = 12
 
 
 class UserCredentialUserType(IntEnum):
     """User types supported by User Credential CC."""
 
-    GENERAL = 0x00
-    PROGRAMMING = 0x03
-    NON_ACCESS = 0x04
-    DURESS = 0x05
-    DISPOSABLE = 0x06
-    EXPIRING = 0x07
-    REMOTE_ONLY = 0x09
+    GENERAL = 0
+    PROGRAMMING = 3
+    NON_ACCESS = 4
+    DURESS = 5
+    DISPOSABLE = 6
+    EXPIRING = 7
+    REMOTE_ONLY = 9
 
 
 class UserCredentialRule(IntEnum):
     """Credential rules supported by User Credential CC."""
 
-    SINGLE = 0x01
-    DUAL = 0x02
-    TRIPLE = 0x03
+    SINGLE = 1
+    DUAL = 2
+    TRIPLE = 3
 
 
 class UserCredentialLearnStatus(IntEnum):
     """Credential learn statuses supported by User Credential CC."""
 
-    STARTED = 0x00
-    SUCCESS = 0x01
-    ALREADY_IN_PROGRESS = 0x02
-    ENDED_NOT_DUE_TO_TIMEOUT = 0x03
-    TIMEOUT = 0x04
-    STEP_RETRY = 0x05
-    INVALID_ADD_OPERATION_TYPE = 0xFE
-    INVALID_MODIFY_OPERATION_TYPE = 0xFF
+    STARTED = 0
+    SUCCESS = 1
+    ALREADY_IN_PROGRESS = 2
+    ENDED_NOT_DUE_TO_TIMEOUT = 3
+    TIMEOUT = 4
+    STEP_RETRY = 5
+    INVALID_ADD_OPERATION_TYPE = 254
+    INVALID_MODIFY_OPERATION_TYPE = 255
 
 
 class SetUserResult(IntEnum):
@@ -62,7 +62,7 @@ class SetUserResult(IntEnum):
     OK = 0
     ERROR_ADD_REJECTED_LOCATION_OCCUPIED = 1
     ERROR_MODIFY_REJECTED_LOCATION_EMPTY = 2
-    ERROR_UNKNOWN = 0xFF
+    ERROR_UNKNOWN = 255
 
 
 class SetCredentialResult(IntEnum):
@@ -75,7 +75,7 @@ class SetCredentialResult(IntEnum):
     ERROR_MANUFACTURER_SECURITY_RULES = 4
     ERROR_DUPLICATE_ADMIN_PIN_CODE = 5
     ERROR_WRONG_USER_UNIQUE_IDENTIFIER = 6
-    ERROR_UNKNOWN = 0xFF
+    ERROR_UNKNOWN = 255
 
 
 class AssignCredentialResult(IntEnum):
@@ -84,4 +84,4 @@ class AssignCredentialResult(IntEnum):
     OK = 0
     ERROR_INVALID_CREDENTIAL = 1
     ERROR_INVALID_USER = 2
-    ERROR_UNKNOWN = 0xFF
+    ERROR_UNKNOWN = 255

--- a/zwave_js_server/const/command_class/access_control.py
+++ b/zwave_js_server/const/command_class/access_control.py
@@ -54,3 +54,34 @@ class UserCredentialLearnStatus(IntEnum):
     STEP_RETRY = 0x05
     INVALID_ADD_OPERATION_TYPE = 0xFE
     INVALID_MODIFY_OPERATION_TYPE = 0xFF
+
+
+class SetUserStatus(IntEnum):
+    """Result status for set_user / delete_user / delete_all_users commands."""
+
+    OK = 0
+    ERROR_ADD_REJECTED_LOCATION_OCCUPIED = 1
+    ERROR_MODIFY_REJECTED_LOCATION_EMPTY = 2
+    ERROR_UNKNOWN = 0xFF
+
+
+class SetCredentialStatus(IntEnum):
+    """Result status for set_credential / delete_credential commands."""
+
+    OK = 0
+    ERROR_ADD_REJECTED_LOCATION_OCCUPIED = 1
+    ERROR_MODIFY_REJECTED_LOCATION_EMPTY = 2
+    ERROR_DUPLICATE_CREDENTIAL = 3
+    ERROR_MANUFACTURER_SECURITY_RULES = 4
+    ERROR_DUPLICATE_ADMIN_PIN_CODE = 5
+    ERROR_WRONG_USER_UNIQUE_IDENTIFIER = 6
+    ERROR_UNKNOWN = 0xFF
+
+
+class AssignCredentialStatus(IntEnum):
+    """Result status for assign_credential commands."""
+
+    OK = 0
+    ERROR_INVALID_CREDENTIAL = 1
+    ERROR_INVALID_USER = 2
+    ERROR_UNKNOWN = 0xFF

--- a/zwave_js_server/model/access_control.py
+++ b/zwave_js_server/model/access_control.py
@@ -528,7 +528,7 @@ class AccessControlAPI:
         """Initialize the API wrapper for the given endpoint."""
         self._endpoint = endpoint
 
-    async def async_is_supported(self) -> bool:
+    async def is_supported(self) -> bool:
         """Return whether the endpoint supports access-control methods."""
         result = await self._endpoint.async_send_command(
             "access_control.is_supported",
@@ -538,7 +538,7 @@ class AccessControlAPI:
         assert result
         return cast(bool, result["supported"])
 
-    async def async_get_user_capabilities_cached(self) -> UserCapabilities:
+    async def get_user_capabilities_cached(self) -> UserCapabilities:
         """Return cached user capabilities for access control."""
         result = await self._endpoint.async_send_command(
             "access_control.get_user_capabilities_cached",
@@ -550,7 +550,7 @@ class AccessControlAPI:
         assert capabilities is not None
         return UserCapabilities.from_dict(cast(UserCapabilitiesDataType, capabilities))
 
-    async def async_get_credential_capabilities_cached(
+    async def get_credential_capabilities_cached(
         self,
     ) -> CredentialCapabilities:
         """Return cached credential capabilities for access control."""
@@ -566,7 +566,7 @@ class AccessControlAPI:
             cast(CredentialCapabilitiesDataType, capabilities)
         )
 
-    async def async_get_user(self, user_id: int) -> UserData | None:
+    async def get_user(self, user_id: int) -> UserData | None:
         """Return fresh data for a single access-control user."""
         result = await self._endpoint.async_send_command(
             "access_control.get_user",
@@ -579,7 +579,7 @@ class AccessControlAPI:
             return None
         return UserData.from_dict(cast(UserDataDataType, user))
 
-    async def async_get_user_cached(self, user_id: int) -> UserData | None:
+    async def get_user_cached(self, user_id: int) -> UserData | None:
         """Return cached data for a single access-control user."""
         result = await self._endpoint.async_send_command(
             "access_control.get_user_cached",
@@ -592,7 +592,7 @@ class AccessControlAPI:
             return None
         return UserData.from_dict(cast(UserDataDataType, user))
 
-    async def async_get_users(self) -> list[UserData]:
+    async def get_users(self) -> list[UserData]:
         """Return fresh data for all configured access-control users."""
         result = await self._endpoint.async_send_command(
             "access_control.get_users",
@@ -604,7 +604,7 @@ class AccessControlAPI:
         assert users is not None
         return [UserData.from_dict(cast(UserDataDataType, user)) for user in users]
 
-    async def async_get_users_cached(self) -> list[UserData]:
+    async def get_users_cached(self) -> list[UserData]:
         """Return cached data for all configured access-control users."""
         result = await self._endpoint.async_send_command(
             "access_control.get_users_cached",
@@ -616,9 +616,7 @@ class AccessControlAPI:
         assert users is not None
         return [UserData.from_dict(cast(UserDataDataType, user)) for user in users]
 
-    async def async_set_user(
-        self, user_id: int, options: SetUserOptions
-    ) -> SetUserResult:
+    async def set_user(self, user_id: int, options: SetUserOptions) -> SetUserResult:
         """Create or update an access-control user."""
         result = await self._endpoint.async_send_command(
             "access_control.set_user",
@@ -630,7 +628,7 @@ class AccessControlAPI:
         assert result is not None
         return SetUserResult(result["result"])
 
-    async def async_delete_user(self, user_id: int) -> SetUserResult:
+    async def delete_user(self, user_id: int) -> SetUserResult:
         """Delete an access-control user."""
         result = await self._endpoint.async_send_command(
             "access_control.delete_user",
@@ -641,7 +639,7 @@ class AccessControlAPI:
         assert result is not None
         return SetUserResult(result["result"])
 
-    async def async_delete_all_users(self) -> SetUserResult:
+    async def delete_all_users(self) -> SetUserResult:
         """Delete all configured access-control users."""
         result = await self._endpoint.async_send_command(
             "access_control.delete_all_users",
@@ -651,7 +649,7 @@ class AccessControlAPI:
         assert result is not None
         return SetUserResult(result["result"])
 
-    async def async_get_credential(
+    async def get_credential(
         self,
         credential_type: UserCredentialType,
         credential_slot: int,
@@ -669,7 +667,7 @@ class AccessControlAPI:
             return None
         return CredentialData.from_dict(cast(CredentialDataDataType, credential))
 
-    async def async_get_credential_cached(
+    async def get_credential_cached(
         self,
         credential_type: UserCredentialType,
         credential_slot: int,
@@ -687,7 +685,7 @@ class AccessControlAPI:
             return None
         return CredentialData.from_dict(cast(CredentialDataDataType, credential))
 
-    async def async_get_credentials(self, user_id: int) -> list[CredentialData]:
+    async def get_credentials(self, user_id: int) -> list[CredentialData]:
         """Return fresh data for all credentials assigned to a user."""
         result = await self._endpoint.async_send_command(
             "access_control.get_credentials",
@@ -703,7 +701,7 @@ class AccessControlAPI:
             for credential in credentials
         ]
 
-    async def async_get_credentials_cached(self, user_id: int) -> list[CredentialData]:
+    async def get_credentials_cached(self, user_id: int) -> list[CredentialData]:
         """Return cached data for all credentials assigned to a user."""
         result = await self._endpoint.async_send_command(
             "access_control.get_credentials_cached",
@@ -719,7 +717,7 @@ class AccessControlAPI:
             for credential in credentials
         ]
 
-    async def async_get_credentials_by_type(
+    async def get_credentials_by_type(
         self, credential_type: UserCredentialType
     ) -> list[CredentialData]:
         """Return fresh data for all credentials of the given type."""
@@ -737,7 +735,7 @@ class AccessControlAPI:
             for credential in credentials
         ]
 
-    async def async_get_credentials_by_type_cached(
+    async def get_credentials_by_type_cached(
         self, credential_type: UserCredentialType
     ) -> list[CredentialData]:
         """Return cached data for all credentials of the given type."""
@@ -755,7 +753,7 @@ class AccessControlAPI:
             for credential in credentials
         ]
 
-    async def async_get_all_credentials(self) -> list[CredentialData]:
+    async def get_all_credentials(self) -> list[CredentialData]:
         """Return fresh data for all credentials regardless of type or user."""
         result = await self._endpoint.async_send_command(
             "access_control.get_all_credentials",
@@ -770,7 +768,7 @@ class AccessControlAPI:
             for credential in credentials
         ]
 
-    async def async_get_all_credentials_cached(self) -> list[CredentialData]:
+    async def get_all_credentials_cached(self) -> list[CredentialData]:
         """Return cached data for all credentials regardless of type or user."""
         result = await self._endpoint.async_send_command(
             "access_control.get_all_credentials_cached",
@@ -785,7 +783,7 @@ class AccessControlAPI:
             for credential in credentials
         ]
 
-    async def async_assign_credential(
+    async def assign_credential(
         self,
         credential_type: UserCredentialType,
         credential_slot: int,
@@ -803,7 +801,7 @@ class AccessControlAPI:
         assert result is not None
         return AssignCredentialResult(result["result"])
 
-    async def async_set_credential(
+    async def set_credential(
         self,
         user_id: int,
         credential_type: UserCredentialType,
@@ -823,7 +821,7 @@ class AccessControlAPI:
         assert result is not None
         return SetCredentialResult(result["result"])
 
-    async def async_delete_credential(
+    async def delete_credential(
         self,
         user_id: int,
         credential_type: UserCredentialType,
@@ -841,7 +839,7 @@ class AccessControlAPI:
         assert result is not None
         return SetCredentialResult(result["result"])
 
-    async def async_start_credential_learn(
+    async def start_credential_learn(
         self,
         user_id: int,
         credential_type: UserCredentialType,
@@ -863,7 +861,7 @@ class AccessControlAPI:
         )
         return parse_supervision_result(result)
 
-    async def async_cancel_credential_learn(self) -> SupervisionResult | None:
+    async def cancel_credential_learn(self) -> SupervisionResult | None:
         """Cancel any active credential learn operation."""
         result = await self._endpoint.async_send_command(
             "access_control.cancel_credential_learn",
@@ -872,7 +870,7 @@ class AccessControlAPI:
         )
         return parse_supervision_result(result)
 
-    async def async_get_admin_code(self) -> str | None:
+    async def get_admin_code(self) -> str | None:
         """Return the configured admin code for access control."""
         result = await self._endpoint.async_send_command(
             "access_control.get_admin_code",
@@ -882,7 +880,7 @@ class AccessControlAPI:
         assert result
         return cast(str | None, result.get("code"))
 
-    async def async_set_admin_code(self, code: str) -> SupervisionResult | None:
+    async def set_admin_code(self, code: str) -> SupervisionResult | None:
         """Set the admin code for access control."""
         result = await self._endpoint.async_send_command(
             "access_control.set_admin_code",

--- a/zwave_js_server/model/access_control.py
+++ b/zwave_js_server/model/access_control.py
@@ -1,0 +1,799 @@
+"""Shared models and API wrapper for endpoint access-control support."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, TypedDict, cast
+
+from ..const.command_class.access_control import (
+    UserCredentialLearnStatus,
+    UserCredentialRule,
+    UserCredentialType,
+    UserCredentialUserType,
+)
+from ..util.helpers import (
+    BufferObjectDataType,
+    buffer_object_to_bytes,
+    bytes_to_buffer_object,
+)
+from .value import SupervisionResult, parse_supervision_result
+
+if TYPE_CHECKING:
+    from .endpoint import Endpoint
+
+
+def serialize_credential_data(data: str | bytes) -> str | BufferObjectDataType:
+    """Serialize a credential payload for websocket transport."""
+    if isinstance(data, bytes):
+        return bytes_to_buffer_object(data)
+    return data
+
+
+def deserialize_credential_data(
+    data: str | BufferObjectDataType | None,
+) -> str | bytes | None:
+    """Deserialize a credential payload from websocket transport."""
+    if data is None:
+        return None
+    if isinstance(data, str):
+        return data
+    return buffer_object_to_bytes(data)
+
+
+class UserCredentialCapabilityDataType(TypedDict, total=False):
+    """Represent a credential capability payload."""
+
+    numberOfCredentialSlots: int
+    minCredentialLength: int
+    maxCredentialLength: int
+    maxCredentialHashLength: int
+    supportsCredentialLearn: bool
+    credentialLearnRecommendedTimeout: int
+    credentialLearnNumberOfSteps: int
+
+
+@dataclass
+class UserCredentialCapability:
+    """Credential capability for a single credential type."""
+
+    number_of_credential_slots: int
+    min_credential_length: int
+    max_credential_length: int
+    max_credential_hash_length: int
+    supports_credential_learn: bool
+    credential_learn_recommended_timeout: int | None = None
+    credential_learn_number_of_steps: int | None = None
+
+    @classmethod
+    def from_dict(
+        cls, data: UserCredentialCapabilityDataType
+    ) -> UserCredentialCapability:
+        """Return capability from serialized data."""
+        return cls(
+            number_of_credential_slots=data["numberOfCredentialSlots"],
+            min_credential_length=data["minCredentialLength"],
+            max_credential_length=data["maxCredentialLength"],
+            max_credential_hash_length=data["maxCredentialHashLength"],
+            supports_credential_learn=data["supportsCredentialLearn"],
+            credential_learn_recommended_timeout=data.get(
+                "credentialLearnRecommendedTimeout"
+            ),
+            credential_learn_number_of_steps=data.get("credentialLearnNumberOfSteps"),
+        )
+
+    def to_dict(self) -> UserCredentialCapabilityDataType:
+        """Return serialized capability data."""
+        data: UserCredentialCapabilityDataType = {
+            "numberOfCredentialSlots": self.number_of_credential_slots,
+            "minCredentialLength": self.min_credential_length,
+            "maxCredentialLength": self.max_credential_length,
+            "maxCredentialHashLength": self.max_credential_hash_length,
+            "supportsCredentialLearn": self.supports_credential_learn,
+        }
+        if self.credential_learn_recommended_timeout is not None:
+            data["credentialLearnRecommendedTimeout"] = (
+                self.credential_learn_recommended_timeout
+            )
+        if self.credential_learn_number_of_steps is not None:
+            data["credentialLearnNumberOfSteps"] = self.credential_learn_number_of_steps
+        return data
+
+
+class UserCapabilitiesDataType(TypedDict, total=False):
+    """Represent user capabilities payload."""
+
+    maxUsers: int
+    supportedUserTypes: list[UserCredentialUserType]
+    maxUserNameLength: int
+    supportedCredentialRules: list[UserCredentialRule]
+
+
+@dataclass
+class UserCapabilities:
+    """User-related capabilities for an access-control endpoint."""
+
+    max_users: int
+    supported_user_types: list[UserCredentialUserType] = field(default_factory=list)
+    max_user_name_length: int | None = None
+    supported_credential_rules: list[UserCredentialRule] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: UserCapabilitiesDataType) -> UserCapabilities:
+        """Return user capabilities from serialized data."""
+        return cls(
+            max_users=data["maxUsers"],
+            supported_user_types=[
+                UserCredentialUserType(user_type)
+                for user_type in data.get("supportedUserTypes", [])
+            ],
+            max_user_name_length=data.get("maxUserNameLength"),
+            supported_credential_rules=[
+                UserCredentialRule(rule)
+                for rule in data.get("supportedCredentialRules", [])
+            ],
+        )
+
+    def to_dict(self) -> UserCapabilitiesDataType:
+        """Return serialized user capabilities."""
+        data: UserCapabilitiesDataType = {
+            "maxUsers": self.max_users,
+            "supportedUserTypes": list(self.supported_user_types),
+            "supportedCredentialRules": list(self.supported_credential_rules),
+        }
+        if self.max_user_name_length is not None:
+            data["maxUserNameLength"] = self.max_user_name_length
+        return data
+
+
+class CredentialCapabilitiesDataType(TypedDict, total=False):
+    """Represent credential capabilities payload."""
+
+    supportedCredentialTypes: dict[str, UserCredentialCapabilityDataType]
+    supportsAdminCode: bool
+    supportsAdminCodeDeactivation: bool
+
+
+@dataclass
+class CredentialCapabilities:
+    """Credential-related capabilities for an access-control endpoint."""
+
+    supported_credential_types: dict[UserCredentialType, UserCredentialCapability] = (
+        field(default_factory=dict)
+    )
+    supports_admin_code: bool = False
+    supports_admin_code_deactivation: bool = False
+
+    @classmethod
+    def from_dict(cls, data: CredentialCapabilitiesDataType) -> CredentialCapabilities:
+        """Return credential capabilities from serialized data."""
+        supported_credential_types = {
+            UserCredentialType(
+                int(credential_type)
+            ): UserCredentialCapability.from_dict(capability)
+            for credential_type, capability in data.get(
+                "supportedCredentialTypes", {}
+            ).items()
+        }
+        return cls(
+            supported_credential_types=supported_credential_types,
+            supports_admin_code=data.get("supportsAdminCode", False),
+            supports_admin_code_deactivation=data.get(
+                "supportsAdminCodeDeactivation", False
+            ),
+        )
+
+    def to_dict(self) -> CredentialCapabilitiesDataType:
+        """Return serialized credential capabilities."""
+        return {
+            "supportedCredentialTypes": {
+                str(int(credential_type)): capability.to_dict()
+                for credential_type, capability in self.supported_credential_types.items()
+            },
+            "supportsAdminCode": self.supports_admin_code,
+            "supportsAdminCodeDeactivation": self.supports_admin_code_deactivation,
+        }
+
+
+class UserDataDataType(TypedDict, total=False):
+    """Represent access-control user payload."""
+
+    userId: int
+    active: bool
+    userType: UserCredentialUserType
+    userName: str
+    credentialRule: UserCredentialRule
+    expiringTimeoutMinutes: int
+
+
+@dataclass
+class UserData:
+    """User data returned by endpoint access-control commands."""
+
+    user_id: int
+    active: bool
+    user_type: UserCredentialUserType
+    user_name: str | None = None
+    credential_rule: UserCredentialRule | None = None
+    expiring_timeout_minutes: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: UserDataDataType) -> UserData:
+        """Return user data from serialized payload."""
+        return cls(
+            user_id=data["userId"],
+            active=data.get("active", False),
+            user_type=UserCredentialUserType(data.get("userType", 0)),
+            user_name=data.get("userName"),
+            credential_rule=(
+                UserCredentialRule(credential_rule)
+                if (credential_rule := data.get("credentialRule")) is not None
+                else None
+            ),
+            expiring_timeout_minutes=data.get("expiringTimeoutMinutes"),
+        )
+
+    def to_dict(self) -> UserDataDataType:
+        """Return serialized user payload."""
+        data: UserDataDataType = {
+            "userId": self.user_id,
+            "active": self.active,
+            "userType": self.user_type,
+        }
+        if self.user_name is not None:
+            data["userName"] = self.user_name
+        if self.credential_rule is not None:
+            data["credentialRule"] = self.credential_rule
+        if self.expiring_timeout_minutes is not None:
+            data["expiringTimeoutMinutes"] = self.expiring_timeout_minutes
+        return data
+
+
+class SetUserOptionsDataType(TypedDict, total=False):
+    """Represent serialized set-user options."""
+
+    active: bool
+    userType: UserCredentialUserType
+    userName: str
+    credentialRule: UserCredentialRule
+    expiringTimeoutMinutes: int
+
+
+@dataclass
+class SetUserOptions:
+    """Options for creating or updating a user."""
+
+    active: bool | None = None
+    user_type: UserCredentialUserType | None = None
+    user_name: str | None = None
+    credential_rule: UserCredentialRule | None = None
+    expiring_timeout_minutes: int | None = None
+
+    def to_dict(self) -> SetUserOptionsDataType:
+        """Return serialized set-user options."""
+        data: SetUserOptionsDataType = {}
+        if self.active is not None:
+            data["active"] = self.active
+        if self.user_type is not None:
+            data["userType"] = self.user_type
+        if self.user_name is not None:
+            data["userName"] = self.user_name
+        if self.credential_rule is not None:
+            data["credentialRule"] = self.credential_rule
+        if self.expiring_timeout_minutes is not None:
+            data["expiringTimeoutMinutes"] = self.expiring_timeout_minutes
+        return data
+
+
+class CredentialDataDataType(TypedDict, total=False):
+    """Represent access-control credential payload."""
+
+    userId: int
+    type: UserCredentialType
+    slot: int
+    data: str | BufferObjectDataType
+
+
+@dataclass
+class CredentialData:
+    """Credential data returned by endpoint access-control commands."""
+
+    user_id: int
+    type: UserCredentialType
+    slot: int
+    data: str | bytes | None = None
+
+    @classmethod
+    def from_dict(cls, data: CredentialDataDataType) -> CredentialData:
+        """Return credential data from serialized payload."""
+        return cls(
+            user_id=data["userId"],
+            type=UserCredentialType(data["type"]),
+            slot=data["slot"],
+            data=deserialize_credential_data(data.get("data")),
+        )
+
+    def to_dict(self) -> CredentialDataDataType:
+        """Return serialized credential payload."""
+        data: CredentialDataDataType = {
+            "userId": self.user_id,
+            "type": self.type,
+            "slot": self.slot,
+        }
+        if self.data is not None:
+            data["data"] = serialize_credential_data(self.data)
+        return data
+
+
+class UserDeletedArgsDataType(TypedDict):
+    """Represent access-control user deleted event args."""
+
+    userId: int
+
+
+@dataclass
+class UserDeletedArgs:
+    """Args for access-control user deleted events."""
+
+    user_id: int
+
+    @classmethod
+    def from_dict(cls, data: UserDeletedArgsDataType) -> UserDeletedArgs:
+        """Return user deleted args from serialized payload."""
+        return cls(user_id=data["userId"])
+
+    def to_dict(self) -> UserDeletedArgsDataType:
+        """Return serialized user deleted args."""
+        return {"userId": self.user_id}
+
+
+class CredentialChangedArgsDataType(TypedDict, total=False):
+    """Represent access-control credential changed event args."""
+
+    userId: int
+    credentialType: UserCredentialType
+    credentialSlot: int
+    data: str | BufferObjectDataType
+
+
+@dataclass
+class CredentialChangedArgs:
+    """Args for access-control credential add/modify events."""
+
+    user_id: int
+    credential_type: UserCredentialType
+    credential_slot: int
+    data: str | bytes | None = None
+
+    @classmethod
+    def from_dict(cls, data: CredentialChangedArgsDataType) -> CredentialChangedArgs:
+        """Return credential changed args from serialized payload."""
+        return cls(
+            user_id=data["userId"],
+            credential_type=UserCredentialType(data["credentialType"]),
+            credential_slot=data["credentialSlot"],
+            data=deserialize_credential_data(data.get("data")),
+        )
+
+    def to_dict(self) -> CredentialChangedArgsDataType:
+        """Return serialized credential changed args."""
+        data: CredentialChangedArgsDataType = {
+            "userId": self.user_id,
+            "credentialType": self.credential_type,
+            "credentialSlot": self.credential_slot,
+        }
+        if self.data is not None:
+            data["data"] = serialize_credential_data(self.data)
+        return data
+
+
+class CredentialDeletedArgsDataType(TypedDict):
+    """Represent access-control credential deleted event args."""
+
+    userId: int
+    credentialType: UserCredentialType
+    credentialSlot: int
+
+
+@dataclass
+class CredentialDeletedArgs:
+    """Args for access-control credential deleted events."""
+
+    user_id: int
+    credential_type: UserCredentialType
+    credential_slot: int
+
+    @classmethod
+    def from_dict(cls, data: CredentialDeletedArgsDataType) -> CredentialDeletedArgs:
+        """Return credential deleted args from serialized payload."""
+        return cls(
+            user_id=data["userId"],
+            credential_type=UserCredentialType(data["credentialType"]),
+            credential_slot=data["credentialSlot"],
+        )
+
+    def to_dict(self) -> CredentialDeletedArgsDataType:
+        """Return serialized credential deleted args."""
+        return {
+            "userId": self.user_id,
+            "credentialType": self.credential_type,
+            "credentialSlot": self.credential_slot,
+        }
+
+
+class CredentialLearnProgressArgsDataType(TypedDict):
+    """Represent access-control credential learn progress event args."""
+
+    userId: int
+    credentialType: UserCredentialType
+    credentialSlot: int
+    stepsRemaining: int
+    status: UserCredentialLearnStatus
+
+
+@dataclass
+class CredentialLearnProgressArgs:
+    """Args for access-control credential learn progress events."""
+
+    user_id: int
+    credential_type: UserCredentialType
+    credential_slot: int
+    steps_remaining: int
+    status: UserCredentialLearnStatus
+
+    @classmethod
+    def from_dict(
+        cls, data: CredentialLearnProgressArgsDataType
+    ) -> CredentialLearnProgressArgs:
+        """Return credential learn progress args from serialized payload."""
+        return cls(
+            user_id=data["userId"],
+            credential_type=UserCredentialType(data["credentialType"]),
+            credential_slot=data["credentialSlot"],
+            steps_remaining=data["stepsRemaining"],
+            status=UserCredentialLearnStatus(data["status"]),
+        )
+
+    def to_dict(self) -> CredentialLearnProgressArgsDataType:
+        """Return serialized credential learn progress args."""
+        return {
+            "userId": self.user_id,
+            "credentialType": self.credential_type,
+            "credentialSlot": self.credential_slot,
+            "stepsRemaining": self.steps_remaining,
+            "status": self.status,
+        }
+
+
+class CredentialLearnCompletedArgsDataType(TypedDict):
+    """Represent access-control credential learn completed event args."""
+
+    userId: int
+    credentialType: UserCredentialType
+    credentialSlot: int
+    status: UserCredentialLearnStatus
+    success: bool
+
+
+@dataclass
+class CredentialLearnCompletedArgs:
+    """Args for access-control credential learn completed events."""
+
+    user_id: int
+    credential_type: UserCredentialType
+    credential_slot: int
+    status: UserCredentialLearnStatus
+    success: bool
+
+    @classmethod
+    def from_dict(
+        cls, data: CredentialLearnCompletedArgsDataType
+    ) -> CredentialLearnCompletedArgs:
+        """Return credential learn completed args from serialized payload."""
+        return cls(
+            user_id=data["userId"],
+            credential_type=UserCredentialType(data["credentialType"]),
+            credential_slot=data["credentialSlot"],
+            status=UserCredentialLearnStatus(data["status"]),
+            success=data["success"],
+        )
+
+    def to_dict(self) -> CredentialLearnCompletedArgsDataType:
+        """Return serialized credential learn completed args."""
+        return {
+            "userId": self.user_id,
+            "credentialType": self.credential_type,
+            "credentialSlot": self.credential_slot,
+            "status": self.status,
+            "success": self.success,
+        }
+
+
+class AccessControlAPI:
+    """Access-control command API wrapper for a single endpoint.
+
+    Schema 48+. Obtain via :attr:`Endpoint.access_control` or
+    :attr:`Node.access_control` (root endpoint shortcut).
+    """
+
+    def __init__(self, endpoint: Endpoint) -> None:
+        """Initialize the API wrapper for the given endpoint."""
+        self._endpoint = endpoint
+
+    async def async_is_supported(self) -> bool:
+        """Return whether the endpoint supports access-control methods."""
+        result = await self._endpoint.async_send_command(
+            "access_control.is_supported",
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        return cast(bool, result["supported"])
+
+    async def async_get_user_capabilities_cached(self) -> UserCapabilities:
+        """Return cached user capabilities for access control."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_user_capabilities_cached",
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        capabilities = result["capabilities"]
+        assert capabilities is not None
+        return UserCapabilities.from_dict(cast(UserCapabilitiesDataType, capabilities))
+
+    async def async_get_credential_capabilities_cached(
+        self,
+    ) -> CredentialCapabilities:
+        """Return cached credential capabilities for access control."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_credential_capabilities_cached",
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        capabilities = result["capabilities"]
+        assert capabilities is not None
+        return CredentialCapabilities.from_dict(
+            cast(CredentialCapabilitiesDataType, capabilities)
+        )
+
+    async def async_get_user(self, user_id: int) -> UserData | None:
+        """Return fresh data for a single access-control user."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_user",
+            userId=user_id,
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result is not None
+        if (user := result.get("user")) is None:
+            return None
+        return UserData.from_dict(cast(UserDataDataType, user))
+
+    async def async_get_user_cached(self, user_id: int) -> UserData | None:
+        """Return cached data for a single access-control user."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_user_cached",
+            userId=user_id,
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result is not None
+        if (user := result.get("user")) is None:
+            return None
+        return UserData.from_dict(cast(UserDataDataType, user))
+
+    async def async_get_users(self) -> list[UserData]:
+        """Return fresh data for all configured access-control users."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_users",
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        users = result["users"]
+        assert users is not None
+        return [UserData.from_dict(cast(UserDataDataType, user)) for user in users]
+
+    async def async_get_users_cached(self) -> list[UserData]:
+        """Return cached data for all configured access-control users."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_users_cached",
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        users = result["users"]
+        assert users is not None
+        return [UserData.from_dict(cast(UserDataDataType, user)) for user in users]
+
+    async def async_set_user(
+        self, user_id: int, options: SetUserOptions
+    ) -> SupervisionResult | None:
+        """Create or update an access-control user."""
+        result = await self._endpoint.async_send_command(
+            "access_control.set_user",
+            userId=user_id,
+            options=options.to_dict(),
+            require_schema=48,
+            wait_for_result=None,
+        )
+        return parse_supervision_result(result)
+
+    async def async_delete_user(self, user_id: int) -> SupervisionResult | None:
+        """Delete an access-control user."""
+        result = await self._endpoint.async_send_command(
+            "access_control.delete_user",
+            userId=user_id,
+            require_schema=48,
+            wait_for_result=None,
+        )
+        return parse_supervision_result(result)
+
+    async def async_delete_all_users(self) -> SupervisionResult | None:
+        """Delete all configured access-control users."""
+        result = await self._endpoint.async_send_command(
+            "access_control.delete_all_users",
+            require_schema=48,
+            wait_for_result=None,
+        )
+        return parse_supervision_result(result)
+
+    async def async_get_credential(
+        self,
+        user_id: int,
+        credential_type: UserCredentialType,
+        credential_slot: int,
+    ) -> CredentialData | None:
+        """Return fresh data for a single access-control credential."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_credential",
+            userId=user_id,
+            credentialType=credential_type,
+            credentialSlot=credential_slot,
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result is not None
+        if (credential := result.get("credential")) is None:
+            return None
+        return CredentialData.from_dict(cast(CredentialDataDataType, credential))
+
+    async def async_get_credential_cached(
+        self,
+        user_id: int,
+        credential_type: UserCredentialType,
+        credential_slot: int,
+    ) -> CredentialData | None:
+        """Return cached data for a single access-control credential."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_credential_cached",
+            userId=user_id,
+            credentialType=credential_type,
+            credentialSlot=credential_slot,
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result is not None
+        if (credential := result.get("credential")) is None:
+            return None
+        return CredentialData.from_dict(cast(CredentialDataDataType, credential))
+
+    async def async_get_credentials(self, user_id: int) -> list[CredentialData]:
+        """Return fresh data for all credentials assigned to a user."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_credentials",
+            userId=user_id,
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        credentials = result["credentials"]
+        assert credentials is not None
+        return [
+            CredentialData.from_dict(cast(CredentialDataDataType, credential))
+            for credential in credentials
+        ]
+
+    async def async_get_credentials_cached(self, user_id: int) -> list[CredentialData]:
+        """Return cached data for all credentials assigned to a user."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_credentials_cached",
+            userId=user_id,
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        credentials = result["credentials"]
+        assert credentials is not None
+        return [
+            CredentialData.from_dict(cast(CredentialDataDataType, credential))
+            for credential in credentials
+        ]
+
+    async def async_set_credential(
+        self,
+        user_id: int,
+        credential_type: UserCredentialType,
+        credential_slot: int,
+        data: str | bytes,
+    ) -> SupervisionResult | None:
+        """Create or update an access-control credential."""
+        result = await self._endpoint.async_send_command(
+            "access_control.set_credential",
+            userId=user_id,
+            credentialType=credential_type,
+            credentialSlot=credential_slot,
+            data=serialize_credential_data(data),
+            require_schema=48,
+            wait_for_result=None,
+        )
+        return parse_supervision_result(result)
+
+    async def async_delete_credential(
+        self,
+        user_id: int,
+        credential_type: UserCredentialType,
+        credential_slot: int,
+    ) -> SupervisionResult | None:
+        """Delete an access-control credential."""
+        result = await self._endpoint.async_send_command(
+            "access_control.delete_credential",
+            userId=user_id,
+            credentialType=credential_type,
+            credentialSlot=credential_slot,
+            require_schema=48,
+            wait_for_result=None,
+        )
+        return parse_supervision_result(result)
+
+    async def async_start_credential_learn(
+        self,
+        user_id: int,
+        credential_type: UserCredentialType,
+        credential_slot: int,
+        timeout: int | None = None,
+    ) -> SupervisionResult | None:
+        """Start learning mode for an access-control credential."""
+        cmd_kwargs: dict[str, Any] = {}
+        if timeout is not None:
+            cmd_kwargs["timeout"] = timeout
+        result = await self._endpoint.async_send_command(
+            "access_control.start_credential_learn",
+            userId=user_id,
+            credentialType=credential_type,
+            credentialSlot=credential_slot,
+            require_schema=48,
+            wait_for_result=None,
+            **cmd_kwargs,
+        )
+        return parse_supervision_result(result)
+
+    async def async_cancel_credential_learn(self) -> SupervisionResult | None:
+        """Cancel any active credential learn operation."""
+        result = await self._endpoint.async_send_command(
+            "access_control.cancel_credential_learn",
+            require_schema=48,
+            wait_for_result=None,
+        )
+        return parse_supervision_result(result)
+
+    async def async_get_admin_code(self) -> str | None:
+        """Return the configured admin code for access control."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_admin_code",
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        return cast(str | None, result.get("code"))
+
+    async def async_set_admin_code(self, code: str) -> SupervisionResult | None:
+        """Set the admin code for access control."""
+        result = await self._endpoint.async_send_command(
+            "access_control.set_admin_code",
+            code=code,
+            require_schema=48,
+            wait_for_result=None,
+        )
+        return parse_supervision_result(result)

--- a/zwave_js_server/model/access_control.py
+++ b/zwave_js_server/model/access_control.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from ..const.command_class.access_control import (
-    AssignCredentialStatus,
-    SetCredentialStatus,
-    SetUserStatus,
+    AssignCredentialResult,
+    SetCredentialResult,
+    SetUserResult,
     UserCredentialLearnStatus,
     UserCredentialRule,
     UserCredentialType,
@@ -612,7 +612,7 @@ class AccessControlAPI:
 
     async def async_set_user(
         self, user_id: int, options: SetUserOptions
-    ) -> SetUserStatus:
+    ) -> SetUserResult:
         """Create or update an access-control user."""
         result = await self._endpoint.async_send_command(
             "access_control.set_user",
@@ -622,9 +622,9 @@ class AccessControlAPI:
             wait_for_result=True,
         )
         assert result is not None
-        return SetUserStatus(result["status"])
+        return SetUserResult(result["result"])
 
-    async def async_delete_user(self, user_id: int) -> SetUserStatus:
+    async def async_delete_user(self, user_id: int) -> SetUserResult:
         """Delete an access-control user."""
         result = await self._endpoint.async_send_command(
             "access_control.delete_user",
@@ -633,9 +633,9 @@ class AccessControlAPI:
             wait_for_result=True,
         )
         assert result is not None
-        return SetUserStatus(result["status"])
+        return SetUserResult(result["result"])
 
-    async def async_delete_all_users(self) -> SetUserStatus:
+    async def async_delete_all_users(self) -> SetUserResult:
         """Delete all configured access-control users."""
         result = await self._endpoint.async_send_command(
             "access_control.delete_all_users",
@@ -643,7 +643,7 @@ class AccessControlAPI:
             wait_for_result=True,
         )
         assert result is not None
-        return SetUserStatus(result["status"])
+        return SetUserResult(result["result"])
 
     async def async_get_credential(
         self,
@@ -784,7 +784,7 @@ class AccessControlAPI:
         credential_type: UserCredentialType,
         credential_slot: int,
         destination_user_id: int,
-    ) -> AssignCredentialStatus:
+    ) -> AssignCredentialResult:
         """Reassign an existing credential to a different user."""
         result = await self._endpoint.async_send_command(
             "access_control.assign_credential",
@@ -795,7 +795,7 @@ class AccessControlAPI:
             wait_for_result=True,
         )
         assert result is not None
-        return AssignCredentialStatus(result["status"])
+        return AssignCredentialResult(result["result"])
 
     async def async_set_credential(
         self,
@@ -803,7 +803,7 @@ class AccessControlAPI:
         credential_type: UserCredentialType,
         credential_slot: int,
         data: str | bytes,
-    ) -> SetCredentialStatus:
+    ) -> SetCredentialResult:
         """Create or update an access-control credential."""
         result = await self._endpoint.async_send_command(
             "access_control.set_credential",
@@ -815,14 +815,14 @@ class AccessControlAPI:
             wait_for_result=True,
         )
         assert result is not None
-        return SetCredentialStatus(result["status"])
+        return SetCredentialResult(result["result"])
 
     async def async_delete_credential(
         self,
         user_id: int,
         credential_type: UserCredentialType,
         credential_slot: int,
-    ) -> SetCredentialStatus:
+    ) -> SetCredentialResult:
         """Delete an access-control credential."""
         result = await self._endpoint.async_send_command(
             "access_control.delete_credential",
@@ -833,7 +833,7 @@ class AccessControlAPI:
             wait_for_result=True,
         )
         assert result is not None
-        return SetCredentialStatus(result["status"])
+        return SetCredentialResult(result["result"])
 
     async def async_start_credential_learn(
         self,

--- a/zwave_js_server/model/access_control.py
+++ b/zwave_js_server/model/access_control.py
@@ -154,6 +154,7 @@ class CredentialCapabilitiesDataType(TypedDict, total=False):
     supportedCredentialTypes: dict[str, UserCredentialCapabilityDataType]
     supportsAdminCode: bool
     supportsAdminCodeDeactivation: bool
+    supportsCredentialAssignment: bool
 
 
 @dataclass
@@ -165,6 +166,7 @@ class CredentialCapabilities:
     )
     supports_admin_code: bool = False
     supports_admin_code_deactivation: bool = False
+    supports_credential_assignment: bool = False
 
     @classmethod
     def from_dict(cls, data: CredentialCapabilitiesDataType) -> CredentialCapabilities:
@@ -183,6 +185,9 @@ class CredentialCapabilities:
             supports_admin_code_deactivation=data.get(
                 "supportsAdminCodeDeactivation", False
             ),
+            supports_credential_assignment=data.get(
+                "supportsCredentialAssignment", False
+            ),
         )
 
     def to_dict(self) -> CredentialCapabilitiesDataType:
@@ -194,6 +199,7 @@ class CredentialCapabilities:
             },
             "supportsAdminCode": self.supports_admin_code,
             "supportsAdminCodeDeactivation": self.supports_admin_code_deactivation,
+            "supportsCredentialAssignment": self.supports_credential_assignment,
         }
 
 

--- a/zwave_js_server/model/access_control.py
+++ b/zwave_js_server/model/access_control.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Self, TypedDict, cast
 
 from ..const.command_class.access_control import (
     AssignCredentialResult,
@@ -68,9 +68,7 @@ class UserCredentialCapability:
     credential_learn_number_of_steps: int | None = None
 
     @classmethod
-    def from_dict(
-        cls, data: UserCredentialCapabilityDataType
-    ) -> UserCredentialCapability:
+    def from_dict(cls, data: UserCredentialCapabilityDataType) -> Self:
         """Return capability from serialized data."""
         return cls(
             number_of_credential_slots=data["numberOfCredentialSlots"],
@@ -121,7 +119,7 @@ class UserCapabilities:
     supported_credential_rules: list[UserCredentialRule] = field(default_factory=list)
 
     @classmethod
-    def from_dict(cls, data: UserCapabilitiesDataType) -> UserCapabilities:
+    def from_dict(cls, data: UserCapabilitiesDataType) -> Self:
         """Return user capabilities from serialized data."""
         return cls(
             max_users=data["maxUsers"],
@@ -169,7 +167,7 @@ class CredentialCapabilities:
     supports_credential_assignment: bool = False
 
     @classmethod
-    def from_dict(cls, data: CredentialCapabilitiesDataType) -> CredentialCapabilities:
+    def from_dict(cls, data: CredentialCapabilitiesDataType) -> Self:
         """Return credential capabilities from serialized data."""
         supported_credential_types = {
             UserCredentialType(
@@ -226,7 +224,7 @@ class UserData:
     expiring_timeout_minutes: int | None = None
 
     @classmethod
-    def from_dict(cls, data: UserDataDataType) -> UserData:
+    def from_dict(cls, data: UserDataDataType) -> Self:
         """Return user data from serialized payload."""
         return cls(
             user_id=data["userId"],
@@ -312,7 +310,7 @@ class CredentialData:
     data: str | bytes | None = None
 
     @classmethod
-    def from_dict(cls, data: CredentialDataDataType) -> CredentialData:
+    def from_dict(cls, data: CredentialDataDataType) -> Self:
         """Return credential data from serialized payload."""
         return cls(
             user_id=data["userId"],
@@ -346,7 +344,7 @@ class UserDeletedArgs:
     user_id: int
 
     @classmethod
-    def from_dict(cls, data: UserDeletedArgsDataType) -> UserDeletedArgs:
+    def from_dict(cls, data: UserDeletedArgsDataType) -> Self:
         """Return user deleted args from serialized payload."""
         return cls(user_id=data["userId"])
 
@@ -374,7 +372,7 @@ class CredentialChangedArgs:
     data: str | bytes | None = None
 
     @classmethod
-    def from_dict(cls, data: CredentialChangedArgsDataType) -> CredentialChangedArgs:
+    def from_dict(cls, data: CredentialChangedArgsDataType) -> Self:
         """Return credential changed args from serialized payload."""
         return cls(
             user_id=data["userId"],
@@ -412,7 +410,7 @@ class CredentialDeletedArgs:
     credential_slot: int
 
     @classmethod
-    def from_dict(cls, data: CredentialDeletedArgsDataType) -> CredentialDeletedArgs:
+    def from_dict(cls, data: CredentialDeletedArgsDataType) -> Self:
         """Return credential deleted args from serialized payload."""
         return cls(
             user_id=data["userId"],
@@ -450,9 +448,7 @@ class CredentialLearnProgressArgs:
     status: UserCredentialLearnStatus
 
     @classmethod
-    def from_dict(
-        cls, data: CredentialLearnProgressArgsDataType
-    ) -> CredentialLearnProgressArgs:
+    def from_dict(cls, data: CredentialLearnProgressArgsDataType) -> Self:
         """Return credential learn progress args from serialized payload."""
         return cls(
             user_id=data["userId"],
@@ -494,9 +490,7 @@ class CredentialLearnCompletedArgs:
     success: bool
 
     @classmethod
-    def from_dict(
-        cls, data: CredentialLearnCompletedArgsDataType
-    ) -> CredentialLearnCompletedArgs:
+    def from_dict(cls, data: CredentialLearnCompletedArgsDataType) -> Self:
         """Return credential learn completed args from serialized payload."""
         return cls(
             user_id=data["userId"],

--- a/zwave_js_server/model/access_control.py
+++ b/zwave_js_server/model/access_control.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from ..const.command_class.access_control import (
+    AssignCredentialStatus,
+    SetCredentialStatus,
+    SetUserStatus,
     UserCredentialLearnStatus,
     UserCredentialRule,
     UserCredentialType,
@@ -609,46 +612,47 @@ class AccessControlAPI:
 
     async def async_set_user(
         self, user_id: int, options: SetUserOptions
-    ) -> SupervisionResult | None:
+    ) -> SetUserStatus:
         """Create or update an access-control user."""
         result = await self._endpoint.async_send_command(
             "access_control.set_user",
             userId=user_id,
             options=options.to_dict(),
             require_schema=48,
-            wait_for_result=None,
+            wait_for_result=True,
         )
-        return parse_supervision_result(result)
+        assert result is not None
+        return SetUserStatus(result["status"])
 
-    async def async_delete_user(self, user_id: int) -> SupervisionResult | None:
+    async def async_delete_user(self, user_id: int) -> SetUserStatus:
         """Delete an access-control user."""
         result = await self._endpoint.async_send_command(
             "access_control.delete_user",
             userId=user_id,
             require_schema=48,
-            wait_for_result=None,
+            wait_for_result=True,
         )
-        return parse_supervision_result(result)
+        assert result is not None
+        return SetUserStatus(result["status"])
 
-    async def async_delete_all_users(self) -> SupervisionResult | None:
+    async def async_delete_all_users(self) -> SetUserStatus:
         """Delete all configured access-control users."""
         result = await self._endpoint.async_send_command(
             "access_control.delete_all_users",
             require_schema=48,
-            wait_for_result=None,
+            wait_for_result=True,
         )
-        return parse_supervision_result(result)
+        assert result is not None
+        return SetUserStatus(result["status"])
 
     async def async_get_credential(
         self,
-        user_id: int,
         credential_type: UserCredentialType,
         credential_slot: int,
     ) -> CredentialData | None:
         """Return fresh data for a single access-control credential."""
         result = await self._endpoint.async_send_command(
             "access_control.get_credential",
-            userId=user_id,
             credentialType=credential_type,
             credentialSlot=credential_slot,
             require_schema=48,
@@ -661,14 +665,12 @@ class AccessControlAPI:
 
     async def async_get_credential_cached(
         self,
-        user_id: int,
         credential_type: UserCredentialType,
         credential_slot: int,
     ) -> CredentialData | None:
         """Return cached data for a single access-control credential."""
         result = await self._endpoint.async_send_command(
             "access_control.get_credential_cached",
-            userId=user_id,
             credentialType=credential_type,
             credentialSlot=credential_slot,
             require_schema=48,
@@ -711,13 +713,97 @@ class AccessControlAPI:
             for credential in credentials
         ]
 
+    async def async_get_credentials_by_type(
+        self, credential_type: UserCredentialType
+    ) -> list[CredentialData]:
+        """Return fresh data for all credentials of the given type."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_credentials_by_type",
+            credentialType=credential_type,
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        credentials = result["credentials"]
+        assert credentials is not None
+        return [
+            CredentialData.from_dict(cast(CredentialDataDataType, credential))
+            for credential in credentials
+        ]
+
+    async def async_get_credentials_by_type_cached(
+        self, credential_type: UserCredentialType
+    ) -> list[CredentialData]:
+        """Return cached data for all credentials of the given type."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_credentials_by_type_cached",
+            credentialType=credential_type,
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        credentials = result["credentials"]
+        assert credentials is not None
+        return [
+            CredentialData.from_dict(cast(CredentialDataDataType, credential))
+            for credential in credentials
+        ]
+
+    async def async_get_all_credentials(self) -> list[CredentialData]:
+        """Return fresh data for all credentials regardless of type or user."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_all_credentials",
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        credentials = result["credentials"]
+        assert credentials is not None
+        return [
+            CredentialData.from_dict(cast(CredentialDataDataType, credential))
+            for credential in credentials
+        ]
+
+    async def async_get_all_credentials_cached(self) -> list[CredentialData]:
+        """Return cached data for all credentials regardless of type or user."""
+        result = await self._endpoint.async_send_command(
+            "access_control.get_all_credentials_cached",
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result
+        credentials = result["credentials"]
+        assert credentials is not None
+        return [
+            CredentialData.from_dict(cast(CredentialDataDataType, credential))
+            for credential in credentials
+        ]
+
+    async def async_assign_credential(
+        self,
+        credential_type: UserCredentialType,
+        credential_slot: int,
+        destination_user_id: int,
+    ) -> AssignCredentialStatus:
+        """Reassign an existing credential to a different user."""
+        result = await self._endpoint.async_send_command(
+            "access_control.assign_credential",
+            credentialType=credential_type,
+            credentialSlot=credential_slot,
+            destinationUserId=destination_user_id,
+            require_schema=48,
+            wait_for_result=True,
+        )
+        assert result is not None
+        return AssignCredentialStatus(result["status"])
+
     async def async_set_credential(
         self,
         user_id: int,
         credential_type: UserCredentialType,
         credential_slot: int,
         data: str | bytes,
-    ) -> SupervisionResult | None:
+    ) -> SetCredentialStatus:
         """Create or update an access-control credential."""
         result = await self._endpoint.async_send_command(
             "access_control.set_credential",
@@ -726,16 +812,17 @@ class AccessControlAPI:
             credentialSlot=credential_slot,
             data=serialize_credential_data(data),
             require_schema=48,
-            wait_for_result=None,
+            wait_for_result=True,
         )
-        return parse_supervision_result(result)
+        assert result is not None
+        return SetCredentialStatus(result["status"])
 
     async def async_delete_credential(
         self,
         user_id: int,
         credential_type: UserCredentialType,
         credential_slot: int,
-    ) -> SupervisionResult | None:
+    ) -> SetCredentialStatus:
         """Delete an access-control credential."""
         result = await self._endpoint.async_send_command(
             "access_control.delete_credential",
@@ -743,9 +830,10 @@ class AccessControlAPI:
             credentialType=credential_type,
             credentialSlot=credential_slot,
             require_schema=48,
-            wait_for_result=None,
+            wait_for_result=True,
         )
-        return parse_supervision_result(result)
+        assert result is not None
+        return SetCredentialStatus(result["status"])
 
     async def async_start_credential_learn(
         self,

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 from ..const import NodeStatus
 from ..event import EventBase
 from ..exceptions import FailedCommand, NotFoundError
+from .access_control import AccessControlAPI
 from .command_class import CommandClass, CommandClassInfo, CommandClassInfoDataType
 from .device_class import DeviceClass, DeviceClassDataType
 from .value import (
@@ -292,6 +293,11 @@ class Endpoint(EventBase):
         )
         assert result
         return cast("NodeDataType", result["node"])
+
+    @cached_property
+    def access_control(self) -> AccessControlAPI:
+        """Return the access-control API wrapper for this endpoint."""
+        return AccessControlAPI(self)
 
     async def async_set_raw_config_parameter_value(
         self,

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -7,11 +7,13 @@ https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=endpoint-properties
 from __future__ import annotations
 
 import asyncio
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 from ..const import NodeStatus
 from ..event import EventBase
 from ..exceptions import FailedCommand, NotFoundError
+from .access_control import AccessControlAPI
 from .command_class import CommandClass, CommandClassInfo, CommandClassInfoDataType
 from .device_class import DeviceClass, DeviceClassDataType
 from .value import (
@@ -290,6 +292,11 @@ class Endpoint(EventBase):
         )
         assert result
         return cast("NodeDataType", result["node"])
+
+    @cached_property
+    def access_control(self) -> AccessControlAPI:
+        """Return the access-control API wrapper for this endpoint."""
+        return AccessControlAPI(self)
 
     async def async_set_raw_config_parameter_value(
         self,

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -20,6 +20,15 @@ from ...const import (
 )
 from ...event import Event, EventBase
 from ...exceptions import NotFoundError, UnparseableValue, UnwriteableValue
+from ..access_control import (
+    AccessControlAPI,
+    CredentialChangedArgs,
+    CredentialDeletedArgs,
+    CredentialLearnCompletedArgs,
+    CredentialLearnProgressArgs,
+    UserData,
+    UserDeletedArgs,
+)
 from ..command_class import CommandClassInfo
 from ..device_class import DeviceClass
 from ..device_config import DeviceConfig
@@ -738,6 +747,11 @@ class Node(EventBase):
         """Call endpoint.get_node_unsafe command."""
         return await self.endpoints[0].async_get_node_unsafe()
 
+    @property
+    def access_control(self) -> AccessControlAPI:
+        """Return the access-control API wrapper for the root endpoint."""
+        return self.endpoints[0].access_control
+
     async def async_has_security_class(
         self, security_class: SecurityClass
     ) -> bool | None:
@@ -1023,6 +1037,25 @@ class Node(EventBase):
             property_, property_key, allow_unexpected_response
         )
 
+    def _handle_access_control_event(
+        self,
+        event: Event,
+        args_factory: type[
+            UserData
+            | UserDeletedArgs
+            | CredentialChangedArgs
+            | CredentialDeletedArgs
+            | CredentialLearnProgressArgs
+            | CredentialLearnCompletedArgs
+        ],
+    ) -> None:
+        """Resolve endpoint and normalize access-control event args."""
+        if (endpoint_index := event.data.get("endpointIndex")) is not None and (
+            endpoint := self.endpoints.get(endpoint_index)
+        ):
+            event.data["endpoint"] = endpoint
+        event.data["args"] = args_factory.from_dict(event.data["args"])
+
     def handle_test_powerlevel_progress(self, event: Event) -> None:
         """Process a test power level progress event."""
         event.data["test_power_level_progress"] = TestPowerLevelProgress(
@@ -1169,6 +1202,38 @@ class Node(EventBase):
     def handle_node_info_received(self, event: Event) -> None:
         """Process a node info received event."""
         # Nothing to do for now
+
+    def handle_user_added(self, event: Event) -> None:
+        """Process a node user added event."""
+        self._handle_access_control_event(event, UserData)
+
+    def handle_user_modified(self, event: Event) -> None:
+        """Process a node user modified event."""
+        self._handle_access_control_event(event, UserData)
+
+    def handle_user_deleted(self, event: Event) -> None:
+        """Process a node user deleted event."""
+        self._handle_access_control_event(event, UserDeletedArgs)
+
+    def handle_credential_added(self, event: Event) -> None:
+        """Process a node credential added event."""
+        self._handle_access_control_event(event, CredentialChangedArgs)
+
+    def handle_credential_modified(self, event: Event) -> None:
+        """Process a node credential modified event."""
+        self._handle_access_control_event(event, CredentialChangedArgs)
+
+    def handle_credential_deleted(self, event: Event) -> None:
+        """Process a node credential deleted event."""
+        self._handle_access_control_event(event, CredentialDeletedArgs)
+
+    def handle_credential_learn_progress(self, event: Event) -> None:
+        """Process a node credential learn progress event."""
+        self._handle_access_control_event(event, CredentialLearnProgressArgs)
+
+    def handle_credential_learn_completed(self, event: Event) -> None:
+        """Process a node credential learn completed event."""
+        self._handle_access_control_event(event, CredentialLearnCompletedArgs)
 
     def handle_firmware_update_progress(self, event: Event) -> None:
         """Process a node firmware update progress event."""

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -20,6 +20,15 @@ from ...const import (
 )
 from ...event import Event, EventBase
 from ...exceptions import NotFoundError, UnparseableValue, UnwriteableValue
+from ..access_control import (
+    AccessControlAPI,
+    CredentialChangedArgs,
+    CredentialDeletedArgs,
+    CredentialLearnCompletedArgs,
+    CredentialLearnProgressArgs,
+    UserData,
+    UserDeletedArgs,
+)
 from ..command_class import CommandClassInfo
 from ..device_class import DeviceClass
 from ..device_config import DeviceConfig
@@ -738,6 +747,11 @@ class Node(EventBase):
         """Call endpoint.get_node_unsafe command."""
         return await self.endpoints[0].async_get_node_unsafe()
 
+    @property
+    def access_control(self) -> AccessControlAPI:
+        """Return the access-control API wrapper for the root endpoint."""
+        return self.endpoints[0].access_control
+
     async def async_has_security_class(
         self, security_class: SecurityClass
     ) -> bool | None:
@@ -1023,6 +1037,25 @@ class Node(EventBase):
             property_, property_key, allow_unexpected_response
         )
 
+    def _handle_access_control_event(
+        self,
+        event: Event,
+        args_factory: type[
+            UserData
+            | UserDeletedArgs
+            | CredentialChangedArgs
+            | CredentialDeletedArgs
+            | CredentialLearnProgressArgs
+            | CredentialLearnCompletedArgs
+        ],
+    ) -> None:
+        """Resolve endpoint and normalize access-control event args."""
+        if (endpoint_index := event.data.get("endpointIndex")) is not None and (
+            endpoint := self.endpoints.get(endpoint_index)
+        ):
+            event.data["endpoint"] = endpoint
+        event.data["args"] = args_factory.from_dict(event.data["args"])
+
     def handle_test_powerlevel_progress(self, event: Event) -> None:
         """Process a test power level progress event."""
         event.data["test_power_level_progress"] = TestPowerLevelProgress(
@@ -1173,6 +1206,38 @@ class Node(EventBase):
     def handle_node_info_received(self, event: Event) -> None:
         """Process a node info received event."""
         # Nothing to do for now
+
+    def handle_user_added(self, event: Event) -> None:
+        """Process a node user added event."""
+        self._handle_access_control_event(event, UserData)
+
+    def handle_user_modified(self, event: Event) -> None:
+        """Process a node user modified event."""
+        self._handle_access_control_event(event, UserData)
+
+    def handle_user_deleted(self, event: Event) -> None:
+        """Process a node user deleted event."""
+        self._handle_access_control_event(event, UserDeletedArgs)
+
+    def handle_credential_added(self, event: Event) -> None:
+        """Process a node credential added event."""
+        self._handle_access_control_event(event, CredentialChangedArgs)
+
+    def handle_credential_modified(self, event: Event) -> None:
+        """Process a node credential modified event."""
+        self._handle_access_control_event(event, CredentialChangedArgs)
+
+    def handle_credential_deleted(self, event: Event) -> None:
+        """Process a node credential deleted event."""
+        self._handle_access_control_event(event, CredentialDeletedArgs)
+
+    def handle_credential_learn_progress(self, event: Event) -> None:
+        """Process a node credential learn progress event."""
+        self._handle_access_control_event(event, CredentialLearnProgressArgs)
+
+    def handle_credential_learn_completed(self, event: Event) -> None:
+        """Process a node credential learn completed event."""
+        self._handle_access_control_event(event, CredentialLearnCompletedArgs)
 
     def handle_firmware_update_progress(self, event: Event) -> None:
         """Process a node firmware update progress event."""

--- a/zwave_js_server/model/node/event_model.py
+++ b/zwave_js_server/model/node/event_model.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 from pydantic import BaseModel
 
@@ -220,7 +220,7 @@ class BaseNodeEndpointArgsEventModel(BaseNodeEventModel):
     args: Any
 
     @classmethod
-    def from_dict(cls, data: dict) -> BaseNodeEndpointArgsEventModel:
+    def from_dict(cls, data: dict) -> Self:
         """Initialize from dict."""
         return cls(
             source=data["source"],

--- a/zwave_js_server/model/node/event_model.py
+++ b/zwave_js_server/model/node/event_model.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
 from ...const import CommandClass
 from ...event import BaseEventModel
+from ..access_control import (
+    CredentialChangedArgsDataType,
+    CredentialDeletedArgsDataType,
+    CredentialLearnCompletedArgsDataType,
+    CredentialLearnProgressArgsDataType,
+    UserDataDataType,
+    UserDeletedArgsDataType,
+)
 from ..notification import (
     EntryControlNotificationArgsDataType,
     MultilevelSwitchNotificationArgsDataType,
@@ -205,6 +213,80 @@ class NotificationEventModel(BaseNodeEventModel):
         )
 
 
+class BaseNodeEndpointArgsEventModel(BaseNodeEventModel):
+    """Base model for node endpoint events with args payload."""
+
+    endpointIndex: int
+    args: Any
+
+    @classmethod
+    def from_dict(cls, data: dict) -> BaseNodeEndpointArgsEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            endpointIndex=data["endpointIndex"],
+            args=data["args"],
+        )
+
+
+class UserAddedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `user added` event data."""
+
+    event: Literal["user added"]
+    args: UserDataDataType
+
+
+class UserModifiedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `user modified` event data."""
+
+    event: Literal["user modified"]
+    args: UserDataDataType
+
+
+class UserDeletedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `user deleted` event data."""
+
+    event: Literal["user deleted"]
+    args: UserDeletedArgsDataType
+
+
+class CredentialAddedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `credential added` event data."""
+
+    event: Literal["credential added"]
+    args: CredentialChangedArgsDataType
+
+
+class CredentialModifiedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `credential modified` event data."""
+
+    event: Literal["credential modified"]
+    args: CredentialChangedArgsDataType
+
+
+class CredentialDeletedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `credential deleted` event data."""
+
+    event: Literal["credential deleted"]
+    args: CredentialDeletedArgsDataType
+
+
+class CredentialLearnProgressEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `credential learn progress` event data."""
+
+    event: Literal["credential learn progress"]
+    args: CredentialLearnProgressArgsDataType
+
+
+class CredentialLearnCompletedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `credential learn completed` event data."""
+
+    event: Literal["credential learn completed"]
+    args: CredentialLearnCompletedArgsDataType
+
+
 class ReadyEventModel(BaseNodeEventModel):
     """Model for `ready` event data."""
 
@@ -360,6 +442,11 @@ NODE_EVENT_MODEL_MAP: dict[str, type[BaseNodeEventModel]] = {
     "check lifeline health progress": CheckLifelineHealthProgressEventModel,
     "check link reliability progress": CheckLinkReliabilityProgressEventModel,
     "check route health progress": CheckRouteHealthProgressEventModel,
+    "credential added": CredentialAddedEventModel,
+    "credential deleted": CredentialDeletedEventModel,
+    "credential learn completed": CredentialLearnCompletedEventModel,
+    "credential learn progress": CredentialLearnProgressEventModel,
+    "credential modified": CredentialModifiedEventModel,
     "dead": DeadEventModel,
     "firmware update finished": FirmwareUpdateFinishedEventModel,
     "firmware update progress": FirmwareUpdateProgressEventModel,
@@ -374,6 +461,9 @@ NODE_EVENT_MODEL_MAP: dict[str, type[BaseNodeEventModel]] = {
     "sleep": SleepEventModel,
     "statistics updated": StatisticsUpdatedEventModel,
     "test powerlevel progress": TestPowerLevelProgressEventModel,
+    "user added": UserAddedEventModel,
+    "user deleted": UserDeletedEventModel,
+    "user modified": UserModifiedEventModel,
     "value added": ValueAddedEventModel,
     "value notification": ValueNotificationEventModel,
     "value removed": ValueRemovedEventModel,

--- a/zwave_js_server/model/node/event_model.py
+++ b/zwave_js_server/model/node/event_model.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
 from ...const import CommandClass
 from ...event import BaseEventModel
+from ..access_control import (
+    CredentialChangedArgsDataType,
+    CredentialDeletedArgsDataType,
+    CredentialLearnCompletedArgsDataType,
+    CredentialLearnProgressArgsDataType,
+    UserDataDataType,
+    UserDeletedArgsDataType,
+)
 from ..notification import (
     EntryControlNotificationArgsDataType,
     MultilevelSwitchNotificationArgsDataType,
@@ -188,6 +196,80 @@ class NotificationEventModel(BaseNodeEventModel):
         )
 
 
+class BaseNodeEndpointArgsEventModel(BaseNodeEventModel):
+    """Base model for node endpoint events with args payload."""
+
+    endpointIndex: int
+    args: Any
+
+    @classmethod
+    def from_dict(cls, data: dict) -> BaseNodeEndpointArgsEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            endpointIndex=data["endpointIndex"],
+            args=data["args"],
+        )
+
+
+class UserAddedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `user added` event data."""
+
+    event: Literal["user added"]
+    args: UserDataDataType
+
+
+class UserModifiedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `user modified` event data."""
+
+    event: Literal["user modified"]
+    args: UserDataDataType
+
+
+class UserDeletedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `user deleted` event data."""
+
+    event: Literal["user deleted"]
+    args: UserDeletedArgsDataType
+
+
+class CredentialAddedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `credential added` event data."""
+
+    event: Literal["credential added"]
+    args: CredentialChangedArgsDataType
+
+
+class CredentialModifiedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `credential modified` event data."""
+
+    event: Literal["credential modified"]
+    args: CredentialChangedArgsDataType
+
+
+class CredentialDeletedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `credential deleted` event data."""
+
+    event: Literal["credential deleted"]
+    args: CredentialDeletedArgsDataType
+
+
+class CredentialLearnProgressEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `credential learn progress` event data."""
+
+    event: Literal["credential learn progress"]
+    args: CredentialLearnProgressArgsDataType
+
+
+class CredentialLearnCompletedEventModel(BaseNodeEndpointArgsEventModel):
+    """Model for `credential learn completed` event data."""
+
+    event: Literal["credential learn completed"]
+    args: CredentialLearnCompletedArgsDataType
+
+
 class ReadyEventModel(BaseNodeEventModel):
     """Model for `ready` event data."""
 
@@ -342,6 +424,11 @@ NODE_EVENT_MODEL_MAP: dict[str, type[BaseNodeEventModel]] = {
     "alive": AliveEventModel,
     "check lifeline health progress": CheckLifelineHealthProgressEventModel,
     "check route health progress": CheckRouteHealthProgressEventModel,
+    "credential added": CredentialAddedEventModel,
+    "credential deleted": CredentialDeletedEventModel,
+    "credential learn completed": CredentialLearnCompletedEventModel,
+    "credential learn progress": CredentialLearnProgressEventModel,
+    "credential modified": CredentialModifiedEventModel,
     "dead": DeadEventModel,
     "firmware update finished": FirmwareUpdateFinishedEventModel,
     "firmware update progress": FirmwareUpdateProgressEventModel,
@@ -356,6 +443,9 @@ NODE_EVENT_MODEL_MAP: dict[str, type[BaseNodeEventModel]] = {
     "sleep": SleepEventModel,
     "statistics updated": StatisticsUpdatedEventModel,
     "test powerlevel progress": TestPowerLevelProgressEventModel,
+    "user added": UserAddedEventModel,
+    "user deleted": UserDeletedEventModel,
+    "user modified": UserModifiedEventModel,
     "value added": ValueAddedEventModel,
     "value notification": ValueNotificationEventModel,
     "value removed": ValueRemovedEventModel,

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -460,6 +460,15 @@ class SupervisionResult:
             )
 
 
+def parse_supervision_result(
+    data: dict[str, Any] | None,
+) -> SupervisionResult | None:
+    """Return a parsed supervision result from a command response."""
+    if not data or (result := data.get("result")) is None:
+        return None
+    return SupervisionResult(result)
+
+
 class ConfigurationValue(Value):
     """Model for a Configuration Value."""
 

--- a/zwave_js_server/util/helpers.py
+++ b/zwave_js_server/util/helpers.py
@@ -4,9 +4,36 @@ from __future__ import annotations
 
 import base64
 import json
-from typing import Any
+from typing import Any, Literal, TypeGuard, TypedDict
 
 from ..exceptions import UnparseableValue
+
+
+class BufferObjectDataType(TypedDict):
+    """Buffer object representation used by zwave-js-server JSON transport."""
+
+    type: Literal["Buffer"]
+    data: list[int]
+
+
+def is_buffer_object(value: Any) -> TypeGuard[BufferObjectDataType]:
+    """Return whether value matches zwave-js-server buffer transport shape."""
+    return (
+        isinstance(value, dict)
+        and value.get("type") == "Buffer"
+        and isinstance(value.get("data"), list)
+        and all(isinstance(item, int) for item in value["data"])
+    )
+
+
+def bytes_to_buffer_object(data: bytes) -> BufferObjectDataType:
+    """Wrap bytes in the websocket Buffer transport shape."""
+    return {"type": "Buffer", "data": list(data)}
+
+
+def buffer_object_to_bytes(value: BufferObjectDataType) -> bytes:
+    """Unwrap a websocket Buffer transport shape into bytes."""
+    return bytes(value["data"])
 
 
 def is_json_string(value: Any) -> bool:
@@ -38,7 +65,7 @@ def parse_buffer(value: dict[str, Any] | str) -> str:
 
 def parse_buffer_from_dict(value: dict[str, Any]) -> str:
     """Parse value dictionary from a buffer data type."""
-    if value.get("type") != "Buffer" or "data" not in value:
+    if not is_buffer_object(value):
         raise UnparseableValue(f"Unparseable value: {value}") from ValueError(
             "JSON does not match expected schema"
         )


### PR DESCRIPTION
Adds support for the new access-control / credential-management API introduced in Z-Wave JS 15.23.4 and exposed via Z-Wave JS Server schema 48 (zwave-js-server v3.8.0).

Bumps `MAX_SERVER_SCHEMA_VERSION` to 48 and adds:

- `AccessControlAPI` wrapper on `Endpoint` / `Node` with all schema-48 commands (users, credentials, admin code, credential learn)
- Dataclasses + `DataType` TypedDicts for `UserData`, `CredentialData`, capabilities, event args
- Enums in `const.command_class.access_control`: `UserCredentialType`, `UserCredentialUserType`, `UserCredentialRule`, `UserCredentialLearnStatus`, `SetUserResult`, `SetCredentialResult`, `AssignCredentialResult`
- Node/endpoint event models: `user added/modified/deleted`, `credential added/modified/deleted`, `credential learn progress/completed`
- Buffer helpers (`bytes_to_buffer_object` / `buffer_object_to_bytes`) for credential payloads

Requires:
- zwave-js >= 15.23.4
- zwave-js-server >= 3.8.0