### PR TITLE
Freeze immutable dataclasses and cache expensive properties

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -152,7 +152,7 @@ def test_from_state(client):
     assert node.endpoints[0].index == 0
     assert node.endpoints[0].installer_icon is None
     assert node.endpoints[0].user_icon is None
-    assert node.endpoints[0].command_classes == []
+    assert node.endpoints[0].command_classes == ()
     assert node.endpoints[0].endpoint_label is None
     device_class = node.endpoints[0].device_class
     assert device_class.basic.key == 2
@@ -226,6 +226,12 @@ async def test_command_classes(endpoints_with_command_classes: Node) -> None:
     assert command_class_info.version == 2
     assert command_class_info.is_secure is False
     assert command_class_info.to_dict() == command_class_info.data
+
+    # Cache: same object returned on repeated access.
+    assert node.endpoints[0].command_classes is node.endpoints[0].command_classes
+
+    # Returns a tuple (immutable).
+    assert isinstance(node.endpoints[0].command_classes, tuple)
 
 
 async def test_device_config(

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -457,7 +457,7 @@ class DateAndTimeDataType(TypedDict, total=False):
     standardOffset: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class DateAndTime:
     """Represent a date and time."""
 
@@ -474,16 +474,16 @@ class DateAndTime:
 
     def __post_init__(self) -> None:
         """Post initialization."""
-        self.hour = self.data.get("hour")
-        self.minute = self.data.get("minute")
+        object.__setattr__(self, "hour", self.data.get("hour"))
+        object.__setattr__(self, "minute", self.data.get("minute"))
         if weekday := self.data.get("weekday"):
-            self.weekday = Weekday(weekday)
-        self.second = self.data.get("second")
-        self.year = self.data.get("year")
-        self.month = self.data.get("month")
-        self.day = self.data.get("day")
-        self.dst_offset = self.data.get("dstOffset")
-        self.standard_offset = self.data.get("standardOffset")
+            object.__setattr__(self, "weekday", Weekday(weekday))
+        object.__setattr__(self, "second", self.data.get("second"))
+        object.__setattr__(self, "year", self.data.get("year"))
+        object.__setattr__(self, "month", self.data.get("month"))
+        object.__setattr__(self, "day", self.data.get("day"))
+        object.__setattr__(self, "dst_offset", self.data.get("dstOffset"))
+        object.__setattr__(self, "standard_offset", self.data.get("standardOffset"))
 
 
 class ControllerStatus(IntEnum):

--- a/zwave_js_server/const/command_class/lock.py
+++ b/zwave_js_server/const/command_class/lock.py
@@ -173,7 +173,7 @@ class DoorLockCCConfigurationSetOptions:
             "outside_handles_can_open_door_configuration",
         ):
             if not getattr(self, attr_name):
-                object.__setattr__(self, attr_name, DEFAULT_HANDLE_CONFIGURATION)
+                object.__setattr__(self, attr_name, list(DEFAULT_HANDLE_CONFIGURATION))
 
     def to_dict(self) -> DoorLockCCConfigurationSetOptionsDataType:
         """Convert command options to dict."""

--- a/zwave_js_server/const/command_class/lock.py
+++ b/zwave_js_server/const/command_class/lock.py
@@ -151,7 +151,7 @@ class DoorLockCCConfigurationSetOptionsDataType(TypedDict, total=False):
 DEFAULT_HANDLE_CONFIGURATION = [True, True, True, True]
 
 
-@dataclass
+@dataclass(frozen=True)
 class DoorLockCCConfigurationSetOptions:
     """Door Lock CC Configuration Set command options."""
 
@@ -173,7 +173,7 @@ class DoorLockCCConfigurationSetOptions:
             "outside_handles_can_open_door_configuration",
         ):
             if not getattr(self, attr_name):
-                setattr(self, attr_name, DEFAULT_HANDLE_CONFIGURATION)
+                object.__setattr__(self, attr_name, DEFAULT_HANDLE_CONFIGURATION)
 
     def to_dict(self) -> DoorLockCCConfigurationSetOptionsDataType:
         """Convert command options to dict."""

--- a/zwave_js_server/model/association.py
+++ b/zwave_js_server/model/association.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .node import Node
 
 
-@dataclass
+@dataclass(frozen=True)
 class AssociationGroup:
     """Represent a association group dict type."""
 
@@ -22,7 +22,7 @@ class AssociationGroup:
     issued_commands: dict[int, list[int]] = field(default_factory=dict)
 
 
-@dataclass
+@dataclass(frozen=True)
 class AssociationAddress:
     """Represent a association dict type."""
 

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cached_property
 import logging
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -64,7 +65,7 @@ DEFAULT_CONTROLLER_STATISTICS = (  # pylint: disable=invalid-name
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class NVMProgress:
     """Class to represent an NVM backup/restore progress event."""
 
@@ -267,7 +268,7 @@ class Controller(EventBase):
         """Return the Z-Wave API version (kind + version) supported by the controller."""
         return self.data.get("zwaveApiVersion")
 
-    @property
+    @cached_property
     def zwave_chip_type(self) -> ZWaveChipType | None:
         """Return the Z-Wave chip type."""
         if (raw := self.data.get("zwaveChipType")) is None:
@@ -277,6 +278,7 @@ class Controller(EventBase):
     def update(self, data: ControllerDataType) -> None:
         """Update controller data."""
         self.data = data
+        self.__dict__.pop("zwave_chip_type", None)
         self._statistics = ControllerStatistics(
             self.data.get("statistics", DEFAULT_CONTROLLER_STATISTICS)
         )

--- a/zwave_js_server/model/controller/inclusion_and_provisioning.py
+++ b/zwave_js_server/model/controller/inclusion_and_provisioning.py
@@ -16,7 +16,7 @@ class InclusionGrantDataType(TypedDict):
     clientSideAuth: bool
 
 
-@dataclass
+@dataclass(frozen=True)
 class InclusionGrant:
     """Representation of an inclusion grant."""
 
@@ -41,7 +41,7 @@ class InclusionGrant:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class ProvisioningEntry:
     """Class to represent the base fields of a provisioning entry."""
 
@@ -82,19 +82,28 @@ class ProvisioningEntry:
             for k, v in data.items()
             if k not in ("dsk", "securityClasses", "requestedSecurityClasses", "status")
         }:
-            cls_instance.additional_properties = additional_properties
+            object.__setattr__(
+                cls_instance, "additional_properties", additional_properties
+            )
         if "requestedSecurityClasses" in data:
-            cls_instance.requested_security_classes = [
-                SecurityClass(sec_cls) for sec_cls in data["requestedSecurityClasses"]
-            ]
+            object.__setattr__(
+                cls_instance,
+                "requested_security_classes",
+                [
+                    SecurityClass(sec_cls)
+                    for sec_cls in data["requestedSecurityClasses"]
+                ],
+            )
         if "status" in data:
-            cls_instance.status = ProvisioningEntryStatus(data["status"])
+            object.__setattr__(
+                cls_instance, "status", ProvisioningEntryStatus(data["status"])
+            )
         if "protocol" in data:
-            cls_instance.protocol = Protocols(data["protocol"])
+            object.__setattr__(cls_instance, "protocol", Protocols(data["protocol"]))
         return cls_instance
 
 
-@dataclass
+@dataclass(frozen=True)
 class QRProvisioningInformationMixin:
     """Mixin class to represent the base fields of a QR provisioning information."""
 
@@ -111,7 +120,7 @@ class QRProvisioningInformationMixin:
     supported_protocols: list[Protocols] | None
 
 
-@dataclass
+@dataclass(frozen=True)
 class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixin):
     """Representation of provisioning information retrieved from a QR code."""
 
@@ -193,11 +202,20 @@ class QRProvisioningInformation(ProvisioningEntry, QRProvisioningInformationMixi
                 "status",
             )
         }:
-            cls_instance.additional_properties = additional_properties
+            object.__setattr__(
+                cls_instance, "additional_properties", additional_properties
+            )
         if "requestedSecurityClasses" in data:
-            cls_instance.requested_security_classes = [
-                SecurityClass(sec_cls) for sec_cls in data["requestedSecurityClasses"]
-            ]
+            object.__setattr__(
+                cls_instance,
+                "requested_security_classes",
+                [
+                    SecurityClass(sec_cls)
+                    for sec_cls in data["requestedSecurityClasses"]
+                ],
+            )
         if "status" in data:
-            cls_instance.status = ProvisioningEntryStatus(data["status"])
+            object.__setattr__(
+                cls_instance, "status", ProvisioningEntryStatus(data["status"])
+            )
         return cls_instance

--- a/zwave_js_server/model/controller/rebuild_routes.py
+++ b/zwave_js_server/model/controller/rebuild_routes.py
@@ -13,7 +13,7 @@ class RebuildRoutesOptionsDataType(TypedDict, total=False):
     includeSleeping: bool
 
 
-@dataclass
+@dataclass(frozen=True)
 class RebuildRoutesOptions:
     """Represent options for rebuilding routes."""
 

--- a/zwave_js_server/model/controller/statistics.py
+++ b/zwave_js_server/model/controller/statistics.py
@@ -19,7 +19,7 @@ class ControllerLifelineRoutesDataType(TypedDict):
     nlwr: RouteStatisticsDataType
 
 
-@dataclass
+@dataclass(frozen=True)
 class ControllerLifelineRoutes:
     """Represent controller lifeline routes."""
 
@@ -32,10 +32,10 @@ class ControllerLifelineRoutes:
         """Post initialize."""
         if lwr := self.data.get("lwr"):
             with suppress(ValueError):
-                self.lwr = RouteStatistics(self.client, lwr)
+                object.__setattr__(self, "lwr", RouteStatistics(self.client, lwr))
         if nlwr := self.data.get("nlwr"):
             with suppress(ValueError):
-                self.nlwr = RouteStatistics(self.client, nlwr)
+                object.__setattr__(self, "nlwr", RouteStatistics(self.client, nlwr))
 
 
 class ChannelRSSIDataType(TypedDict):
@@ -72,7 +72,7 @@ class ControllerStatisticsDataType(TypedDict, total=False):
     backgroundRSSI: BackgroundRSSIDataType
 
 
-@dataclass
+@dataclass(frozen=True)
 class ChannelRSSI:
     """Represent a channel RSSI."""
 
@@ -82,11 +82,11 @@ class ChannelRSSI:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.average = self.data["average"]
-        self.current = self.data["current"]
+        object.__setattr__(self, "average", self.data["average"])
+        object.__setattr__(self, "current", self.data["current"])
 
 
-@dataclass
+@dataclass(frozen=True)
 class BackgroundRSSI:
     """Represent a background RSSI update."""
 
@@ -99,19 +99,19 @@ class BackgroundRSSI:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.timestamp = self.data["timestamp"]
-        self.channel_0 = ChannelRSSI(self.data["channel0"])
-        self.channel_1 = ChannelRSSI(self.data["channel1"])
+        object.__setattr__(self, "timestamp", self.data["timestamp"])
+        object.__setattr__(self, "channel_0", ChannelRSSI(self.data["channel0"]))
+        object.__setattr__(self, "channel_1", ChannelRSSI(self.data["channel1"]))
         # Channels 2 and 3 may not be present, but 3 requires 2 to be present
-        self.channel_2 = None
-        self.channel_3 = None
+        object.__setattr__(self, "channel_2", None)
+        object.__setattr__(self, "channel_3", None)
         if channel_2 := self.data.get("channel2"):
-            self.channel_2 = ChannelRSSI(channel_2)
+            object.__setattr__(self, "channel_2", ChannelRSSI(channel_2))
             if channel_3 := self.data.get("channel3"):
