### PR TITLE
Add support for schema 49, add_user command

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -262,7 +262,7 @@ def version_data_fixture() -> dict[str, Any]:
         "serverVersion": "test_server_version",
         "homeId": "test_home_id",
         "minSchemaVersion": 0,
-        "maxSchemaVersion": 48,
+        "maxSchemaVersion": 49,
     }
 
 

--- a/test/model/test_access_control.py
+++ b/test/model/test_access_control.py
@@ -102,6 +102,7 @@ async def test_access_control_support_and_capabilities(
                     UserCredentialRule.SINGLE,
                     UserCredentialRule.DUAL,
                 ],
+                "supportsUsersWithoutCredentials": True,
             }
         },
     )
@@ -160,6 +161,7 @@ async def test_access_control_support_and_capabilities(
             UserCredentialRule.SINGLE,
             UserCredentialRule.DUAL,
         ],
+        supports_users_without_credentials=True,
     )
     assert credential_capabilities.supports_admin_code
     assert credential_capabilities.supports_admin_code_deactivation
@@ -1186,11 +1188,13 @@ def test_user_capabilities_to_dict() -> None:
             UserCredentialRule.SINGLE,
             UserCredentialRule.DUAL,
         ],
+        "supportsUsersWithoutCredentials": True,
     }
     minimal_payload = {
         "maxUsers": 25,
         "supportedUserTypes": [],
         "supportedCredentialRules": [],
+        "supportsUsersWithoutCredentials": False,
     }
 
     assert UserCapabilities.from_dict(full_payload).to_dict() == full_payload

--- a/test/model/test_access_control.py
+++ b/test/model/test_access_control.py
@@ -16,6 +16,8 @@ from zwave_js_server.const.command_class.access_control import (
 )
 from zwave_js_server.event import Event
 from zwave_js_server.model.access_control import (
+    AddUserCredential,
+    AddUserResult,
     CredentialCapabilities,
     CredentialChangedArgs,
     CredentialData,
@@ -283,6 +285,90 @@ async def test_access_control_set_user(
                 "userName": "Guest",
                 "credentialRule": UserCredentialRule.SINGLE,
             },
+            "messageId": uuid4,
+        }
+    ]
+
+
+async def test_access_control_add_user_with_credential(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test add_user with a credential returns the user and credential results."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.add_user",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"result": {"user": SetUserResult.OK, "credential": SetCredentialResult.OK}},
+    )
+
+    result = await node.access_control.add_user(
+        user_id=3,
+        options=SetUserOptions(
+            active=True,
+            user_type=UserCredentialUserType.GENERAL,
+            user_name="Guest",
+        ),
+        credential=AddUserCredential(
+            credential_type=UserCredentialType.PIN_CODE,
+            credential_slot=3,
+            data=b"1234",
+        ),
+    )
+
+    assert result == AddUserResult(
+        user=SetUserResult.OK, credential=SetCredentialResult.OK
+    )
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.add_user",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "userId": 3,
+            "options": {
+                "active": True,
+                "userType": UserCredentialUserType.GENERAL,
+                "userName": "Guest",
+            },
+            "credential": {
+                "credentialType": UserCredentialType.PIN_CODE,
+                "credentialSlot": 3,
+                "data": {"type": "Buffer", "data": [49, 50, 51, 52]},
+            },
+            "messageId": uuid4,
+        }
+    ]
+
+
+async def test_access_control_add_user_without_credential(
+    lock_schlage_be469: Node, mock_command: MockCommandProtocol, uuid4: str
+) -> None:
+    """Test add_user without a credential omits the credential field."""
+    node = lock_schlage_be469
+    ack_commands = mock_command(
+        {
+            "command": "endpoint.access_control.add_user",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+        },
+        {"result": {"user": SetUserResult.OK}},
+    )
+
+    result = await node.access_control.add_user(
+        user_id=3,
+        options=SetUserOptions(active=True),
+    )
+
+    assert result == AddUserResult(user=SetUserResult.OK, credential=None)
+    assert ack_commands == [
+        {
+            "command": "endpoint.access_control.add_user",
+            "nodeId": node.node_id,
+            "endpoint": 0,
+            "userId": 3,
+            "options": {"active": True},
             "messageId": uuid4,
         }
     ]

