### PR TITLE
Fix wrong field name in toggle RF command

### DIFF
--- a/test/model/test_controller.py
+++ b/test/model/test_controller.py
@@ -1937,7 +1937,7 @@ async def test_toggle_rf(controller, uuid4, mock_command):
     assert len(ack_commands) == 1
     assert ack_commands[0] == {
         "command": "controller.toggle_rf",
-        "enable": True,
+        "enabled": True,
         "messageId": uuid4,
     }
 

--- a/zwave_js_server/model/controller/__init__.py
+++ b/zwave_js_server/model/controller/__init__.py
@@ -841,10 +841,10 @@ class Controller(EventBase):
         )
         return cast(bool, data["success"])
 
-    async def async_toggle_rf(self, enable: bool) -> bool:
+    async def async_toggle_rf(self, enabled: bool) -> bool:
         """Send toggleRF command to Controller."""
         data = await self.client.async_send_command(
-            {"command": "controller.toggle_rf", "enable": enable}, require_schema=43
+            {"command": "controller.toggle_rf", "enabled": enabled}, require_schema=43
         )
         return cast(bool, data["success"])
 


### PR DESCRIPTION
`async_toggle_rf` sends the boolean as `enable`, but zwave-js-server's handler reads `message.enabled` ([message_handler.ts](https://github.com/zwave-js/zwave-js-server/blob/master/src/lib/controller/message_handler.ts)), so `toggleRF` has always received `undefined`. Send `enabled` and rename the parameter to match.

Needed for home-assistant/core#179363.
