### PR TITLE
Treat missing continuesToFunction/supportsActivation as unknown

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -2363,6 +2363,46 @@ async def test_get_firmware_update_capabilities_string(
     }
 
 
+async def test_get_firmware_update_capabilities_missing_optional_keys(
+    multisensor_6: node_pkg.Node, uuid4, mock_command
+):
+    """Test get_firmware_update_capabilities when optional keys are omitted.
+
+    Older devices that implement an earlier revision of the Firmware Update
+    Meta Data CC do not report continuesToFunction / supportsActivation, so
+    zwave-js-server omits the fields entirely from the capabilities payload.
+    """
+    node = multisensor_6
+    ack_commands = mock_command(
+        {"command": "node.get_firmware_update_capabilities", "nodeId": node.node_id},
+        {
+            "capabilities": {
+                "firmwareUpgradable": True,
+                "firmwareTargets": [0],
+            }
+        },
+    )
+    capabilities = await node.async_get_firmware_update_capabilities()
+    assert capabilities.firmware_upgradable
+    assert capabilities.firmware_targets == [0]
+    assert capabilities.continues_to_function is None
+    assert capabilities.supports_activation is None
+
+    assert len(ack_commands) == 1
+    assert ack_commands[0] == {
+        "command": "node.get_firmware_update_capabilities",
+        "nodeId": node.node_id,
+        "messageId": uuid4,
+    }
+
+    assert capabilities.to_dict() == {
+        "firmware_upgradable": True,
+        "firmware_targets": [0],
+        "continues_to_function": None,
+        "supports_activation": None,
+    }
+
+
 async def test_get_firmware_update_capabilities_cached(
     multisensor_6: node_pkg.Node, uuid4, mock_command
 ):

--- a/zwave_js_server/model/node/firmware.py
+++ b/zwave_js_server/model/node/firmware.py
@@ -89,7 +89,9 @@ class NodeFirmwareUpdateCapabilities:
         """Return whether node continues to function during update."""
         if not self.firmware_upgradable:
             raise TypeError("Firmware is not upgradeable.")
-        if (val := self.data["continuesToFunction"]) == VALUE_UNKNOWN:
+        if (
+            val := self.data.get("continuesToFunction", VALUE_UNKNOWN)
+        ) == VALUE_UNKNOWN:
             return None
         assert isinstance(val, bool)
         return val
@@ -99,7 +101,7 @@ class NodeFirmwareUpdateCapabilities:
         """Return whether node supports delayed activation of the new firmware."""
         if not self.firmware_upgradable:
             raise TypeError("Firmware is not upgradeable.")
-        if (val := self.data["supportsActivation"]) == VALUE_UNKNOWN:
+        if (val := self.data.get("supportsActivation", VALUE_UNKNOWN)) == VALUE_UNKNOWN:
             return None
         assert isinstance(val, bool)
         return val


### PR DESCRIPTION
## Proposed change

`NodeFirmwareUpdateCapabilities.continues_to_function` and `.supports_activation` accessed the underlying TypedDict keys directly with `self.data["continuesToFunction"]` / `self.data["supportsActivation"]`. Both keys are declared optional in `NodeFirmwareUpdateCapabilitiesDataType` (no `Required` marker, `total=False`), so the direct access raised `KeyError` whenever the server omitted them.

This matches the plan outlined in home-assistant/core#170350 (comment): use the `Required` marker for required keys, treat everything else as optional, and have the access pattern follow the type annotation. The TypedDict was already declared this way — the accessors just needed to catch up.

See https://zwave-js.github.io/zwave-js/#/api/node?id=getfirmwareupdatecapabilitiescached for the source data docs.

Switch both accessors to `self.data.get(field, VALUE_UNKNOWN)`, which collapses "field missing" into the existing "field is the unknown sentinel" path. Both cases now return `None`.

## Why

Older Z-Wave devices implement an earlier revision of the Firmware Update Meta Data CC and do not report `continuesToFunction` / `supportsActivation` at all. zwave-js-server omits the fields from its payload in that case, so the Python client crashed when serializing the result.

Concretely this surfaced as a Home Assistant firmware-update flow failure on a Shelly Wave Plug S (QNPL-0A112, firmware 10.4.0):

```
File ".../zwave_js_server/model/node/firmware.py", line 92, in continues_to_function
    if (val := self.data["continuesToFunction"]) == VALUE_UNKNOWN:
KeyError: 'continuesToFunction'
```

Reported in home-assistant/core#170350. Also related to the TypedDict-typing tracking issue #590.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- The existing `total=False` / no-`Required` annotation on these keys already reflected the actual server contract — only the property bodies were inconsistent.
- New test `test_get_firmware_update_capabilities_missing_optional_keys` covers the case where both keys are entirely absent from the payload (distinct from the existing `_string` test which sends `"unknown"`).
- No behavioural change for payloads that already include these keys (with `bool` or `"unknown"`).

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated