### PR TITLE
Move NVMProgress dataclass to controller.data_model

### DIFF
--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -26,7 +25,12 @@ from ...util.helpers import convert_base64_to_bytes, convert_bytes_to_base64
 from ..association import AssociationAddress, AssociationGroup
 from ..node import Node
 from ..node.firmware import NodeFirmwareUpdateResult
-from .data_model import ControllerDataType, ZWaveApiVersionDataType, ZWaveChipType
+from .data_model import (
+    ControllerDataType,
+    NVMProgress,
+    ZWaveApiVersionDataType,
+    ZWaveChipType,
+)
 from .event_model import CONTROLLER_EVENT_MODEL_MAP
 from .inclusion_and_provisioning import (
     InclusionGrant,
@@ -62,14 +66,6 @@ DEFAULT_CONTROLLER_STATISTICS = (  # pylint: disable=invalid-name
         timeoutCallback=0,
     )
 )
-
-
-@dataclass
-class NVMProgress:
-    """Class to represent an NVM backup/restore progress event."""
-
-    bytes_read_or_written: int
-    total_bytes: int
 
 
 class Controller(EventBase):

--- a/zwave_js_server/model/controller/data_model.py
+++ b/zwave_js_server/model/controller/data_model.py
@@ -42,6 +42,14 @@ class ZWaveChipType:
         return cls(type=data["type"], version=data["version"])
 
 
+@dataclass
+class NVMProgress:
+    """Class to represent an NVM backup/restore progress event."""
+
+    bytes_read_or_written: int
+    total_bytes: int
+
+
 class ControllerDataType(TypedDict, total=False):
     """Represent a controller data dict type."""
 

--- a/zwave_js_server/model/controller/data_model.py
+++ b/zwave_js_server/model/controller/data_model.py
@@ -48,6 +48,7 @@ class NVMProgress:
 
     Used for backup, restore, and convert progress updates.
     """
+
     bytes_read_or_written: int
     total_bytes: int
 

--- a/zwave_js_server/model/controller/data_model.py
+++ b/zwave_js_server/model/controller/data_model.py
@@ -44,8 +44,10 @@ class ZWaveChipType:
 
 @dataclass
 class NVMProgress:
-    """Class to represent an NVM backup/restore progress event."""
+    """Class to represent an NVM operation progress event.
 
+    Used for backup, restore, and convert progress updates.
+    """
     bytes_read_or_written: int
     total_bytes: int
 


### PR DESCRIPTION
## Summary

Pure refactor: relocate the `NVMProgress` dataclass from `controller/__init__.py` to `controller/data_model.py`, where the other controller data containers (`ZWaveChipType`, `ZWaveApiVersionDataType`, `ControllerDataType`) live. `controller/__init__.py` re-imports it from `data_model`, so existing handler code (`handle_nvm_backup_progress`, `handle_nvm_convert_progress`, `handle_nvm_restore_progress`) is unchanged.

Carved out of #1417 so reviewers can evaluate the move independently of the schema 47 command additions.

## Test plan

- [x] `pytest -q` — all tests passing
- [x] black + ruff + pylint + mypy all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)