-                self.channel_3 = ChannelRSSI(channel_3)
+                object.__setattr__(self, "channel_3", ChannelRSSI(channel_3))
 
 
-@dataclass
+@dataclass(frozen=True)
 class ControllerStatistics:
     """Represent a controller statistics update."""
 
@@ -129,14 +129,14 @@ class ControllerStatistics:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.messages_tx = self.data["messagesTX"]
-        self.messages_rx = self.data["messagesRX"]
-        self.messages_dropped_rx = self.data["messagesDroppedRX"]
-        self.messages_dropped_tx = self.data["messagesDroppedTX"]
-        self.nak = self.data["NAK"]
-        self.can = self.data["CAN"]
-        self.timeout_ack = self.data["timeoutACK"]
-        self.timeout_response = self.data["timeoutResponse"]
-        self.timeout_callback = self.data["timeoutCallback"]
+        object.__setattr__(self, "messages_tx", self.data["messagesTX"])
+        object.__setattr__(self, "messages_rx", self.data["messagesRX"])
+        object.__setattr__(self, "messages_dropped_rx", self.data["messagesDroppedRX"])
+        object.__setattr__(self, "messages_dropped_tx", self.data["messagesDroppedTX"])
+        object.__setattr__(self, "nak", self.data["NAK"])
+        object.__setattr__(self, "can", self.data["CAN"])
+        object.__setattr__(self, "timeout_ack", self.data["timeoutACK"])
+        object.__setattr__(self, "timeout_response", self.data["timeoutResponse"])
+        object.__setattr__(self, "timeout_callback", self.data["timeoutCallback"])
         if background_rssi := self.data.get("backgroundRSSI"):
-            self.background_rssi = BackgroundRSSI(background_rssi)
+            object.__setattr__(self, "background_rssi", BackgroundRSSI(background_rssi))

--- a/zwave_js_server/model/device_class.py
+++ b/zwave_js_server/model/device_class.py
@@ -25,7 +25,7 @@ class DeviceClassDataType(TypedDict):
     specific: DeviceClassItemDataType
 
 
-@dataclass
+@dataclass(frozen=True)
 class DeviceClassItem:
     """Model for a DeviceClass item (e.g. basic or generic)."""
 

--- a/zwave_js_server/model/driver/firmware.py
+++ b/zwave_js_server/model/driver/firmware.py
@@ -19,7 +19,7 @@ class DriverFirmwareUpdateDataDataType(FirmwareUpdateDataDataType):
     """Represent a driver firmware update data dict type."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class DriverFirmwareUpdateData(FirmwareUpdateData):
     """Driver firmware update data."""
 
@@ -44,7 +44,7 @@ class DriverFirmwareUpdateProgressDataType(FirmwareUpdateProgressDataType):
     """Represent a driver firmware update progress dict type."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class DriverFirmwareUpdateProgress(FirmwareUpdateProgress):
     """Model for a driver firmware update progress data."""
 
@@ -55,7 +55,7 @@ class DriverFirmwareUpdateResultDataType(FirmwareUpdateResultDataType):
     """Represent a driver firmware update result dict type."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class DriverFirmwareUpdateResult(FirmwareUpdateResult):
     """Model for driver firmware update result data."""
 

--- a/zwave_js_server/model/duration.py
+++ b/zwave_js_server/model/duration.py
@@ -14,7 +14,7 @@ class DurationDataType(TypedDict, total=False):
     value: int | float
 
 
-@dataclass
+@dataclass(frozen=True)
 class Duration:
     """Duration class."""
 
@@ -25,11 +25,11 @@ class Duration:
     def __post_init__(self) -> None:
         """Post init."""
         if isinstance(self.data, str):
-            self.unit = self.data
-            self.value = None
+            object.__setattr__(self, "unit", self.data)
+            object.__setattr__(self, "value", None)
             return
-        self.unit = self.data["unit"]
-        self.value = self.data.get("value")
+        object.__setattr__(self, "unit", self.data["unit"])
+        object.__setattr__(self, "value", self.data.get("value"))
 
     def __repr__(self) -> str:
         """Return the representation."""

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -7,6 +7,7 @@ https://zwave-js.github.io/node-zwave-js/#/api/endpoint?id=endpoint-properties
 from __future__ import annotations
 
 import asyncio
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 from ..const import NodeStatus
@@ -103,7 +104,7 @@ class Endpoint(EventBase):
         """Return user icon property."""
         return self.data.get("userIcon")
 
-    @property
+    @cached_property
     def command_classes(self) -> list[CommandClassInfo]:
         """Return all CommandClasses supported on this node."""
         return [CommandClassInfo(cc) for cc in self.data["commandClasses"]]
@@ -118,6 +119,7 @@ class Endpoint(EventBase):
     ) -> None:
         """Update the endpoint data."""
         self.data = data
+        self.__dict__.pop("command_classes", None)
         if (device_class := self.data.get("deviceClass")) is None:
             self._device_class = None
         else:

--- a/zwave_js_server/model/endpoint.py
+++ b/zwave_js_server/model/endpoint.py
@@ -105,9 +105,9 @@ class Endpoint(EventBase):
         return self.data.get("userIcon")
 
     @cached_property
-    def command_classes(self) -> list[CommandClassInfo]:
+    def command_classes(self) -> tuple[CommandClassInfo, ...]:
         """Return all CommandClasses supported on this node."""
-        return [CommandClassInfo(cc) for cc in self.data["commandClasses"]]
+        return tuple(CommandClassInfo(cc) for cc in self.data["commandClasses"])
 
     @property
     def endpoint_label(self) -> str | None:

--- a/zwave_js_server/model/firmware.py
+++ b/zwave_js_server/model/firmware.py
@@ -10,7 +10,7 @@ from zwave_js_server.const import RFRegion
 from zwave_js_server.util.helpers import convert_bytes_to_base64
 
 
-@dataclass
+@dataclass(frozen=True)
 class FirmwareUpdateData:
     """Firmware update data."""
 
@@ -37,7 +37,7 @@ class FirmwareUpdateDataDataType(TypedDict, total=False):
     fileFormat: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class FirmwareUpdateInfo:
     """Represent a firmware update info."""
 
@@ -90,7 +90,7 @@ class FirmwareUpdateInfoDataType(TypedDict, total=False):
     device: FirmwareUpdateDeviceIDDataType
 
 
-@dataclass
+@dataclass(frozen=True)
 class FirmwareUpdateDeviceID:
     """Represent a firmware update device ID."""
 
@@ -134,7 +134,7 @@ class FirmwareUpdateDeviceIDDataType(TypedDict, total=False):
     rfRegion: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class FirmwareUpdateFileInfo:
     """Represent a firmware update file info."""
 
@@ -164,7 +164,7 @@ class FirmwareUpdateFileInfoDataType(TypedDict):
     integrity: str  # sha256
 
 
-@dataclass
+@dataclass(frozen=True)
 class FirmwareUpdateProgress:
     """Model for a firmware update progress."""
 
@@ -175,9 +175,9 @@ class FirmwareUpdateProgress:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.sent_fragments = self.data["sentFragments"]
-        self.total_fragments = self.data["totalFragments"]
-        self.progress = float(self.data["progress"])
+        object.__setattr__(self, "sent_fragments", self.data["sentFragments"])
+        object.__setattr__(self, "total_fragments", self.data["totalFragments"])
+        object.__setattr__(self, "progress", float(self.data["progress"]))
 
 
 class FirmwareUpdateProgressDataType(TypedDict):
@@ -188,7 +188,7 @@ class FirmwareUpdateProgressDataType(TypedDict):
     progress: float
 
 
-@dataclass
+@dataclass(frozen=True)
 class FirmwareUpdateResult:
     """Model for firmware update result data."""
 
@@ -199,8 +199,8 @@ class FirmwareUpdateResult:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.status = self._status_class(self.data["status"])
-        self.success = self.data["success"]
+        object.__setattr__(self, "status", self._status_class(self.data["status"]))
+        object.__setattr__(self, "success", self.data["success"])
 
 
 class FirmwareUpdateResultDataType(TypedDict):

--- a/zwave_js_server/model/log_config.py
+++ b/zwave_js_server/model/log_config.py
@@ -18,7 +18,7 @@ class LogConfigDataType(TypedDict, total=False):
     forceConsole: bool
 
 
-@dataclass
+@dataclass(frozen=True)
 class LogConfig:
     """Represent a log config dict type."""
 

--- a/zwave_js_server/model/log_message.py
+++ b/zwave_js_server/model/log_message.py
@@ -24,7 +24,7 @@ class LogMessageContextDataType(TypedDict, total=False):
     propertyKey: int | str
 
 
-@dataclass
+@dataclass(frozen=True)
 class LogMessageContext:
     """Represent log message context information."""
 
@@ -45,18 +45,18 @@ class LogMessageContext:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.source = self.data["source"]
-        self.type = self.data.get("type")
-        self.node_id = self.data.get("nodeId")
-        self.header = self.data.get("header")
-        self.direction = self.data.get("direction")
-        self.change = self.data.get("change")
-        self.internal = self.data.get("internal")
-        self.endpoint = self.data.get("endpoint")
+        object.__setattr__(self, "source", self.data["source"])
+        object.__setattr__(self, "type", self.data.get("type"))
+        object.__setattr__(self, "node_id", self.data.get("nodeId"))
+        object.__setattr__(self, "header", self.data.get("header"))
+        object.__setattr__(self, "direction", self.data.get("direction"))
+        object.__setattr__(self, "change", self.data.get("change"))
+        object.__setattr__(self, "internal", self.data.get("internal"))
+        object.__setattr__(self, "endpoint", self.data.get("endpoint"))
         if (command_class := self.data.get("commandClass")) is not None:
-            self.command_class = CommandClass(command_class)
-        self.property_ = self.data.get("property")
-        self.property_key = self.data.get("propertyKey")
+            object.__setattr__(self, "command_class", CommandClass(command_class))
+        object.__setattr__(self, "property_", self.data.get("property"))
+        object.__setattr__(self, "property_key", self.data.get("propertyKey"))
 
 
 class LogMessageDataType(TypedDict, total=False):
@@ -87,7 +87,7 @@ def _process_message(message: str | list[str]) -> list[str]:
     return [message.rstrip("\n") for message in message]
 
 
-@dataclass
+@dataclass(frozen=True)
 class LogMessage:
     """Represent a log message."""
 
@@ -106,14 +106,18 @@ class LogMessage:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.message = _process_message(self.data["message"])
-        self.formatted_message = _process_message(self.data["formattedMessage"])
-        self.direction = self.data["direction"]
-        self.level = self.data["level"]
-        self.context = LogMessageContext(self.data["context"])
-        self.primary_tags = self.data.get("primaryTags")
-        self.secondary_tags = self.data.get("secondaryTags")
-        self.secondary_tag_padding = self.data.get("secondaryTagPadding")
-        self.multiline = self.data.get("multiline")
-        self.timestamp = self.data.get("timestamp")
-        self.label = self.data.get("label")
+        object.__setattr__(self, "message", _process_message(self.data["message"]))
+        object.__setattr__(
+            self, "formatted_message", _process_message(self.data["formattedMessage"])
+        )
+        object.__setattr__(self, "direction", self.data["direction"])
+        object.__setattr__(self, "level", self.data["level"])
+        object.__setattr__(self, "context", LogMessageContext(self.data["context"]))
+        object.__setattr__(self, "primary_tags", self.data.get("primaryTags"))
+        object.__setattr__(self, "secondary_tags", self.data.get("secondaryTags"))
+        object.__setattr__(
+            self, "secondary_tag_padding", self.data.get("secondaryTagPadding")
+        )
+        object.__setattr__(self, "multiline", self.data.get("multiline"))
+        object.__setattr__(self, "timestamp", self.data.get("timestamp"))
+        object.__setattr__(self, "label", self.data.get("label"))

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -485,7 +485,7 @@ class Node(EventBase):
         if last_seen := data.get("lastSeen"):
             self._last_seen = datetime.fromisoformat(last_seen)
         if not self._statistics.last_seen and self.last_seen:
-            self._statistics.last_seen = self.last_seen
+            object.__setattr__(self._statistics, "last_seen", self.last_seen)
             self._statistics.data["lastSeen"] = self.last_seen.isoformat()
 
         self._update_values(self.data.pop("values"))

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -328,7 +328,7 @@ class Node(EventBase):
         return self.interview_stage in (None, NOT_INTERVIEWED)
 
     @property
-    def command_classes(self) -> list[CommandClassInfo]:
+    def command_classes(self) -> tuple[CommandClassInfo, ...]:
         """Return all CommandClasses supported on this node."""
         return self.endpoints[0].command_classes
 

--- a/zwave_js_server/model/node/firmware.py
+++ b/zwave_js_server/model/node/firmware.py
@@ -33,7 +33,7 @@ class NodeFirmwareUpdateDataDataType(FirmwareUpdateDataDataType):
     firmwareTarget: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class NodeFirmwareUpdateData(FirmwareUpdateData):
     """Firmware update data."""
 
@@ -66,7 +66,7 @@ class NodeFirmwareUpdateCapabilitiesDict(TypedDict, total=False):
     supports_activation: bool | None
 
 
-@dataclass
+@dataclass(frozen=True)
 class NodeFirmwareUpdateCapabilities:
     """Model for firmware update capabilities."""
 
@@ -75,7 +75,7 @@ class NodeFirmwareUpdateCapabilities:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.firmware_upgradable = self.data["firmwareUpgradable"]
+        object.__setattr__(self, "firmware_upgradable", self.data["firmwareUpgradable"])
 
     @property
     def firmware_targets(self) -> list[int]:
@@ -144,7 +144,7 @@ class NodeFirmwareUpdateProgressDataType(FirmwareUpdateProgressDataType):
     totalFiles: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class NodeFirmwareUpdateProgress(FirmwareUpdateProgress):
     """Model for a node firmware update progress data."""
 
@@ -160,13 +160,13 @@ class NodeFirmwareUpdateProgress(FirmwareUpdateProgress):
         that requires the node as first parameter.
         """
         super().__init__(data)
