### PR TITLE
Forward the `interview progress` event

### DIFF
--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1227,6 +1227,23 @@ async def test_interview_events(multisensor_6):
     assert node.awaiting_manual_interview
 
     event = Event(
+        type="interview progress",
+        data={
+            "source": "node",
+            "event": "interview progress",
+            "nodeId": 52,
+            "stage": "CommandClasses",
+            "progress": 42.5,
+            "endpoint": 0,
+            "commandClass": 112,
+        },
+    )
+    node.receive_event(event)
+    assert node.interview_stage == "CommandClasses"
+    assert not node.ready
+    assert node.in_interview
+
+    event = Event(
         type="interview stage completed",
         data={
             "source": "node",

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1239,9 +1239,10 @@ async def test_interview_events(multisensor_6):
         },
     )
     node.receive_event(event)
-    assert node.interview_stage == "CommandClasses"
+    # `interview progress` reports the in-progress stage and must not change
+    # the last-completed interview stage
+    assert node.interview_stage is None
     assert not node.ready
-    assert node.in_interview
 
     event = Event(
         type="interview stage completed",

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1238,7 +1238,7 @@ async def test_interview_events(multisensor_6):
             "commandClass": 112,
         },
     )
-    node.receive_event(event)
+    node.handle_interview_progress(event)
     # `interview progress` reports the in-progress stage and must not change
     # the last-completed interview stage
     assert node.interview_stage is None

--- a/test/model/test_node.py
+++ b/test/model/test_node.py
@@ -1205,7 +1205,7 @@ async def test_entry_control_notification(ring_keypad):
     assert event.data["notification"].event_data == "cat"
 
 
-async def test_interview_events(multisensor_6):
+async def test_interview_events(multisensor_6, caplog):
     """Test Node interview events."""
     node = multisensor_6
     assert node.interview_stage is None
@@ -1238,9 +1238,14 @@ async def test_interview_events(multisensor_6):
             "commandClass": 112,
         },
     )
-    node.handle_interview_progress(event)
+    with caplog.at_level(logging.DEBUG):
+        node.receive_event(event)
+    # The event must be handled, not dropped as an unknown event (which would
+    # happen if the `handle_interview_progress` handler were removed).
+    assert "Received unknown event" not in caplog.text
+    assert event.data["node"] is node
     # `interview progress` reports the in-progress stage and must not change
-    # the last-completed interview stage
+    # the last-completed interview stage.
     assert node.interview_stage is None
     assert not node.ready
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -463,7 +463,7 @@ async def test_additional_user_agent_components(client_session, url):
             {
                 "command": "initialize",
                 "messageId": "initialize",
-                "schemaVersion": 49,
+                "schemaVersion": 50,
                 "additionalUserAgentComponents": {
                     "zwave-js-server-python": __version__,
                     "foo": "bar",

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -106,7 +106,7 @@ async def test_dump_additional_user_agent_components(
         {
             "command": "initialize",
             "messageId": "initialize",
-            "schemaVersion": 49,
+            "schemaVersion": 50,
             "additionalUserAgentComponents": {
                 "zwave-js-server-python": __version__,
                 "foo": "bar",

--- a/zwave_js_server/const/__init__.py
+++ b/zwave_js_server/const/__init__.py
@@ -13,7 +13,7 @@ __version__ = "0.72.0"
 # minimal server schema version we can handle
 MIN_SERVER_SCHEMA_VERSION = 49
 # max server schema version we can handle (and our code is compatible with)
-MAX_SERVER_SCHEMA_VERSION = 49
+MAX_SERVER_SCHEMA_VERSION = 50
 
 VALUE_UNKNOWN = "unknown"
 

--- a/zwave_js_server/model/node/__init__.py
+++ b/zwave_js_server/model/node/__init__.py
@@ -1114,6 +1114,12 @@ class Node(EventBase):
         self.data["ready"] = False
         self.data["interviewStage"] = None
 
+    def handle_interview_progress(self, event: Event) -> None:
+        """Process a node interview progress event."""
+        # Do not override the interview stage here. The stage of the
+        # `interview progress` event is the _current_ one, while the
+        # `interviewStage` field is the _last completed_ stage.
+
     def handle_interview_stage_completed(self, event: Event) -> None:
         """Process a node interview stage completed event."""
         self.data["interviewStage"] = event.data["stageName"]

--- a/zwave_js_server/model/node/event_model.py
+++ b/zwave_js_server/model/node/event_model.py
@@ -163,6 +163,29 @@ class InterviewFailedEventModel(BaseNodeEventModel):
         )
 
 
+class InterviewProgressEventModel(BaseNodeEventModel):
+    """Model for `interview progress` event data."""
+
+    event: Literal["interview progress"]
+    stage: str
+    progress: float
+    endpoint: int | None = None
+    commandClass: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> InterviewProgressEventModel:
+        """Initialize from dict."""
+        return cls(
+            source=data["source"],
+            event=data["event"],
+            nodeId=data["nodeId"],
+            stage=data["stage"],
+            progress=data["progress"],
+            endpoint=data.get("endpoint"),
+            commandClass=data.get("commandClass"),
+        )
+
+
 class InterviewStageCompletedEventModel(BaseNodeEventModel):
     """Model for `interview stage completed` event data."""
 
@@ -452,6 +475,7 @@ NODE_EVENT_MODEL_MAP: dict[str, type[BaseNodeEventModel]] = {
     "firmware update progress": FirmwareUpdateProgressEventModel,
     "interview completed": InterviewCompletedEventModel,
     "interview failed": InterviewFailedEventModel,
+    "interview progress": InterviewProgressEventModel,
     "interview stage completed": InterviewStageCompletedEventModel,
     "interview started": InterviewStartedEventModel,
     "metadata updated": MetadataUpdatedEventModel,


### PR DESCRIPTION
Adds support for the new `interview progress` event included in schema 50 (https://github.com/zwave-js/zwave-js-server/pull/1562).

I opted not to bump the minimum version, so we don't force users to upgrade for a nice-to-have UI improvement.