--- a/test/model/test_access_control.py
+++ b/test/model/test_access_control.py
@@ -1288,6 +1288,19 @@ def test_credential_data_to_dict() -> None:
     assert CredentialData.from_dict(no_data_payload).to_dict() == no_data_payload
 
 
+def test_add_user_result_to_dict() -> None:
+    """Test AddUserResult round-trips with and without a credential result."""
+
+    with_credential = {
+        "user": SetUserResult.OK,
+        "credential": SetCredentialResult.OK,
+    }
+    without_credential = {"user": SetUserResult.OK}
+
+    assert AddUserResult.from_dict(with_credential).to_dict() == with_credential
+    assert AddUserResult.from_dict(without_credential).to_dict() == without_credential
+
+
 def test_user_deleted_args_to_dict() -> None:
     """Test UserDeletedArgs round-trips via from_dict/to_dict."""
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -463,7 +463,7 @@ async def test_additional_user_agent_components(client_session, url):
             {
                 "command": "initialize",
                 "messageId": "initialize",
-                "schemaVersion": 48,
+                "schemaVersion": 49,
                 "additionalUserAgentComponents": {
                     "zwave-js-server-python": __version__,
                     "foo": "bar",

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -106,7 +106,7 @@ async def test_dump_additional_user_agent_components(
         {
             "command": "initialize",
             "messageId": "initialize",
-            "schemaVersion": 48,
+            "schemaVersion": 49,
             "additionalUserAgentComponents": {
                 "zwave-js-server-python": __version__,
                 "foo": "bar",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -58,7 +58,7 @@ def test_dump_state(
     assert captured.out == (
         "{'type': 'version', 'driverVersion': 'test_driver_version', "
         "'serverVersion': 'test_server_version', 'homeId': 'test_home_id', "
-        "'minSchemaVersion': 0, 'maxSchemaVersion': 48}\n"
+        "'minSchemaVersion': 0, 'maxSchemaVersion': 49}\n"
         "{'type': 'result', 'success': True, 'result': {}, 'messageId': 'initialize'}\n"
         "test_result\n"
     )

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -11,7 +11,7 @@ PACKAGE_NAME = "zwave-js-server-python"
 __version__ = "0.71.0"
 
 # minimal server schema version we can handle
-MIN_SERVER_SCHEMA_VERSION = 47
+MIN_SERVER_SCHEMA_VERSION = 49
 # max server schema version we can handle (and our code is compatible with)
 MAX_SERVER_SCHEMA_VERSION = 49
 

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -13,7 +13,7 @@ __version__ = "0.71.0"
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 47
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 48
+MAX_SERVER_SCHEMA_VERSION = 49
 
 VALUE_UNKNOWN = "unknown"
 

--- a/zwave_js_server/model/access_control.py
+++ b/zwave_js_server/model/access_control.py
@@ -107,6 +107,7 @@ class UserCapabilitiesDataType(TypedDict, total=False):
     supportedUserTypes: list[UserCredentialUserType]
     maxUserNameLength: int
     supportedCredentialRules: list[UserCredentialRule]
+    supportsUsersWithoutCredentials: bool
 
 
 @dataclass
@@ -117,6 +118,7 @@ class UserCapabilities:
     supported_user_types: list[UserCredentialUserType] = field(default_factory=list)
     max_user_name_length: int | None = None
     supported_credential_rules: list[UserCredentialRule] = field(default_factory=list)
+    supports_users_without_credentials: bool = False
 
     @classmethod
     def from_dict(cls, data: UserCapabilitiesDataType) -> Self:
@@ -132,6 +134,9 @@ class UserCapabilities:
                 UserCredentialRule(rule)
                 for rule in data.get("supportedCredentialRules", [])
             ],
+            supports_users_without_credentials=data.get(
+                "supportsUsersWithoutCredentials", False
+            ),
         )
 
     def to_dict(self) -> UserCapabilitiesDataType:
@@ -140,6 +145,9 @@ class UserCapabilities:
             "maxUsers": self.max_users,
             "supportedUserTypes": list(self.supported_user_types),
             "supportedCredentialRules": list(self.supported_credential_rules),
+            "supportsUsersWithoutCredentials": (
+                self.supports_users_without_credentials
+            ),
         }
         if self.max_user_name_length is not None:
             data["maxUserNameLength"] = self.max_user_name_length

--- a/zwave_js_server/model/access_control.py
+++ b/zwave_js_server/model/access_control.py
@@ -291,6 +291,31 @@ class SetUserOptions:
         return data
 
 
+class AddUserCredentialDataType(TypedDict):
+    """Represent a credential serialized for an add-user command."""
+
+    credentialType: UserCredentialType
+    credentialSlot: int
+    data: str | BufferObjectDataType
+
+
+@dataclass
+class AddUserCredential:
+    """Credential to write together with a new user via add_user."""
+
+    credential_type: UserCredentialType
+    credential_slot: int
+    data: str | bytes
+
+    def to_dict(self) -> AddUserCredentialDataType:
+        """Return the serialized credential for an add-user command."""
+        return {
+            "credentialType": self.credential_type,
+            "credentialSlot": self.credential_slot,
+            "data": serialize_credential_data(self.data),
+        }
+
+
 class CredentialDataDataType(TypedDict, total=False):
     """Represent access-control credential payload."""
 
@@ -328,6 +353,43 @@ class CredentialData:
         }
         if self.data is not None:
             data["data"] = serialize_credential_data(self.data)
+        return data
+
+
+class AddUserResultDataType(TypedDict, total=False):
+    """Represent the result of an add-user command."""
+
+    user: SetUserResult
+    credential: SetCredentialResult
+
+
+@dataclass
+class AddUserResult:
+    """Result of an add-user command.
+
+    Mirrors zwave-js's ``addUser`` return value: the result of adding the user
+    and, when a credential was provided, the result of writing it.
+    """
+
+    user: SetUserResult
+    credential: SetCredentialResult | None = None
+
+    @classmethod
+    def from_dict(cls, data: AddUserResultDataType) -> Self:
+        """Return add-user result from serialized payload."""
+        credential = data.get("credential")
+        return cls(
+            user=SetUserResult(data["user"]),
+            credential=(
+                SetCredentialResult(credential) if credential is not None else None
+            ),
+        )
+
+    def to_dict(self) -> AddUserResultDataType:
+        """Return the serialized add-user result."""
+        data: AddUserResultDataType = {"user": self.user}
+        if self.credential is not None:
+            data["credential"] = self.credential
         return data
 
 
@@ -621,6 +683,31 @@ class AccessControlAPI:
         )
         assert result is not None
         return SetUserResult(result["result"])
+
+    async def add_user(
+        self,
+        user_id: int,
+        options: SetUserOptions,
+        credential: AddUserCredential | None = None,
+    ) -> AddUserResult:
+        """Create a new user, optionally writing a credential in the same call.
+
+        On devices using User Code CC, users and credentials cannot be stored
+        separately, so ``credential`` is required there.
+        """
+        cmd_kwargs: dict[str, Any] = {}
+        if credential is not None:
+            cmd_kwargs["credential"] = credential.to_dict()
+        result = await self._endpoint.async_send_command(
+            "access_control.add_user",
+            userId=user_id,
+            options=options.to_dict(),
+            require_schema=49,
+            wait_for_result=True,
+            **cmd_kwargs,
+        )
+        assert result is not None
+        return AddUserResult.from_dict(cast(AddUserResultDataType, result["result"]))
 
     async def delete_user(self, user_id: int) -> SetUserResult:
         """Delete an access-control user."""


### PR DESCRIPTION
Implements the new command exposed in https://github.com/zwave-js/zwave-js-server/releases/tag/3.9.0, required to fix https://github.com/home-assistant/core/issues/172466