-        self.node = node
+        object.__setattr__(self, "node", node)
 
     def __post_init__(self) -> None:
         """Post initialize."""
         super().__post_init__()
-        self.current_file = self.data["currentFile"]
-        self.total_files = self.data["totalFiles"]
+        object.__setattr__(self, "current_file", self.data["currentFile"])
+        object.__setattr__(self, "total_files", self.data["totalFiles"])
 
 
 class NodeFirmwareUpdateResultDataType(FirmwareUpdateResultDataType, total=False):
@@ -176,7 +176,7 @@ class NodeFirmwareUpdateResultDataType(FirmwareUpdateResultDataType, total=False
     reInterview: Required[bool]
 
 
-@dataclass
+@dataclass(frozen=True)
 class NodeFirmwareUpdateResult(FirmwareUpdateResult):
     """Model for node firmware update result data."""
 
@@ -194,20 +194,20 @@ class NodeFirmwareUpdateResult(FirmwareUpdateResult):
         that requires the node as first parameter.
         """
         super().__init__(data)
-        self.node = node
+        object.__setattr__(self, "node", node)
 
     def __post_init__(self) -> None:
         """Post initialize."""
         super().__post_init__()
-        self.wait_time = self.data.get("waitTime")
-        self.reinterview = self.data["reInterview"]
+        object.__setattr__(self, "wait_time", self.data.get("waitTime"))
+        object.__setattr__(self, "reinterview", self.data["reInterview"])
 
 
 class NodeFirmwareUpdateFileInfoDataType(FirmwareUpdateFileInfoDataType):
     """Represent a node firmware update file info data dict type."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class NodeFirmwareUpdateFileInfo(FirmwareUpdateFileInfo):
     """Represent a firmware update file info."""
 
@@ -227,7 +227,7 @@ class NodeFirmwareUpdateDeviceIDDataType(FirmwareUpdateDeviceIDDataType):
     """Represent a node firmware update device ID data dict type."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class NodeFirmwareUpdateDeviceID(FirmwareUpdateDeviceID):
     """Represent a firmware update device ID."""
 
@@ -247,7 +247,7 @@ class NodeFirmwareUpdateInfoDataType(FirmwareUpdateInfoDataType):
     """Represent a node firmware update info data dict type."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class NodeFirmwareUpdateInfo(FirmwareUpdateInfo):
     """Represent a firmware update info."""
 

--- a/zwave_js_server/model/node/health_check.py
+++ b/zwave_js_server/model/node/health_check.py
@@ -131,7 +131,7 @@ class RouteHealthCheckSummary:
         self.results = [RouteHealthCheckResult(r) for r in self.data.get("results", [])]
 
 
-@dataclass
+@dataclass(frozen=True)
 class TestPowerLevelProgress:
     """Class to represent a test power level progress update."""
 
@@ -139,7 +139,7 @@ class TestPowerLevelProgress:
     total: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class CheckHealthProgress:
     """Represent a check lifeline/route health progress update."""
 

--- a/zwave_js_server/model/node/health_check.py
+++ b/zwave_js_server/model/node/health_check.py
@@ -30,7 +30,7 @@ class LifelineHealthCheckSummaryDataType(TypedDict):
     rating: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class LifelineHealthCheckResult:
     """Represent a lifeline health check result."""
 
@@ -46,18 +46,20 @@ class LifelineHealthCheckResult:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.latency = self.data["latency"]
-        self.num_neighbors = self.data["numNeighbors"]
-        self.failed_pings_node = self.data["failedPingsNode"]
-        self.rating = self.data["rating"]
-        self.route_changes = self.data.get("routeChanges")
+        object.__setattr__(self, "latency", self.data["latency"])
+        object.__setattr__(self, "num_neighbors", self.data["numNeighbors"])
+        object.__setattr__(self, "failed_pings_node", self.data["failedPingsNode"])
+        object.__setattr__(self, "rating", self.data["rating"])
+        object.__setattr__(self, "route_changes", self.data.get("routeChanges"))
         if (min_power_level := self.data.get("minPowerlevel")) is not None:
-            self.min_power_level = PowerLevel(min_power_level)
-        self.failed_pings_controller = self.data.get("failedPingsController")
-        self.snr_margin = self.data.get("snrMargin")
+            object.__setattr__(self, "min_power_level", PowerLevel(min_power_level))
+        object.__setattr__(
+            self, "failed_pings_controller", self.data.get("failedPingsController")
+        )
+        object.__setattr__(self, "snr_margin", self.data.get("snrMargin"))
 
 
-@dataclass
+@dataclass(frozen=True)
 class LifelineHealthCheckSummary:
     """Represent a lifeline health check summary update."""
 
@@ -67,10 +69,12 @@ class LifelineHealthCheckSummary:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.rating = self.data["rating"]
-        self.results = [
-            LifelineHealthCheckResult(r) for r in self.data.get("results", [])
-        ]
+        object.__setattr__(self, "rating", self.data["rating"])
+        object.__setattr__(
+            self,
+            "results",
+            [LifelineHealthCheckResult(r) for r in self.data.get("results", [])],
+        )
 
 
 class RouteHealthCheckResultDataType(TypedDict, total=False):
@@ -93,7 +97,7 @@ class RouteHealthCheckSummaryDataType(TypedDict):
     rating: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class RouteHealthCheckResult:
     """Represent a route health check result."""
 
@@ -107,17 +111,25 @@ class RouteHealthCheckResult:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.num_neighbors = self.data["numNeighbors"]
-        self.rating = self.data["rating"]
-        self.failed_pings_to_target = self.data.get("failedPingsToTarget")
-        self.failed_pings_to_source = self.data.get("failedPingsToSource")
+        object.__setattr__(self, "num_neighbors", self.data["numNeighbors"])
+        object.__setattr__(self, "rating", self.data["rating"])
+        object.__setattr__(
+            self, "failed_pings_to_target", self.data.get("failedPingsToTarget")
+        )
+        object.__setattr__(
+            self, "failed_pings_to_source", self.data.get("failedPingsToSource")
+        )
         if (min_power_level_source := self.data.get("minPowerlevelSource")) is not None:
-            self.min_power_level_source = PowerLevel(min_power_level_source)
+            object.__setattr__(
+                self, "min_power_level_source", PowerLevel(min_power_level_source)
+            )
         if (min_power_level_target := self.data.get("minPowerlevelTarget")) is not None:
-            self.min_power_level_target = PowerLevel(min_power_level_target)
+            object.__setattr__(
+                self, "min_power_level_target", PowerLevel(min_power_level_target)
+            )
 
 
-@dataclass
+@dataclass(frozen=True)
 class RouteHealthCheckSummary:
     """Represent a route health check summary update."""
 
@@ -127,8 +139,12 @@ class RouteHealthCheckSummary:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.rating = self.data["rating"]
-        self.results = [RouteHealthCheckResult(r) for r in self.data.get("results", [])]
+        object.__setattr__(self, "rating", self.data["rating"])
+        object.__setattr__(
+            self,
+            "results",
+            [RouteHealthCheckResult(r) for r in self.data.get("results", [])],
+        )
 
 
 @dataclass(frozen=True)

--- a/zwave_js_server/model/node/statistics.py
+++ b/zwave_js_server/model/node/statistics.py
@@ -32,7 +32,7 @@ class NodeStatisticsDataType(TypedDict, total=False):
     lastSeen: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class NodeStatistics:
     """Represent a node statistics update."""
 
@@ -50,20 +50,20 @@ class NodeStatistics:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.commands_tx = self.data["commandsTX"]
-        self.commands_rx = self.data["commandsRX"]
-        self.commands_dropped_rx = self.data["commandsDroppedRX"]
-        self.commands_dropped_tx = self.data["commandsDroppedTX"]
-        self.timeout_response = self.data["timeoutResponse"]
-        self.rtt = self.data.get("rtt")
+        object.__setattr__(self, "commands_tx", self.data["commandsTX"])
+        object.__setattr__(self, "commands_rx", self.data["commandsRX"])
+        object.__setattr__(self, "commands_dropped_rx", self.data["commandsDroppedRX"])
+        object.__setattr__(self, "commands_dropped_tx", self.data["commandsDroppedTX"])
+        object.__setattr__(self, "timeout_response", self.data["timeoutResponse"])
+        object.__setattr__(self, "rtt", self.data.get("rtt"))
         if last_seen := self.data.get("lastSeen"):
-            self.last_seen = datetime.fromisoformat(last_seen)
+            object.__setattr__(self, "last_seen", datetime.fromisoformat(last_seen))
         if lwr := self.data.get("lwr"):
             with suppress(ValueError):
-                self.lwr = RouteStatistics(self.client, lwr)
+                object.__setattr__(self, "lwr", RouteStatistics(self.client, lwr))
         if nlwr := self.data.get("nlwr"):
             with suppress(ValueError):
-                self.nlwr = RouteStatistics(self.client, nlwr)
+                object.__setattr__(self, "nlwr", RouteStatistics(self.client, nlwr))
 
     @property
     def rssi(self) -> int | None:

--- a/zwave_js_server/model/notification.py
+++ b/zwave_js_server/model/notification.py
@@ -28,7 +28,7 @@ class BaseNotificationDataType(TypedDict):
     ccId: int  # required
 
 
-@dataclass
+@dataclass(frozen=True)
 class BaseNotification:
     """Model for a Zwave Node's notification event."""
 
@@ -40,9 +40,9 @@ class BaseNotification:
 
     def __post_init__(self) -> None:
         """Post initialization."""
-        self.node_id = self.data["nodeId"]
-        self.endpoint_idx = self.data["endpointIndex"]
-        self.command_class = self.data["ccId"]
+        object.__setattr__(self, "node_id", self.data["nodeId"])
+        object.__setattr__(self, "endpoint_idx", self.data["endpointIndex"])
+        object.__setattr__(self, "command_class", self.data["ccId"])
 
 
 class BatteryNotificationArgsDataType(TypedDict):
@@ -58,7 +58,7 @@ class BatteryNotificationDataType(BaseNotificationDataType):
     args: BatteryNotificationArgsDataType  # required
 
 
-@dataclass
+@dataclass(frozen=True)
 class BatteryNotification(BaseNotification):
     """Model for a Zwave Node's Battery CC notification event."""
 
@@ -69,8 +69,10 @@ class BatteryNotification(BaseNotification):
     def __post_init__(self) -> None:
         """Post initialize."""
         super().__post_init__()
-        self.event_type = self.data["args"]["eventType"]
-        self.urgency = BatteryReplacementStatus(self.data["args"]["urgency"])
+        object.__setattr__(self, "event_type", self.data["args"]["eventType"])
+        object.__setattr__(
+            self, "urgency", BatteryReplacementStatus(self.data["args"]["urgency"])
+        )
 
 
 class EntryControlNotificationArgsDataType(TypedDict, total=False):
@@ -89,7 +91,7 @@ class EntryControlNotificationDataType(BaseNotificationDataType):
     args: EntryControlNotificationArgsDataType  # required
 
 
-@dataclass
+@dataclass(frozen=True)
 class EntryControlNotification(BaseNotification):
     """Model for a Zwave Node's Entry Control CC notification event."""
 
@@ -103,12 +105,14 @@ class EntryControlNotification(BaseNotification):
     def __post_init__(self) -> None:
         """Post initialize."""
         super().__post_init__()
-        self.event_type = self.data["args"]["eventType"]
-        self.event_type_label = self.data["args"]["eventTypeLabel"]
-        self.data_type = self.data["args"]["dataType"]
-        self.data_type_label = self.data["args"]["dataTypeLabel"]
+        object.__setattr__(self, "event_type", self.data["args"]["eventType"])
+        object.__setattr__(
+            self, "event_type_label", self.data["args"]["eventTypeLabel"]
+        )
+        object.__setattr__(self, "data_type", self.data["args"]["dataType"])
+        object.__setattr__(self, "data_type_label", self.data["args"]["dataTypeLabel"])
         if event_data := self.data["args"].get("eventData"):
-            self.event_data = parse_buffer(event_data)
+            object.__setattr__(self, "event_data", parse_buffer(event_data))
 
 
 class NotificationNotificationArgsDataType(TypedDict, total=False):
@@ -127,7 +131,7 @@ class NotificationNotificationDataType(BaseNotificationDataType):
     args: NotificationNotificationArgsDataType  # required
 
 
-@dataclass
+@dataclass(frozen=True)
 class NotificationNotification(BaseNotification):
     """Model for a Zwave Node's Notification CC notification event."""
 
@@ -141,11 +145,11 @@ class NotificationNotification(BaseNotification):
     def __post_init__(self) -> None:
         """Post initialize."""
         super().__post_init__()
-        self.type_ = self.data["args"]["type"]
-        self.label = self.data["args"]["label"]
-        self.event = self.data["args"]["event"]
-        self.event_label = self.data["args"]["eventLabel"]
-        self.parameters = self.data["args"].get("parameters", {})
+        object.__setattr__(self, "type_", self.data["args"]["type"])
+        object.__setattr__(self, "label", self.data["args"]["label"])
+        object.__setattr__(self, "event", self.data["args"]["event"])
+        object.__setattr__(self, "event_label", self.data["args"]["eventLabel"])
+        object.__setattr__(self, "parameters", self.data["args"].get("parameters", {}))
 
 
 class PowerLevelNotificationArgsDataType(TypedDict):
@@ -162,7 +166,7 @@ class PowerLevelNotificationDataType(BaseNotificationDataType):
     args: PowerLevelNotificationArgsDataType  # required
 
 
-@dataclass
+@dataclass(frozen=True)
 class PowerLevelNotification(BaseNotification):
     """Model for a Zwave Node's Power Level CC notification event."""
 
@@ -174,9 +178,13 @@ class PowerLevelNotification(BaseNotification):
     def __post_init__(self) -> None:
         """Post initialize."""
         super().__post_init__()
-        self.test_node_id = self.data["args"]["testNodeId"]
-        self.status = PowerLevelTestStatus(self.data["args"]["status"])
-        self.acknowledged_frames = self.data["args"]["acknowledgedFrames"]
+        object.__setattr__(self, "test_node_id", self.data["args"]["testNodeId"])
+        object.__setattr__(
+            self, "status", PowerLevelTestStatus(self.data["args"]["status"])
+        )
+        object.__setattr__(
+            self, "acknowledged_frames", self.data["args"]["acknowledgedFrames"]
+        )
 
 
 class MultilevelSwitchNotificationArgsDataType(TypedDict, total=False):
@@ -193,7 +201,7 @@ class MultilevelSwitchNotificationDataType(BaseNotificationDataType):
     args: MultilevelSwitchNotificationArgsDataType  # required
 
 
-@dataclass
+@dataclass(frozen=True)
 class MultilevelSwitchNotification(BaseNotification):
     """Model for a Zwave Node's Multi Level CC notification event."""
 
@@ -205,6 +213,10 @@ class MultilevelSwitchNotification(BaseNotification):
     def __post_init__(self) -> None:
         """Post initialize."""
         super().__post_init__()
-        self.event_type = MultilevelSwitchCommand(self.data["args"]["eventType"])
-        self.event_type_label = self.data["args"]["eventTypeLabel"]
-        self.direction = self.data["args"].get("direction")
+        object.__setattr__(
+            self, "event_type", MultilevelSwitchCommand(self.data["args"]["eventType"])
+        )
+        object.__setattr__(
+            self, "event_type_label", self.data["args"]["eventTypeLabel"]
+        )
+        object.__setattr__(self, "direction", self.data["args"].get("direction"))

--- a/zwave_js_server/model/statistics.py
+++ b/zwave_js_server/model/statistics.py
@@ -35,7 +35,7 @@ class RouteStatisticsDict(TypedDict):
     route_failed_between: tuple[Node, Node] | None
 
 
-@dataclass
+@dataclass(frozen=True)
 class RouteStatistics:
     """Represent route statistics."""
 
@@ -45,7 +45,9 @@ class RouteStatistics:
 
     def __post_init__(self) -> None:
         """Post initialize."""
-        self.protocol_data_rate = ProtocolDataRate(self.data["protocolDataRate"])
+        object.__setattr__(
+            self, "protocol_data_rate", ProtocolDataRate(self.data["protocolDataRate"])
+        )
 
     @cached_property
     def repeaters(self) -> list[Node]:

--- a/zwave_js_server/model/value.py
+++ b/zwave_js_server/model/value.py
@@ -437,7 +437,7 @@ class SupervisionResultDataType(TypedDict, total=False):
     remainingDuration: DurationDataType  # not included unless status is 1 (working)
 
 
-@dataclass
+@dataclass(frozen=True)
 class SupervisionResult:
     """Represent a Supervision result type."""
 
@@ -447,9 +447,9 @@ class SupervisionResult:
 
     def __post_init__(self) -> None:
         """Post initialization."""
-        self.status = SupervisionStatus(self.data["status"])
+        object.__setattr__(self, "status", SupervisionStatus(self.data["status"]))
         if remaining_duration := self.data.get("remainingDuration"):
-            self.remaining_duration = Duration(remaining_duration)
+            object.__setattr__(self, "remaining_duration", Duration(remaining_duration))
 
         if self.status == SupervisionStatus.WORKING ^ bool(
             self.remaining_duration is not None
@@ -500,7 +500,7 @@ class SetValueResultDataType(TypedDict, total=False):
     message: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class SetValueResult:
     """Result from setValue command."""
 
@@ -511,13 +511,17 @@ class SetValueResult:
 
     def __post_init__(self) -> None:
         """Post init."""
-        self.status = SetValueStatus(self.data["status"])
-        self.remaining_duration = (
-            Duration(duration_data)
-            if (duration_data := self.data.get("remainingDuration"))
-            else None
+        object.__setattr__(self, "status", SetValueStatus(self.data["status"]))
+        object.__setattr__(
+            self,
+            "remaining_duration",
+            (
+                Duration(duration_data)
+                if (duration_data := self.data.get("remainingDuration"))
+                else None
+            ),
         )
-        self.message = self.data.get("message")
+        object.__setattr__(self, "message", self.data.get("message"))
 
     def __repr__(self) -> str:
         """Return the representation."""

--- a/zwave_js_server/model/version.py
+++ b/zwave_js_server/model/version.py
@@ -16,7 +16,7 @@ class VersionInfoDataType(TypedDict):
     maxSchemaVersion: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class VersionInfo:
     """Version info of the server."""
 

--- a/zwave_js_server/util/lock.py
+++ b/zwave_js_server/util/lock.py
@@ -211,7 +211,7 @@ async def set_configuration(
                 f"- Can't provide value for {property_name} since it is unsupported"
             )
         elif cached_value is not None and val is None and not errors:
-            setattr(configuration, attr_name, cached_value.value)
+            object.__setattr__(configuration, attr_name, cached_value.value)
 
     if errors:
         raise ValueError("\n".join(errors))


### PR DESCRIPTION
## Summary

Freezes all dataclasses in the codebase and caches two expensive properties.

### Frozen dataclasses

**Every dataclass is now `frozen=True`** except `Event` (whose `data` dict is intentionally mutated by event handlers).

- **Simple freezes** (no `__post_init__`): `DeviceClassItem`, `TestPowerLevelProgress`, `CheckHealthProgress`, `VersionInfo`, `AssociationGroup`, `AssociationAddress`, `NVMProgress`
- **`object.__setattr__` refactored** (~40 classes): `Duration`, `LogMessage`, `LogMessageContext`, `SupervisionResult`, `SetValueResult`, `DateAndTime`, all statistics classes, all firmware classes, all health check classes, all notification classes, `InclusionGrant`, `ProvisioningEntry`, `QRProvisioningInformation`, `LogConfig`, `RebuildRoutesOptions`, `DoorLockCCConfigurationSetOptions`
- **External mutation sites fixed**: `Node._statistics.last_seen` assignment, `lock.py` setattr on config options, `ProvisioningEntry`/`QRProvisioningInformation` `from_dict` post-construction assignments

The `object.__setattr__` pattern is the [officially documented approach](https://docs.python.org/3/library/dataclasses.html#frozen-instances) for frozen dataclasses that need post-init computation.

### Cached properties

| Property | Class | What it does | Invalidation |
|---|---|---|---|
| `command_classes` | `Endpoint` | Creates `list[CommandClassInfo]` via list comprehension | `update()` pops cache |
| `zwave_chip_type` | `Controller` | Creates `ZWaveChipType` from wire data | `update()` pops cache when key changes |

## Test plan

- [x] `pytest -q` — 311/311 passing
- [x] black + ruff + mypy all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)